### PR TITLE
Add RFC lookup skill with vendored RFC text files

### DIFF
--- a/.claude/skills/rfc-sip-lookup/SKILL.md
+++ b/.claude/skills/rfc-sip-lookup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: rfc-sip-lookup
+description: Look up SIP/RTP/SDP protocol details across RFC text files using parallel agents. Use when researching protocol specs, debugging SIP compliance, or checking RFC requirements.
+user-invocable: true
+---
+
+# RFC SIP/RTP/SDP Lookup
+
+You are looking up protocol details from RFC text files vendored in `rfcs/`.
+
+## Step 1: Consult the Index
+
+Read `.claude/skills/rfc-sip-lookup/rfc-index.md` to identify which RFC sections are relevant to the user's query. The index maps topic areas (registration, INVITE, SDP, RTP, timers, etc.) to specific files and line ranges.
+
+## Step 2: Dispatch Parallel Explore Agents
+
+Launch 2–3 Explore agents via the Task tool (`subagent_type: "Explore"`) to read the relevant RFC sections in parallel. Each agent should:
+
+- Read the specific line range(s) from the index using the Read tool with `offset` and `limit` parameters
+- Search for specific keywords within the identified sections using Grep
+- Extract the precise normative text (MUST, SHOULD, MAY statements), protocol rules, or message format details relevant to the query
+
+Structure each agent prompt like:
+
+> Read rfcs/rfc3261.txt lines 7471–7633 (§17.2.1 INVITE Server Transaction).
+> Find details about: [user's specific question].
+> Return the exact normative requirements, relevant ABNF, and any examples.
+
+Dispatch agents for different RFC files in parallel. If the query spans multiple topics (e.g., "INVITE with SDP offer"), send one agent for the SIP sections and another for the SDP sections.
+
+## Step 3: Synthesize
+
+Combine the agents' findings into a concise answer:
+
+- Lead with the direct answer to the user's question
+- Include exact RFC section references (e.g., "RFC 3261 §17.2.1, line 7520")
+- Quote key normative language verbatim when precision matters
+- Note any cross-references between RFCs (e.g., SIP→SDP, SIP→Digest Auth)
+- If the query is about implementation, connect the RFC requirements to what the code should do
+
+## Tips
+
+- For broad queries ("how does INVITE work?"), focus on the primary sections and summarize rather than reading everything
+- For narrow queries ("what's Timer G's default value?"), target the exact line range and quote the text
+- RFC 3665 (call flow examples) is the best companion to RFC 3261 — check it for annotated message exchanges
+- The smaller RFCs (2617, 3264, 3551) can often be read in their entirety by a single agent

--- a/.claude/skills/rfc-sip-lookup/rfc-index.md
+++ b/.claude/skills/rfc-sip-lookup/rfc-index.md
@@ -1,0 +1,106 @@
+# RFC Section Index
+
+Quick-reference index mapping protocol topics to exact RFC files and line ranges.
+All files live in `rfcs/` relative to the project root.
+
+## File Summary
+
+| File | RFC | Topic | Lines |
+|------|-----|-------|-------|
+| `rfc3261.txt` | 3261 | Core SIP | 15,067 |
+| `rfc2617.txt` | 2617 | HTTP Digest Authentication | 1,907 |
+| `rfc4566.txt` | 4566 | SDP (Session Description Protocol) | 2,747 |
+| `rfc3264.txt` | 3264 | SDP Offer/Answer Model | 1,403 |
+| `rfc3550.txt` | 3550 | RTP | 5,827 |
+| `rfc3551.txt` | 3551 | RTP Audio/Video Profile | 2,467 |
+| `rfc3665.txt` | 3665 | SIP Basic Call Flow Examples | 5,267 |
+
+---
+
+## Registration & Auth
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §10.3 | `rfc3261.txt` | 3496–3836 | Processing REGISTER requests (registrar behavior) |
+| RFC 3261 §22 | `rfc3261.txt` | 10773–11215 | HTTP digest auth framework for SIP |
+| RFC 2617 §3 | `rfc2617.txt` | 310–380 | Digest Access Authentication overview |
+| RFC 2617 §3.2.1 | `rfc2617.txt` | 399–574 | WWW-Authenticate response header (server challenge) |
+| RFC 2617 §3.2.2 | `rfc2617.txt` | 575–831 | Authorization request header (client response) |
+| RFC 3665 §2 | `rfc3665.txt` | 210–622 | Registration call flow examples (success, update, cancel, failure) |
+
+## Call Setup (INVITE)
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §13 | `rfc3261.txt` | 4301–4961 | Initiating a Session — full INVITE processing |
+| RFC 3261 §12 | `rfc3261.txt` | 3837–4300 | Dialog creation and management |
+| RFC 3665 §3 | `rfc3665.txt` | 623–5046 | Session establishment call flow examples |
+| RFC 3665 §3.1 | `rfc3665.txt` | 638–790 | Successful session establishment (annotated INVITE flow) |
+
+## Call Teardown
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §15.1 | `rfc3261.txt` | 5023–5077 | Terminating a Session — BYE processing |
+| RFC 3261 §9 | `rfc3261.txt` | 2929–3495 | Canceling a Request — CANCEL processing |
+
+## SIP Message Format
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §7 | `rfc3261.txt` | 1451–2529 | Message structure, headers, bodies |
+| RFC 3261 §8.2 | `rfc3261.txt` | 2530–2928 | UAS behavior (how to process incoming requests) |
+
+## Transactions & Timers
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §17.2 | `rfc3261.txt` | 7460–7867 | Server transaction overview |
+| RFC 3261 §17.2.1 | `rfc3261.txt` | 7471–7633 | INVITE server transaction state machine (Timer G/H/I) |
+| RFC 3261 §17.2.2 | `rfc3261.txt` | 7634–7678 | Non-INVITE server transaction state machine (Timer J) |
+
+## Transport
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3261 §18 | `rfc3261.txt` | 7868–8219 | UDP/TCP transport layer |
+
+## SDP (Session Description Protocol)
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 4566 §5 | `rfc4566.txt` | 382–1328 | Full SDP specification (all field definitions) |
+| RFC 4566 §5.1 | `rfc4566.txt` | 551–566 | Protocol version (`v=`) |
+| RFC 4566 §5.2 | `rfc4566.txt` | 567–633 | Origin (`o=`) |
+| RFC 4566 §5.7 | `rfc4566.txt` | 739–856 | Connection data (`c=`) |
+| RFC 4566 §5.9 | `rfc4566.txt` | 914–967 | Timing (`t=`) |
+| RFC 4566 §5.14 | `rfc4566.txt` | 1197–1328 | Media descriptions (`m=`) |
+| RFC 4566 §5.13 | `rfc4566.txt` | 1140–1196 | Attributes (`a=`) |
+| RFC 4566 §6 | `rfc4566.txt` | 1329–1692 | SDP attributes reference |
+| RFC 4566 §9 | `rfc4566.txt` | 2141–2425 | SDP grammar (ABNF) |
+
+## SDP Offer/Answer
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3264 §5 | `rfc3264.txt` | 236–457 | Generating the initial offer |
+| RFC 3264 §6 | `rfc3264.txt` | 458–648 | Generating the answer |
+| RFC 3264 §7 | `rfc3264.txt` | 649–678 | Offerer processing of the answer |
+| RFC 3264 §8 | `rfc3264.txt` | 679–976 | Modifying the session |
+
+## RTP (Real-time Transport Protocol)
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3550 §5 | `rfc3550.txt` | 679–958 | RTP data transfer protocol (header format) |
+| RFC 3550 §5.1 | `rfc3550.txt` | 681–882 | RTP fixed header fields |
+| RFC 3550 §5.3 | `rfc3550.txt` | 959–997 | Profile-specific modifications to the RTP header |
+
+## RTP Audio/Video Profile
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3551 §4 | `rfc3551.txt` | 399–1630 | Audio encodings |
+| RFC 3551 §4.5 | `rfc3551.txt` | 623–1630 | Audio encoding definitions |
+| RFC 3551 §4.5.14 | `rfc3551.txt` | 1538–1552 | PCMA and PCMU codec definitions |
+| RFC 3551 §6 | `rfc3551.txt` | 1756–1888 | Payload type definitions (static assignment table) |

--- a/rfcs/download.sh
+++ b/rfcs/download.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Download RFC text files needed for SIP/RTP/SDP development.
+# Usage: bash rfcs/download.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+rfcs=(3261 2617 4566 3264 3550 3551 3665)
+
+for rfc in "${rfcs[@]}"; do
+    file="rfc${rfc}.txt"
+    if [[ -f "$file" ]]; then
+        echo "skip  $file (exists)"
+    else
+        echo "fetch $file"
+        curl -fsSL "https://www.rfc-editor.org/rfc/rfc${rfc}.txt" -o "$file"
+    fi
+done
+
+echo "done"

--- a/rfcs/rfc2617.txt
+++ b/rfcs/rfc2617.txt
@@ -1,0 +1,1907 @@
+
+
+
+
+
+
+Network Working Group                                          J. Franks
+Request for Comments: 2617                       Northwestern University
+Obsoletes: 2069                                          P. Hallam-Baker
+Category: Standards Track                                 Verisign, Inc.
+                                                            J. Hostetler
+                                                         AbiSource, Inc.
+                                                             S. Lawrence
+                                                   Agranat Systems, Inc.
+                                                                P. Leach
+                                                   Microsoft Corporation
+                                                             A. Luotonen
+                                     Netscape Communications Corporation
+                                                              L. Stewart
+                                                       Open Market, Inc.
+                                                               June 1999
+
+
+      HTTP Authentication: Basic and Digest Access Authentication
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+Abstract
+
+   "HTTP/1.0", includes the specification for a Basic Access
+   Authentication scheme. This scheme is not considered to be a secure
+   method of user authentication (unless used in conjunction with some
+   external secure system such as SSL [5]), as the user name and
+   password are passed over the network as cleartext.
+
+   This document also provides the specification for HTTP's
+   authentication framework, the original Basic authentication scheme
+   and a scheme based on cryptographic hashes, referred to as "Digest
+   Access Authentication".  It is therefore also intended to serve as a
+   replacement for RFC 2069 [6].  Some optional elements specified by
+   RFC 2069 have been removed from this specification due to problems
+   found since its publication; other new elements have been added for
+   compatibility, those new elements have been made optional, but are
+   strongly recommended.
+
+
+
+Franks, et al.              Standards Track                     [Page 1]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   Like Basic, Digest access authentication verifies that both parties
+   to a communication know a shared secret (a password); unlike Basic,
+   this verification can be done without sending the password in the
+   clear, which is Basic's biggest weakness. As with most other
+   authentication protocols, the greatest sources of risks are usually
+   found not in the core protocol itself but in policies and procedures
+   surrounding its use.
+
+Table of Contents
+
+   1   Access Authentication................................   3
+    1.1   Reliance on the HTTP/1.1 Specification............   3
+    1.2   Access Authentication Framework...................   3
+   2   Basic Authentication Scheme..........................   5
+   3   Digest Access Authentication Scheme..................   6
+    3.1   Introduction......................................   6
+     3.1.1  Purpose.........................................   6
+     3.1.2  Overall Operation...............................   6
+     3.1.3  Representation of digest values.................   7
+     3.1.4  Limitations.....................................   7
+    3.2   Specification of Digest Headers...................   7
+     3.2.1  The WWW-Authenticate Response Header............   8
+     3.2.2  The Authorization Request Header................  11
+     3.2.3  The Authentication-Info Header..................  15
+    3.3   Digest Operation..................................  17
+    3.4   Security Protocol Negotiation.....................  18
+    3.5   Example...........................................  18
+    3.6   Proxy-Authentication and Proxy-Authorization......  19
+   4   Security Considerations..............................  19
+    4.1   Authentication of Clients using Basic
+          Authentication....................................  19
+    4.2   Authentication of Clients using Digest
+          Authentication....................................  20
+    4.3   Limited Use Nonce Values..........................  21
+    4.4   Comparison of Digest with Basic Authentication....  22
+    4.5   Replay Attacks....................................  22
+    4.6   Weakness Created by Multiple Authentication
+          Schemes...........................................  23
+    4.7   Online dictionary attacks.........................  23
+    4.8   Man in the Middle.................................  24
+    4.9   Chosen plaintext attacks..........................  24
+    4.10  Precomputed dictionary attacks....................  25
+    4.11  Batch brute force attacks.........................  25
+    4.12  Spoofing by Counterfeit Servers...................  25
+    4.13  Storing passwords.................................  26
+    4.14  Summary...........................................  26
+   5   Sample implementation................................  27
+   6   Acknowledgments......................................  31
+
+
+
+Franks, et al.              Standards Track                     [Page 2]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   7   References...........................................  31
+   8   Authors' Addresses...................................  32
+   9   Full Copyright Statement.............................  34
+
+1 Access Authentication
+
+1.1 Reliance on the HTTP/1.1 Specification
+
+   This specification is a companion to the HTTP/1.1 specification [2].
+   It uses the augmented BNF section 2.1 of that document, and relies on
+   both the non-terminals defined in that document and other aspects of
+   the HTTP/1.1 specification.
+
+1.2 Access Authentication Framework
+
+   HTTP provides a simple challenge-response authentication mechanism
+   that MAY be used by a server to challenge a client request and by a
+   client to provide authentication information. It uses an extensible,
+   case-insensitive token to identify the authentication scheme,
+   followed by a comma-separated list of attribute-value pairs which
+   carry the parameters necessary for achieving authentication via that
+   scheme.
+
+      auth-scheme    = token
+      auth-param     = token "=" ( token | quoted-string )
+
+   The 401 (Unauthorized) response message is used by an origin server
+   to challenge the authorization of a user agent. This response MUST
+   include a WWW-Authenticate header field containing at least one
+   challenge applicable to the requested resource. The 407 (Proxy
+   Authentication Required) response message is used by a proxy to
+   challenge the authorization of a client and MUST include a Proxy-
+   Authenticate header field containing at least one challenge
+   applicable to the proxy for the requested resource.
+
+      challenge   = auth-scheme 1*SP 1#auth-param
+
+   Note: User agents will need to take special care in parsing the WWW-
+   Authenticate or Proxy-Authenticate header field value if it contains
+   more than one challenge, or if more than one WWW-Authenticate header
+   field is provided, since the contents of a challenge may itself
+   contain a comma-separated list of authentication parameters.
+
+   The authentication parameter realm is defined for all authentication
+   schemes:
+
+      realm       = "realm" "=" realm-value
+      realm-value = quoted-string
+
+
+
+Franks, et al.              Standards Track                     [Page 3]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   The realm directive (case-insensitive) is required for all
+   authentication schemes that issue a challenge. The realm value
+   (case-sensitive), in combination with the canonical root URL (the
+   absoluteURI for the server whose abs_path is empty; see section 5.1.2
+   of [2]) of the server being accessed, defines the protection space.
+   These realms allow the protected resources on a server to be
+   partitioned into a set of protection spaces, each with its own
+   authentication scheme and/or authorization database. The realm value
+   is a string, generally assigned by the origin server, which may have
+   additional semantics specific to the authentication scheme. Note that
+   there may be multiple challenges with the same auth-scheme but
+   different realms.
+
+   A user agent that wishes to authenticate itself with an origin
+   server--usually, but not necessarily, after receiving a 401
+   (Unauthorized)--MAY do so by including an Authorization header field
+   with the request. A client that wishes to authenticate itself with a
+   proxy--usually, but not necessarily, after receiving a 407 (Proxy
+   Authentication Required)--MAY do so by including a Proxy-
+   Authorization header field with the request.  Both the Authorization
+   field value and the Proxy-Authorization field value consist of
+   credentials containing the authentication information of the client
+   for the realm of the resource being requested. The user agent MUST
+   choose to use one of the challenges with the strongest auth-scheme it
+   understands and request credentials from the user based upon that
+   challenge.
+
+   credentials = auth-scheme #auth-param
+
+      Note that many browsers will only recognize Basic and will require
+      that it be the first auth-scheme presented. Servers should only
+      include Basic if it is minimally acceptable.
+
+   The protection space determines the domain over which credentials can
+   be automatically applied. If a prior request has been authorized, the
+   same credentials MAY be reused for all other requests within that
+   protection space for a period of time determined by the
+   authentication scheme, parameters, and/or user preference. Unless
+   otherwise defined by the authentication scheme, a single protection
+   space cannot extend outside the scope of its server.
+
+   If the origin server does not wish to accept the credentials sent
+   with a request, it SHOULD return a 401 (Unauthorized) response. The
+   response MUST include a WWW-Authenticate header field containing at
+   least one (possibly new) challenge applicable to the requested
+   resource. If a proxy does not accept the credentials sent with a
+   request, it SHOULD return a 407 (Proxy Authentication Required). The
+   response MUST include a Proxy-Authenticate header field containing a
+
+
+
+Franks, et al.              Standards Track                     [Page 4]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   (possibly new) challenge applicable to the proxy for the requested
+   resource.
+
+   The HTTP protocol does not restrict applications to this simple
+   challenge-response mechanism for access authentication. Additional
+   mechanisms MAY be used, such as encryption at the transport level or
+   via message encapsulation, and with additional header fields
+   specifying authentication information. However, these additional
+   mechanisms are not defined by this specification.
+
+   Proxies MUST be completely transparent regarding user agent
+   authentication by origin servers. That is, they must forward the
+   WWW-Authenticate and Authorization headers untouched, and follow the
+   rules found in section 14.8 of [2]. Both the Proxy-Authenticate and
+   the Proxy-Authorization header fields are hop-by-hop headers (see
+   section 13.5.1 of [2]).
+
+2 Basic Authentication Scheme
+
+   The "basic" authentication scheme is based on the model that the
+   client must authenticate itself with a user-ID and a password for
+   each realm.  The realm value should be considered an opaque string
+   which can only be compared for equality with other realms on that
+   server. The server will service the request only if it can validate
+   the user-ID and password for the protection space of the Request-URI.
+   There are no optional authentication parameters.
+
+   For Basic, the framework above is utilized as follows:
+
+      challenge   = "Basic" realm
+      credentials = "Basic" basic-credentials
+
+   Upon receipt of an unauthorized request for a URI within the
+   protection space, the origin server MAY respond with a challenge like
+   the following:
+
+      WWW-Authenticate: Basic realm="WallyWorld"
+
+   where "WallyWorld" is the string assigned by the server to identify
+   the protection space of the Request-URI. A proxy may respond with the
+   same challenge using the Proxy-Authenticate header field.
+
+   To receive authorization, the client sends the userid and password,
+   separated by a single colon (":") character, within a base64 [7]
+   encoded string in the credentials.
+
+      basic-credentials = base64-user-pass
+      base64-user-pass  = <base64 [4] encoding of user-pass,
+
+
+
+Franks, et al.              Standards Track                     [Page 5]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+                       except not limited to 76 char/line>
+      user-pass   = userid ":" password
+      userid      = *<TEXT excluding ":">
+      password    = *TEXT
+
+   Userids might be case sensitive.
+
+   If the user agent wishes to send the userid "Aladdin" and password
+   "open sesame", it would use the following header field:
+
+      Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+
+   A client SHOULD assume that all paths at or deeper than the depth of
+   the last symbolic element in the path field of the Request-URI also
+   are within the protection space specified by the Basic realm value of
+   the current challenge. A client MAY preemptively send the
+   corresponding Authorization header with requests for resources in
+   that space without receipt of another challenge from the server.
+   Similarly, when a client sends a request to a proxy, it may reuse a
+   userid and password in the Proxy-Authorization header field without
+   receiving another challenge from the proxy server. See section 4 for
+   security considerations associated with Basic authentication.
+
+3 Digest Access Authentication Scheme
+
+3.1 Introduction
+
+3.1.1 Purpose
+
+   The protocol referred to as "HTTP/1.0" includes the specification for
+   a Basic Access Authentication scheme[1]. That scheme is not
+   considered to be a secure method of user authentication, as the user
+   name and password are passed over the network in an unencrypted form.
+   This section provides the specification for a scheme that does not
+   send the password in cleartext,  referred to as "Digest Access
+   Authentication".
+
+   The Digest Access Authentication scheme is not intended to be a
+   complete answer to the need for security in the World Wide Web. This
+   scheme provides no encryption of message content. The intent is
+   simply to create an access authentication method that avoids the most
+   serious flaws of Basic authentication.
+
+3.1.2 Overall Operation
+
+   Like Basic Access Authentication, the Digest scheme is based on a
+   simple challenge-response paradigm. The Digest scheme challenges
+   using a nonce value. A valid response contains a checksum (by
+
+
+
+Franks, et al.              Standards Track                     [Page 6]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   default, the MD5 checksum) of the username, the password, the given
+   nonce value, the HTTP method, and the requested URI. In this way, the
+   password is never sent in the clear. Just as with the Basic scheme,
+   the username and password must be prearranged in some fashion not
+   addressed by this document.
+
+3.1.3 Representation of digest values
+
+   An optional header allows the server to specify the algorithm used to
+   create the checksum or digest. By default the MD5 algorithm is used
+   and that is the only algorithm described in this document.
+
+   For the purposes of this document, an MD5 digest of 128 bits is
+   represented as 32 ASCII printable characters. The bits in the 128 bit
+   digest are converted from most significant to least significant bit,
+   four bits at a time to their ASCII presentation as follows. Each four
+   bits is represented by its familiar hexadecimal notation from the
+   characters 0123456789abcdef. That is, binary 0000 gets represented by
+   the character '0', 0001, by '1', and so on up to the representation
+   of 1111 as 'f'.
+
+3.1.4 Limitations
+
+   The Digest authentication scheme described in this document suffers
+   from many known limitations. It is intended as a replacement for
+   Basic authentication and nothing more. It is a password-based system
+   and (on the server side) suffers from all the same problems of any
+   password system. In particular, no provision is made in this protocol
+   for the initial secure arrangement between user and server to
+   establish the user's password.
+
+   Users and implementors should be aware that this protocol is not as
+   secure as Kerberos, and not as secure as any client-side private-key
+   scheme. Nevertheless it is better than nothing, better than what is
+   commonly used with telnet and ftp, and better than Basic
+   authentication.
+
+3.2 Specification of Digest Headers
+
+   The Digest Access Authentication scheme is conceptually similar to
+   the Basic scheme. The formats of the modified WWW-Authenticate header
+   line and the Authorization header line are specified below. In
+   addition, a new header, Authentication-Info, is specified.
+
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                     [Page 7]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+3.2.1 The WWW-Authenticate Response Header
+
+   If a server receives a request for an access-protected object, and an
+   acceptable Authorization header is not sent, the server responds with
+   a "401 Unauthorized" status code, and a WWW-Authenticate header as
+   per the framework defined above, which for the digest scheme is
+   utilized as follows:
+
+      challenge        =  "Digest" digest-challenge
+
+      digest-challenge  = 1#( realm | [ domain ] | nonce |
+                          [ opaque ] |[ stale ] | [ algorithm ] |
+                          [ qop-options ] | [auth-param] )
+
+
+      domain            = "domain" "=" <"> URI ( 1*SP URI ) <">
+      URI               = absoluteURI | abs_path
+      nonce             = "nonce" "=" nonce-value
+      nonce-value       = quoted-string
+      opaque            = "opaque" "=" quoted-string
+      stale             = "stale" "=" ( "true" | "false" )
+      algorithm         = "algorithm" "=" ( "MD5" | "MD5-sess" |
+                           token )
+      qop-options       = "qop" "=" <"> 1#qop-value <">
+      qop-value         = "auth" | "auth-int" | token
+
+   The meanings of the values of the directives used above are as
+   follows:
+
+   realm
+     A string to be displayed to users so they know which username and
+     password to use. This string should contain at least the name of
+     the host performing the authentication and might additionally
+     indicate the collection of users who might have access. An example
+     might be "registered_users@gotham.news.com".
+
+   domain
+     A quoted, space-separated list of URIs, as specified in RFC XURI
+     [7], that define the protection space.  If a URI is an abs_path, it
+     is relative to the canonical root URL (see section 1.2 above) of
+     the server being accessed. An absoluteURI in this list may refer to
+     a different server than the one being accessed. The client can use
+     this list to determine the set of URIs for which the same
+     authentication information may be sent: any URI that has a URI in
+     this list as a prefix (after both have been made absolute) may be
+     assumed to be in the same protection space. If this directive is
+     omitted or its value is empty, the client should assume that the
+     protection space consists of all URIs on the responding server.
+
+
+
+Franks, et al.              Standards Track                     [Page 8]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+     This directive is not meaningful in Proxy-Authenticate headers, for
+     which the protection space is always the entire proxy; if present
+     it should be ignored.
+
+   nonce
+     A server-specified data string which should be uniquely generated
+     each time a 401 response is made. It is recommended that this
+     string be base64 or hexadecimal data. Specifically, since the
+     string is passed in the header lines as a quoted string, the
+     double-quote character is not allowed.
+
+     The contents of the nonce are implementation dependent. The quality
+     of the implementation depends on a good choice. A nonce might, for
+     example, be constructed as the base 64 encoding of
+
+         time-stamp H(time-stamp ":" ETag ":" private-key)
+
+     where time-stamp is a server-generated time or other non-repeating
+     value, ETag is the value of the HTTP ETag header associated with
+     the requested entity, and private-key is data known only to the
+     server.  With a nonce of this form a server would recalculate the
+     hash portion after receiving the client authentication header and
+     reject the request if it did not match the nonce from that header
+     or if the time-stamp value is not recent enough. In this way the
+     server can limit the time of the nonce's validity. The inclusion of
+     the ETag prevents a replay request for an updated version of the
+     resource.  (Note: including the IP address of the client in the
+     nonce would appear to offer the server the ability to limit the
+     reuse of the nonce to the same client that originally got it.
+     However, that would break proxy farms, where requests from a single
+     user often go through different proxies in the farm. Also, IP
+     address spoofing is not that hard.)
+
+     An implementation might choose not to accept a previously used
+     nonce or a previously used digest, in order to protect against a
+     replay attack. Or, an implementation might choose to use one-time
+     nonces or digests for POST or PUT requests and a time-stamp for GET
+     requests.  For more details on the issues involved see section 4.
+     of this document.
+
+     The nonce is opaque to the client.
+
+   opaque
+     A string of data, specified by the server, which should be returned
+     by the client unchanged in the Authorization header of subsequent
+     requests with URIs in the same protection space. It is recommended
+     that this string be base64 or hexadecimal data.
+
+
+
+
+Franks, et al.              Standards Track                     [Page 9]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   stale
+     A flag, indicating that the previous request from the client was
+     rejected because the nonce value was stale. If stale is TRUE
+     (case-insensitive), the client may wish to simply retry the request
+     with a new encrypted response, without reprompting the user for a
+     new username and password. The server should only set stale to TRUE
+     if it receives a request for which the nonce is invalid but with a
+     valid digest for that nonce (indicating that the client knows the
+     correct username/password). If stale is FALSE, or anything other
+     than TRUE, or the stale directive is not present, the username
+     and/or password are invalid, and new values must be obtained.
+
+   algorithm
+     A string indicating a pair of algorithms used to produce the digest
+     and a checksum. If this is not present it is assumed to be "MD5".
+     If the algorithm is not understood, the challenge should be ignored
+     (and a different one used, if there is more than one).
+
+     In this document the string obtained by applying the digest
+     algorithm to the data "data" with secret "secret" will be denoted
+     by KD(secret, data), and the string obtained by applying the
+     checksum algorithm to the data "data" will be denoted H(data). The
+     notation unq(X) means the value of the quoted-string X without the
+     surrounding quotes.
+
+     For the "MD5" and "MD5-sess" algorithms
+
+         H(data) = MD5(data)
+
+     and
+
+         KD(secret, data) = H(concat(secret, ":", data))
+
+     i.e., the digest is the MD5 of the secret concatenated with a colon
+     concatenated with the data. The "MD5-sess" algorithm is intended to
+     allow efficient 3rd party authentication servers; for the
+     difference in usage, see the description in section 3.2.2.2.
+
+   qop-options
+     This directive is optional, but is made so only for backward
+     compatibility with RFC 2069 [6]; it SHOULD be used by all
+     implementations compliant with this version of the Digest scheme.
+     If present, it is a quoted string of one or more tokens indicating
+     the "quality of protection" values supported by the server.  The
+     value "auth" indicates authentication; the value "auth-int"
+     indicates authentication with integrity protection; see the
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 10]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+     descriptions below for calculating the response directive value for
+     the application of this choice. Unrecognized options MUST be
+     ignored.
+
+   auth-param
+     This directive allows for future extensions. Any unrecognized
+     directive MUST be ignored.
+
+3.2.2 The Authorization Request Header
+
+   The client is expected to retry the request, passing an Authorization
+   header line, which is defined according to the framework above,
+   utilized as follows.
+
+       credentials      = "Digest" digest-response
+       digest-response  = 1#( username | realm | nonce | digest-uri
+                       | response | [ algorithm ] | [cnonce] |
+                       [opaque] | [message-qop] |
+                           [nonce-count]  | [auth-param] )
+
+       username         = "username" "=" username-value
+       username-value   = quoted-string
+       digest-uri       = "uri" "=" digest-uri-value
+       digest-uri-value = request-uri   ; As specified by HTTP/1.1
+       message-qop      = "qop" "=" qop-value
+       cnonce           = "cnonce" "=" cnonce-value
+       cnonce-value     = nonce-value
+       nonce-count      = "nc" "=" nc-value
+       nc-value         = 8LHEX
+       response         = "response" "=" request-digest
+       request-digest = <"> 32LHEX <">
+       LHEX             =  "0" | "1" | "2" | "3" |
+                           "4" | "5" | "6" | "7" |
+                           "8" | "9" | "a" | "b" |
+                           "c" | "d" | "e" | "f"
+
+   The values of the opaque and algorithm fields must be those supplied
+   in the WWW-Authenticate response header for the entity being
+   requested.
+
+   response
+     A string of 32 hex digits computed as defined below, which proves
+     that the user knows a password
+
+   username
+     The user's name in the specified realm.
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 11]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   digest-uri
+     The URI from Request-URI of the Request-Line; duplicated here
+     because proxies are allowed to change the Request-Line in transit.
+
+   qop
+     Indicates what "quality of protection" the client has applied to
+     the message. If present, its value MUST be one of the alternatives
+     the server indicated it supports in the WWW-Authenticate header.
+     These values affect the computation of the request-digest. Note
+     that this is a single token, not a quoted list of alternatives as
+     in WWW- Authenticate.  This directive is optional in order to
+     preserve backward compatibility with a minimal implementation of
+     RFC 2069 [6], but SHOULD be used if the server indicated that qop
+     is supported by providing a qop directive in the WWW-Authenticate
+     header field.
+
+   cnonce
+     This MUST be specified if a qop directive is sent (see above), and
+     MUST NOT be specified if the server did not send a qop directive in
+     the WWW-Authenticate header field.  The cnonce-value is an opaque
+     quoted string value provided by the client and used by both client
+     and server to avoid chosen plaintext attacks, to provide mutual
+     authentication, and to provide some message integrity protection.
+     See the descriptions below of the calculation of the response-
+     digest and request-digest values.
+
+   nonce-count
+     This MUST be specified if a qop directive is sent (see above), and
+     MUST NOT be specified if the server did not send a qop directive in
+     the WWW-Authenticate header field.  The nc-value is the hexadecimal
+     count of the number of requests (including the current request)
+     that the client has sent with the nonce value in this request.  For
+     example, in the first request sent in response to a given nonce
+     value, the client sends "nc=00000001".  The purpose of this
+     directive is to allow the server to detect request replays by
+     maintaining its own copy of this count - if the same nc-value is
+     seen twice, then the request is a replay.   See the description
+     below of the construction of the request-digest value.
+
+   auth-param
+     This directive allows for future extensions. Any unrecognized
+     directive MUST be ignored.
+
+   If a directive or its value is improper, or required directives are
+   missing, the proper response is 400 Bad Request. If the request-
+   digest is invalid, then a login failure should be logged, since
+   repeated login failures from a single client may indicate an attacker
+   attempting to guess passwords.
+
+
+
+Franks, et al.              Standards Track                    [Page 12]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   The definition of request-digest above indicates the encoding for its
+   value. The following definitions show how the value is computed.
+
+3.2.2.1 Request-Digest
+
+   If the "qop" value is "auth" or "auth-int":
+
+      request-digest  = <"> < KD ( H(A1),     unq(nonce-value)
+                                          ":" nc-value
+                                          ":" unq(cnonce-value)
+                                          ":" unq(qop-value)
+                                          ":" H(A2)
+                                  ) <">
+
+   If the "qop" directive is not present (this construction is for
+   compatibility with RFC 2069):
+
+      request-digest  =
+                 <"> < KD ( H(A1), unq(nonce-value) ":" H(A2) ) >
+   <">
+
+   See below for the definitions for A1 and A2.
+
+3.2.2.2 A1
+
+   If the "algorithm" directive's value is "MD5" or is unspecified, then
+   A1 is:
+
+      A1       = unq(username-value) ":" unq(realm-value) ":" passwd
+
+   where
+
+      passwd   = < user's password >
+
+   If the "algorithm" directive's value is "MD5-sess", then A1 is
+   calculated only once - on the first request by the client following
+   receipt of a WWW-Authenticate challenge from the server.  It uses the
+   server nonce from that challenge, and the first client nonce value to
+   construct A1 as follows:
+
+      A1       = H( unq(username-value) ":" unq(realm-value)
+                     ":" passwd )
+                     ":" unq(nonce-value) ":" unq(cnonce-value)
+
+   This creates a 'session key' for the authentication of subsequent
+   requests and responses which is different for each "authentication
+   session", thus limiting the amount of material hashed with any one
+   key.  (Note: see further discussion of the authentication session in
+
+
+
+Franks, et al.              Standards Track                    [Page 13]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   section 3.3.) Because the server need only use the hash of the user
+   credentials in order to create the A1 value, this construction could
+   be used in conjunction with a third party authentication service so
+   that the web server would not need the actual password value.  The
+   specification of such a protocol is beyond the scope of this
+   specification.
+
+3.2.2.3 A2
+
+   If the "qop" directive's value is "auth" or is unspecified, then A2
+   is:
+
+      A2       = Method ":" digest-uri-value
+
+   If the "qop" value is "auth-int", then A2 is:
+
+      A2       = Method ":" digest-uri-value ":" H(entity-body)
+
+3.2.2.4 Directive values and quoted-string
+
+   Note that the value of many of the directives, such as "username-
+   value", are defined as a "quoted-string". However, the "unq" notation
+   indicates that surrounding quotation marks are removed in forming the
+   string A1. Thus if the Authorization header includes the fields
+
+     username="Mufasa", realm=myhost@testrealm.com
+
+   and the user Mufasa has password "Circle Of Life" then H(A1) would be
+   H(Mufasa:myhost@testrealm.com:Circle Of Life) with no quotation marks
+   in the digested string.
+
+   No white space is allowed in any of the strings to which the digest
+   function H() is applied unless that white space exists in the quoted
+   strings or entity body whose contents make up the string to be
+   digested. For example, the string A1 illustrated above must be
+
+        Mufasa:myhost@testrealm.com:Circle Of Life
+
+   with no white space on either side of the colons, but with the white
+   space between the words used in the password value.  Likewise, the
+   other strings digested by H() must not have white space on either
+   side of the colons which delimit their fields unless that white space
+   was in the quoted strings or entity body being digested.
+
+   Also note that if integrity protection is applied (qop=auth-int), the
+   H(entity-body) is the hash of the entity body, not the message body -
+   it is computed before any transfer encoding is applied by the sender
+
+
+
+
+Franks, et al.              Standards Track                    [Page 14]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   and after it has been removed by the recipient. Note that this
+   includes multipart boundaries and embedded headers in each part of
+   any multipart content-type.
+
+3.2.2.5 Various considerations
+
+   The "Method" value is the HTTP request method as specified in section
+   5.1.1 of [2]. The "request-uri" value is the Request-URI from the
+   request line as specified in section 5.1.2 of [2]. This may be "*",
+   an "absoluteURL" or an "abs_path" as specified in section 5.1.2 of
+   [2], but it MUST agree with the Request-URI. In particular, it MUST
+   be an "absoluteURL" if the Request-URI is an "absoluteURL". The
+   "cnonce-value" is an optional  client-chosen value whose purpose is
+   to foil chosen plaintext attacks.
+
+   The authenticating server must assure that the resource designated by
+   the "uri" directive is the same as the resource specified in the
+   Request-Line; if they are not, the server SHOULD return a 400 Bad
+   Request error. (Since this may be a symptom of an attack, server
+   implementers may want to consider logging such errors.) The purpose
+   of duplicating information from the request URL in this field is to
+   deal with the possibility that an intermediate proxy may alter the
+   client's Request-Line. This altered (but presumably semantically
+   equivalent) request would not result in the same digest as that
+   calculated by the client.
+
+   Implementers should be aware of how authenticated transactions
+   interact with shared caches. The HTTP/1.1 protocol specifies that
+   when a shared cache (see section 13.7 of [2]) has received a request
+   containing an Authorization header and a response from relaying that
+   request, it MUST NOT return that response as a reply to any other
+   request, unless one of two Cache-Control (see section 14.9 of [2])
+   directives was present in the response. If the original response
+   included the "must-revalidate" Cache-Control directive, the cache MAY
+   use the entity of that response in replying to a subsequent request,
+   but MUST first revalidate it with the origin server, using the
+   request headers from the new request to allow the origin server to
+   authenticate the new request. Alternatively, if the original response
+   included the "public" Cache-Control directive, the response entity
+   MAY be returned in reply to any subsequent request.
+
+3.2.3 The Authentication-Info Header
+
+   The Authentication-Info header is used by the server to communicate
+   some information regarding the successful authentication in the
+   response.
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 15]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+        AuthenticationInfo = "Authentication-Info" ":" auth-info
+        auth-info          = 1#(nextnonce | [ message-qop ]
+                               | [ response-auth ] | [ cnonce ]
+                               | [nonce-count] )
+        nextnonce          = "nextnonce" "=" nonce-value
+        response-auth      = "rspauth" "=" response-digest
+        response-digest    = <"> *LHEX <">
+
+   The value of the nextnonce directive is the nonce the server wishes
+   the client to use for a future authentication response.  The server
+   may send the Authentication-Info header with a nextnonce field as a
+   means of implementing one-time or otherwise changing  nonces. If the
+   nextnonce field is present the client SHOULD use it when constructing
+   the Authorization header for its next request. Failure of the client
+   to do so may result in a request to re-authenticate from the server
+   with the "stale=TRUE".
+
+     Server implementations should carefully consider the performance
+     implications of the use of this mechanism; pipelined requests will
+     not be possible if every response includes a nextnonce directive
+     that must be used on the next request received by the server.
+     Consideration should be given to the performance vs. security
+     tradeoffs of allowing an old nonce value to be used for a limited
+     time to permit request pipelining.  Use of the nonce-count can
+     retain most of the security advantages of a new server nonce
+     without the deleterious affects on pipelining.
+
+   message-qop
+     Indicates the "quality of protection" options applied to the
+     response by the server.  The value "auth" indicates authentication;
+     the value "auth-int" indicates authentication with integrity
+     protection. The server SHOULD use the same value for the message-
+     qop directive in the response as was sent by the client in the
+     corresponding request.
+
+   The optional response digest in the "response-auth" directive
+   supports mutual authentication -- the server proves that it knows the
+   user's secret, and with qop=auth-int also provides limited integrity
+   protection of the response. The "response-digest" value is calculated
+   as for the "request-digest" in the Authorization header, except that
+   if "qop=auth" or is not specified in the Authorization header for the
+   request, A2 is
+
+      A2       = ":" digest-uri-value
+
+   and if "qop=auth-int", then A2 is
+
+      A2       = ":" digest-uri-value ":" H(entity-body)
+
+
+
+Franks, et al.              Standards Track                    [Page 16]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   where "digest-uri-value" is the value of the "uri" directive on the
+   Authorization header in the request. The "cnonce-value" and "nc-
+   value" MUST be the ones for the client request to which this message
+   is the response. The "response-auth", "cnonce", and "nonce-count"
+   directives MUST BE present if "qop=auth" or "qop=auth-int" is
+   specified.
+
+   The Authentication-Info header is allowed in the trailer of an HTTP
+   message transferred via chunked transfer-coding.
+
+3.3 Digest Operation
+
+   Upon receiving the Authorization header, the server may check its
+   validity by looking up the password that corresponds to the submitted
+   username. Then, the server must perform the same digest operation
+   (e.g., MD5) performed by the client, and compare the result to the
+   given request-digest value.
+
+   Note that the HTTP server does not actually need to know the user's
+   cleartext password. As long as H(A1) is available to the server, the
+   validity of an Authorization header may be verified.
+
+   The client response to a WWW-Authenticate challenge for a protection
+   space starts an authentication session with that protection space.
+   The authentication session lasts until the client receives another
+   WWW-Authenticate challenge from any server in the protection space. A
+   client should remember the username, password, nonce, nonce count and
+   opaque values associated with an authentication session to use to
+   construct the Authorization header in future requests within that
+   protection space. The Authorization header may be included
+   preemptively; doing so improves server efficiency and avoids extra
+   round trips for authentication challenges. The server may choose to
+   accept the old Authorization header information, even though the
+   nonce value included might not be fresh. Alternatively, the server
+   may return a 401 response with a new nonce value, causing the client
+   to retry the request; by specifying stale=TRUE with this response,
+   the server tells the client to retry with the new nonce, but without
+   prompting for a new username and password.
+
+   Because the client is required to return the value of the opaque
+   directive given to it by the server for the duration of a session,
+   the opaque data may be used to transport authentication session state
+   information. (Note that any such use can also be accomplished more
+   easily and safely by including the state in the nonce.) For example,
+   a server could be responsible for authenticating content that
+   actually sits on another server. It would achieve this by having the
+   first 401 response include a domain directive whose value includes a
+   URI on the second server, and an opaque directive whose value
+
+
+
+Franks, et al.              Standards Track                    [Page 17]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   contains the state information. The client will retry the request, at
+   which time the server might respond with a 301/302 redirection,
+   pointing to the URI on the second server. The client will follow the
+   redirection, and pass an Authorization header , including the
+   <opaque> data.
+
+   As with the basic scheme, proxies must be completely transparent in
+   the Digest access authentication scheme. That is, they must forward
+   the WWW-Authenticate, Authentication-Info and Authorization headers
+   untouched. If a proxy wants to authenticate a client before a request
+   is forwarded to the server, it can be done using the Proxy-
+   Authenticate and Proxy-Authorization headers described in section 3.6
+   below.
+
+3.4 Security Protocol Negotiation
+
+   It is useful for a server to be able to know which security schemes a
+   client is capable of handling.
+
+   It is possible that a server may want to require Digest as its
+   authentication method, even if the server does not know that the
+   client supports it. A client is encouraged to fail gracefully if the
+   server specifies only authentication schemes it cannot handle.
+
+3.5 Example
+
+   The following example assumes that an access-protected document is
+   being requested from the server via a GET request. The URI of the
+   document is "http://www.nowhere.org/dir/index.html". Both client and
+   server know that the username for this document is "Mufasa", and the
+   password is "Circle Of Life" (with one space between each of the
+   three words).
+
+   The first time the client requests the document, no Authorization
+   header is sent, so the server responds with:
+
+         HTTP/1.1 401 Unauthorized
+         WWW-Authenticate: Digest
+                 realm="testrealm@host.com",
+                 qop="auth,auth-int",
+                 nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"
+
+   The client may prompt the user for the username and password, after
+   which it will respond with a new request, including the following
+   Authorization header:
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 18]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+         Authorization: Digest username="Mufasa",
+                 realm="testrealm@host.com",
+                 nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+                 uri="/dir/index.html",
+                 qop=auth,
+                 nc=00000001,
+                 cnonce="0a4f113b",
+                 response="6629fae49393a05397450978507c4ef1",
+                 opaque="5ccc069c403ebaf9f0171e9517f40e41"
+
+3.6 Proxy-Authentication and Proxy-Authorization
+
+   The digest authentication scheme may also be used for authenticating
+   users to proxies, proxies to proxies, or proxies to origin servers by
+   use of the Proxy-Authenticate and Proxy-Authorization headers. These
+   headers are instances of the Proxy-Authenticate and Proxy-
+   Authorization headers specified in sections 10.33 and 10.34 of the
+   HTTP/1.1 specification [2] and their behavior is subject to
+   restrictions described there. The transactions for proxy
+   authentication are very similar to those already described. Upon
+   receiving a request which requires authentication, the proxy/server
+   must issue the "407 Proxy Authentication Required" response with a
+   "Proxy-Authenticate" header.  The digest-challenge used in the
+   Proxy-Authenticate header is the same as that for the WWW-
+   Authenticate header as defined above in section 3.2.1.
+
+   The client/proxy must then re-issue the request with a Proxy-
+   Authorization header, with directives as specified for the
+   Authorization header in section 3.2.2 above.
+
+   On subsequent responses, the server sends Proxy-Authentication-Info
+   with directives the same as those for the Authentication-Info header
+   field.
+
+   Note that in principle a client could be asked to authenticate itself
+   to both a proxy and an end-server, but never in the same response.
+
+4 Security Considerations
+
+4.1 Authentication of Clients using Basic Authentication
+
+   The Basic authentication scheme is not a secure method of user
+   authentication, nor does it in any way protect the entity, which is
+   transmitted in cleartext across the physical network used as the
+   carrier. HTTP does not prevent additional authentication schemes and
+   encryption mechanisms from being employed to increase security or the
+   addition of enhancements (such as schemes to use one-time passwords)
+   to Basic authentication.
+
+
+
+Franks, et al.              Standards Track                    [Page 19]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   The most serious flaw in Basic authentication is that it results in
+   the essentially cleartext transmission of the user's password over
+   the physical network. It is this problem which Digest Authentication
+   attempts to address.
+
+   Because Basic authentication involves the cleartext transmission of
+   passwords it SHOULD NOT be used (without enhancements) to protect
+   sensitive or valuable information.
+
+   A common use of Basic authentication is for identification purposes
+   -- requiring the user to provide a user name and password as a means
+   of identification, for example, for purposes of gathering accurate
+   usage statistics on a server. When used in this way it is tempting to
+   think that there is no danger in its use if illicit access to the
+   protected documents is not a major concern. This is only correct if
+   the server issues both user name and password to the users and in
+   particular does not allow the user to choose his or her own password.
+   The danger arises because naive users frequently reuse a single
+   password to avoid the task of maintaining multiple passwords.
+
+   If a server permits users to select their own passwords, then the
+   threat is not only unauthorized access to documents on the server but
+   also unauthorized access to any other resources on other systems that
+   the user protects with the same password. Furthermore, in the
+   server's password database, many of the passwords may also be users'
+   passwords for other sites. The owner or administrator of such a
+   system could therefore expose all users of the system to the risk of
+   unauthorized access to all those sites if this information is not
+   maintained in a secure fashion.
+
+   Basic Authentication is also vulnerable to spoofing by counterfeit
+   servers. If a user can be led to believe that he is connecting to a
+   host containing information protected by Basic authentication when,
+   in fact, he is connecting to a hostile server or gateway, then the
+   attacker can request a password, store it for later use, and feign an
+   error. This type of attack is not possible with Digest
+   Authentication. Server implementers SHOULD guard against the
+   possibility of this sort of counterfeiting by gateways or CGI
+   scripts. In particular it is very dangerous for a server to simply
+   turn over a connection to a gateway.  That gateway can then use the
+   persistent connection mechanism to engage in multiple transactions
+   with the client while impersonating the original server in a way that
+   is not detectable by the client.
+
+4.2 Authentication of Clients using Digest Authentication
+
+   Digest Authentication does not provide a strong authentication
+   mechanism, when compared to public key based mechanisms, for example.
+
+
+
+Franks, et al.              Standards Track                    [Page 20]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   However, it is significantly stronger than (e.g.) CRAM-MD5, which has
+   been proposed for use with LDAP [10], POP and IMAP (see RFC 2195
+   [9]).  It is intended to replace the much weaker and even more
+   dangerous Basic mechanism.
+
+   Digest Authentication offers no confidentiality protection beyond
+   protecting the actual password. All of the rest of the request and
+   response are available to an eavesdropper.
+
+   Digest Authentication offers only limited integrity protection for
+   the messages in either direction. If  qop=auth-int mechanism is used,
+   those parts of the message used in the calculation of the WWW-
+   Authenticate and Authorization header field response directive values
+   (see section 3.2 above) are  protected.  Most header fields and their
+   values could be modified as a part of a man-in-the-middle attack.
+
+   Many needs for secure HTTP transactions cannot be met by Digest
+   Authentication. For those needs TLS or SHTTP are more appropriate
+   protocols. In particular Digest authentication cannot be used for any
+   transaction requiring confidentiality protection.  Nevertheless many
+   functions remain for which Digest authentication is both useful and
+   appropriate.  Any service in present use that uses Basic should be
+   switched to Digest as soon as practical.
+
+4.3 Limited Use Nonce Values
+
+   The Digest scheme uses a server-specified nonce to seed the
+   generation of the request-digest value (as specified in section
+   3.2.2.1 above).  As shown in the example nonce in section 3.2.1, the
+   server is free to construct the nonce such that it may only be used
+   from a particular client, for a particular resource, for a limited
+   period of time or number of uses, or any other restrictions.  Doing
+   so strengthens the protection provided against, for example, replay
+   attacks (see 4.5).  However, it should be noted that the method
+   chosen for generating and checking the nonce also has performance and
+   resource implications.  For example, a server may choose to allow
+   each nonce value to be used only once by maintaining a record of
+   whether or not each recently issued nonce has been returned and
+   sending a next-nonce directive in the Authentication-Info header
+   field of every response. This protects against even an immediate
+   replay attack, but has a high cost checking nonce values, and perhaps
+   more important will cause authentication failures for any pipelined
+   requests (presumably returning a stale nonce indication).  Similarly,
+   incorporating a request-specific element such as the Etag value for a
+   resource limits the use of the nonce to that version of the resource
+   and also defeats pipelining. Thus it may be useful to do so for
+   methods with side effects but have unacceptable performance for those
+   that do not.
+
+
+
+Franks, et al.              Standards Track                    [Page 21]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+4.4 Comparison of Digest with Basic Authentication
+
+   Both Digest and Basic Authentication are very much on the weak end of
+   the security strength spectrum. But a comparison between the two
+   points out the utility, even necessity, of replacing Basic by Digest.
+
+   The greatest threat to the type of transactions for which these
+   protocols are used is network snooping. This kind of transaction
+   might involve, for example, online access to a database whose use is
+   restricted to paying subscribers. With Basic authentication an
+   eavesdropper can obtain the password of the user. This not only
+   permits him to access anything in the database, but, often worse,
+   will permit access to anything else the user protects with the same
+   password.
+
+   By contrast, with Digest Authentication the eavesdropper only gets
+   access to the transaction in question and not to the user's password.
+   The information gained by the eavesdropper would permit a replay
+   attack, but only with a request for the same document, and even that
+   may be limited by the server's choice of nonce.
+
+4.5 Replay Attacks
+
+   A replay attack against Digest authentication would usually be
+   pointless for a simple GET request since an eavesdropper would
+   already have seen the only document he could obtain with a replay.
+   This is because the URI of the requested document is digested in the
+   client request and the server will only deliver that document. By
+   contrast under Basic Authentication once the eavesdropper has the
+   user's password, any document protected by that password is open to
+   him.
+
+   Thus, for some purposes, it is necessary to protect against replay
+   attacks. A good Digest implementation can do this in various ways.
+   The server created "nonce" value is implementation dependent, but if
+   it contains a digest of the client IP, a time-stamp, the resource
+   ETag, and a private server key (as recommended above) then a replay
+   attack is not simple. An attacker must convince the server that the
+   request is coming from a false IP address and must cause the server
+   to deliver the document to an IP address different from the address
+   to which it believes it is sending the document. An attack can only
+   succeed in the period before the time-stamp expires. Digesting the
+   client IP and time-stamp in the nonce permits an implementation which
+   does not maintain state between transactions.
+
+   For applications where no possibility of replay attack can be
+   tolerated the server can use one-time nonce values which will not be
+   honored for a second use. This requires the overhead of the server
+
+
+
+Franks, et al.              Standards Track                    [Page 22]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   remembering which nonce values have been used until the nonce time-
+   stamp (and hence the digest built with it) has expired, but it
+   effectively protects against replay attacks.
+
+   An implementation must give special attention to the possibility of
+   replay attacks with POST and PUT requests. Unless the server employs
+   one-time or otherwise limited-use nonces and/or insists on the use of
+   the integrity protection of qop=auth-int, an attacker could replay
+   valid credentials from a successful request with counterfeit form
+   data or other message body. Even with the use of integrity protection
+   most metadata in header fields is not protected. Proper nonce
+   generation and checking provides some protection against replay of
+   previously used valid credentials, but see 4.8.
+
+4.6 Weakness Created by Multiple Authentication Schemes
+
+   An HTTP/1.1 server may return multiple challenges with a 401
+   (Authenticate) response, and each challenge may use a different
+   auth-scheme. A user agent MUST choose to use the strongest auth-
+   scheme it understands and request credentials from the user based
+   upon that challenge.
+
+      Note that many browsers will only recognize Basic and will require
+      that it be the first auth-scheme presented. Servers should only
+      include Basic if it is minimally acceptable.
+
+   When the server offers choices of authentication schemes using the
+   WWW-Authenticate header, the strength of the resulting authentication
+   is only as good as that of the of the weakest of the authentication
+   schemes. See section 4.8 below for discussion of particular attack
+   scenarios that exploit multiple authentication schemes.
+
+4.7 Online dictionary attacks
+
+   If the attacker can eavesdrop, then it can test any overheard
+   nonce/response pairs against a list of common words. Such a list is
+   usually much smaller than the total number of possible passwords. The
+   cost of computing the response for each password on the list is paid
+   once for each challenge.
+
+   The server can mitigate this attack by not allowing users to select
+   passwords that are in a dictionary.
+
+
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 23]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+4.8 Man in the Middle
+
+   Both Basic and Digest authentication are vulnerable to "man in the
+   middle" (MITM) attacks, for example, from a hostile or compromised
+   proxy. Clearly, this would present all the problems of eavesdropping.
+   But it also offers some additional opportunities to the attacker.
+
+   A possible man-in-the-middle attack would be to add a weak
+   authentication scheme to the set of choices, hoping that the client
+   will use one that exposes the user's credentials (e.g. password). For
+   this reason, the client should always use the strongest scheme that
+   it understands from the choices offered.
+
+   An even better MITM attack would be to remove all offered choices,
+   replacing them with a challenge that requests only Basic
+   authentication, then uses the cleartext credentials from the Basic
+   authentication to authenticate to the origin server using the
+   stronger scheme it requested. A particularly insidious way to mount
+   such a MITM attack would be to offer a "free" proxy caching service
+   to gullible users.
+
+   User agents should consider measures such as presenting a visual
+   indication at the time of the credentials request of what
+   authentication scheme is to be used, or remembering the strongest
+   authentication scheme ever requested by a server and produce a
+   warning message before using a weaker one. It might also be a good
+   idea for the user agent to be configured to demand Digest
+   authentication in general, or from specific sites.
+
+   Or, a hostile proxy might spoof the client into making a request the
+   attacker wanted rather than one the client wanted. Of course, this is
+   still much harder than a comparable attack against Basic
+   Authentication.
+
+4.9 Chosen plaintext attacks
+
+   With Digest authentication, a MITM or a malicious server can
+   arbitrarily choose the nonce that the client will use to compute the
+   response. This is called a "chosen plaintext" attack. The ability to
+   choose the nonce is known to make cryptanalysis much easier [8].
+
+   However, no way to analyze the MD5 one-way function used by Digest
+   using chosen plaintext is currently known.
+
+   The countermeasure against this attack is for clients to be
+   configured to require the use of the optional "cnonce" directive;
+   this allows the client to vary the input to the hash in a way not
+   chosen by the attacker.
+
+
+
+Franks, et al.              Standards Track                    [Page 24]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+4.10 Precomputed dictionary attacks
+
+   With Digest authentication, if the attacker can execute a chosen
+   plaintext attack, the attacker can precompute the response for many
+   common words to a nonce of its choice, and store a dictionary of
+   (response, password) pairs. Such precomputation can often be done in
+   parallel on many machines. It can then use the chosen plaintext
+   attack to acquire a response corresponding to that challenge, and
+   just look up the password in the dictionary. Even if most passwords
+   are not in the dictionary, some might be. Since the attacker gets to
+   pick the challenge, the cost of computing the response for each
+   password on the list can be amortized over finding many passwords. A
+   dictionary with 100 million password/response pairs would take about
+   3.2 gigabytes of disk storage.
+
+   The countermeasure against this attack is to for clients to be
+   configured to require the use of the optional "cnonce" directive.
+
+4.11 Batch brute force attacks
+
+   With Digest authentication, a MITM can execute a chosen plaintext
+   attack, and can gather responses from many users to the same nonce.
+   It can then find all the passwords within any subset of password
+   space that would generate one of the nonce/response pairs in a single
+   pass over that space. It also reduces the time to find the first
+   password by a factor equal to the number of nonce/response pairs
+   gathered. This search of the password space can often be done in
+   parallel on many machines, and even a single machine can search large
+   subsets of the password space very quickly -- reports exist of
+   searching all passwords with six or fewer letters in a few hours.
+
+   The countermeasure against this attack is to for clients to be
+   configured to require the use of the optional "cnonce" directive.
+
+4.12 Spoofing by Counterfeit Servers
+
+   Basic Authentication is vulnerable to spoofing by counterfeit
+   servers.  If a user can be led to believe that she is connecting to a
+   host containing information protected by a password she knows, when
+   in fact she is connecting to a hostile server, then the hostile
+   server can request a password, store it away for later use, and feign
+   an error.  This type of attack is more difficult with Digest
+   Authentication -- but the client must know to demand that Digest
+   authentication be used, perhaps using some of the techniques
+   described above to counter "man-in-the-middle" attacks.  Again, the
+   user can be helped in detecting this attack by a visual indication of
+   the authentication mechanism in use with appropriate guidance in
+   interpreting the implications of each scheme.
+
+
+
+Franks, et al.              Standards Track                    [Page 25]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+4.13 Storing passwords
+
+   Digest authentication requires that the authenticating agent (usually
+   the server) store some data derived from the user's name and password
+   in a "password file" associated with a given realm. Normally this
+   might contain pairs consisting of username and H(A1), where H(A1) is
+   the digested value of the username, realm, and password as described
+   above.
+
+   The security implications of this are that if this password file is
+   compromised, then an attacker gains immediate access to documents on
+   the server using this realm. Unlike, say a standard UNIX password
+   file, this information need not be decrypted in order to access
+   documents in the server realm associated with this file. On the other
+   hand, decryption, or more likely a brute force attack, would be
+   necessary to obtain the user's password. This is the reason that the
+   realm is part of the digested data stored in the password file. It
+   means that if one Digest authentication password file is compromised,
+   it does not automatically compromise others with the same username
+   and password (though it does expose them to brute force attack).
+
+   There are two important security consequences of this. First the
+   password file must be protected as if it contained unencrypted
+   passwords, because for the purpose of accessing documents in its
+   realm, it effectively does.
+
+   A second consequence of this is that the realm string should be
+   unique among all realms which any single user is likely to use. In
+   particular a realm string should include the name of the host doing
+   the authentication. The inability of the client to authenticate the
+   server is a weakness of Digest Authentication.
+
+4.14 Summary
+
+   By modern cryptographic standards Digest Authentication is weak. But
+   for a large range of purposes it is valuable as a replacement for
+   Basic Authentication. It remedies some, but not all, weaknesses of
+   Basic Authentication. Its strength may vary depending on the
+   implementation.  In particular the structure of the nonce (which is
+   dependent on the server implementation) may affect the ease of
+   mounting a replay attack.  A range of server options is appropriate
+   since, for example, some implementations may be willing to accept the
+   server overhead of one-time nonces or digests to eliminate the
+   possibility of replay. Others may satisfied with a nonce like the one
+   recommended above restricted to a single IP address and a single ETag
+   or with a limited lifetime.
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 26]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   The bottom line is that *any* compliant implementation will be
+   relatively weak by cryptographic standards, but *any* compliant
+   implementation will be far superior to Basic Authentication.
+
+5 Sample implementation
+
+   The following code implements the calculations of H(A1), H(A2),
+   request-digest and response-digest, and a test program which computes
+   the values used in the example of section 3.5. It uses the MD5
+   implementation from RFC 1321.
+
+   File "digcalc.h":
+
+#define HASHLEN 16
+typedef char HASH[HASHLEN];
+#define HASHHEXLEN 32
+typedef char HASHHEX[HASHHEXLEN+1];
+#define IN
+#define OUT
+
+/* calculate H(A1) as per HTTP Digest spec */
+void DigestCalcHA1(
+    IN char * pszAlg,
+    IN char * pszUserName,
+    IN char * pszRealm,
+    IN char * pszPassword,
+    IN char * pszNonce,
+    IN char * pszCNonce,
+    OUT HASHHEX SessionKey
+    );
+
+/* calculate request-digest/response-digest as per HTTP Digest spec */
+void DigestCalcResponse(
+    IN HASHHEX HA1,           /* H(A1) */
+    IN char * pszNonce,       /* nonce from server */
+    IN char * pszNonceCount,  /* 8 hex digits */
+    IN char * pszCNonce,      /* client nonce */
+    IN char * pszQop,         /* qop-value: "", "auth", "auth-int" */
+    IN char * pszMethod,      /* method from the request */
+    IN char * pszDigestUri,   /* requested URL */
+    IN HASHHEX HEntity,       /* H(entity body) if qop="auth-int" */
+    OUT HASHHEX Response      /* request-digest or response-digest */
+    );
+
+File "digcalc.c":
+
+#include <global.h>
+#include <md5.h>
+
+
+
+Franks, et al.              Standards Track                    [Page 27]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+#include <string.h>
+#include "digcalc.h"
+
+void CvtHex(
+    IN HASH Bin,
+    OUT HASHHEX Hex
+    )
+{
+    unsigned short i;
+    unsigned char j;
+
+    for (i = 0; i < HASHLEN; i++) {
+        j = (Bin[i] >> 4) & 0xf;
+        if (j <= 9)
+            Hex[i*2] = (j + '0');
+         else
+            Hex[i*2] = (j + 'a' - 10);
+        j = Bin[i] & 0xf;
+        if (j <= 9)
+            Hex[i*2+1] = (j + '0');
+         else
+            Hex[i*2+1] = (j + 'a' - 10);
+    };
+    Hex[HASHHEXLEN] = '\0';
+};
+
+/* calculate H(A1) as per spec */
+void DigestCalcHA1(
+    IN char * pszAlg,
+    IN char * pszUserName,
+    IN char * pszRealm,
+    IN char * pszPassword,
+    IN char * pszNonce,
+    IN char * pszCNonce,
+    OUT HASHHEX SessionKey
+    )
+{
+      MD5_CTX Md5Ctx;
+      HASH HA1;
+
+      MD5Init(&Md5Ctx);
+      MD5Update(&Md5Ctx, pszUserName, strlen(pszUserName));
+      MD5Update(&Md5Ctx, ":", 1);
+      MD5Update(&Md5Ctx, pszRealm, strlen(pszRealm));
+      MD5Update(&Md5Ctx, ":", 1);
+      MD5Update(&Md5Ctx, pszPassword, strlen(pszPassword));
+      MD5Final(HA1, &Md5Ctx);
+      if (stricmp(pszAlg, "md5-sess") == 0) {
+
+
+
+Franks, et al.              Standards Track                    [Page 28]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+            MD5Init(&Md5Ctx);
+            MD5Update(&Md5Ctx, HA1, HASHLEN);
+            MD5Update(&Md5Ctx, ":", 1);
+            MD5Update(&Md5Ctx, pszNonce, strlen(pszNonce));
+            MD5Update(&Md5Ctx, ":", 1);
+            MD5Update(&Md5Ctx, pszCNonce, strlen(pszCNonce));
+            MD5Final(HA1, &Md5Ctx);
+      };
+      CvtHex(HA1, SessionKey);
+};
+
+/* calculate request-digest/response-digest as per HTTP Digest spec */
+void DigestCalcResponse(
+    IN HASHHEX HA1,           /* H(A1) */
+    IN char * pszNonce,       /* nonce from server */
+    IN char * pszNonceCount,  /* 8 hex digits */
+    IN char * pszCNonce,      /* client nonce */
+    IN char * pszQop,         /* qop-value: "", "auth", "auth-int" */
+    IN char * pszMethod,      /* method from the request */
+    IN char * pszDigestUri,   /* requested URL */
+    IN HASHHEX HEntity,       /* H(entity body) if qop="auth-int" */
+    OUT HASHHEX Response      /* request-digest or response-digest */
+    )
+{
+      MD5_CTX Md5Ctx;
+      HASH HA2;
+      HASH RespHash;
+       HASHHEX HA2Hex;
+
+      // calculate H(A2)
+      MD5Init(&Md5Ctx);
+      MD5Update(&Md5Ctx, pszMethod, strlen(pszMethod));
+      MD5Update(&Md5Ctx, ":", 1);
+      MD5Update(&Md5Ctx, pszDigestUri, strlen(pszDigestUri));
+      if (stricmp(pszQop, "auth-int") == 0) {
+            MD5Update(&Md5Ctx, ":", 1);
+            MD5Update(&Md5Ctx, HEntity, HASHHEXLEN);
+      };
+      MD5Final(HA2, &Md5Ctx);
+       CvtHex(HA2, HA2Hex);
+
+      // calculate response
+      MD5Init(&Md5Ctx);
+      MD5Update(&Md5Ctx, HA1, HASHHEXLEN);
+      MD5Update(&Md5Ctx, ":", 1);
+      MD5Update(&Md5Ctx, pszNonce, strlen(pszNonce));
+      MD5Update(&Md5Ctx, ":", 1);
+      if (*pszQop) {
+
+
+
+Franks, et al.              Standards Track                    [Page 29]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+          MD5Update(&Md5Ctx, pszNonceCount, strlen(pszNonceCount));
+          MD5Update(&Md5Ctx, ":", 1);
+          MD5Update(&Md5Ctx, pszCNonce, strlen(pszCNonce));
+          MD5Update(&Md5Ctx, ":", 1);
+          MD5Update(&Md5Ctx, pszQop, strlen(pszQop));
+          MD5Update(&Md5Ctx, ":", 1);
+      };
+      MD5Update(&Md5Ctx, HA2Hex, HASHHEXLEN);
+      MD5Final(RespHash, &Md5Ctx);
+      CvtHex(RespHash, Response);
+};
+
+File "digtest.c":
+
+
+#include <stdio.h>
+#include "digcalc.h"
+
+void main(int argc, char ** argv) {
+
+      char * pszNonce = "dcd98b7102dd2f0e8b11d0f600bfb0c093";
+      char * pszCNonce = "0a4f113b";
+      char * pszUser = "Mufasa";
+      char * pszRealm = "testrealm@host.com";
+      char * pszPass = "Circle Of Life";
+      char * pszAlg = "md5";
+      char szNonceCount[9] = "00000001";
+      char * pszMethod = "GET";
+      char * pszQop = "auth";
+      char * pszURI = "/dir/index.html";
+      HASHHEX HA1;
+      HASHHEX HA2 = "";
+      HASHHEX Response;
+
+      DigestCalcHA1(pszAlg, pszUser, pszRealm, pszPass, pszNonce,
+pszCNonce, HA1);
+      DigestCalcResponse(HA1, pszNonce, szNonceCount, pszCNonce, pszQop,
+       pszMethod, pszURI, HA2, Response);
+      printf("Response = %s\n", Response);
+};
+
+
+
+
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 30]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+6 Acknowledgments
+
+   Eric W. Sink, of AbiSource, Inc., was one of the original authors
+   before the specification underwent substantial revision.
+
+   In addition to the authors, valuable discussion instrumental in
+   creating this document has come from Peter J. Churchyard, Ned Freed,
+   and David M.  Kristol.
+
+   Jim Gettys and Larry Masinter edited this document for update.
+
+7 References
+
+   [1]  Berners-Lee, T.,  Fielding, R. and H. Frystyk, "Hypertext
+        Transfer Protocol -- HTTP/1.0", RFC 1945, May 1996.
+
+   [2]  Fielding, R.,  Gettys, J., Mogul, J., Frysyk, H., Masinter, L.,
+        Leach, P. and T. Berners-Lee, "Hypertext Transfer Protocol --
+        HTTP/1.1", RFC 2616, June 1999.
+
+   [3]  Rivest, R., "The MD5 Message-Digest Algorithm", RFC 1321, April
+        1992.
+
+   [4]  Freed, N. and N. Borenstein. "Multipurpose Internet Mail
+        Extensions (MIME) Part One: Format of Internet Message Bodies",
+        RFC 2045, November 1996.
+
+   [5]  Dierks, T. and C. Allen "The TLS Protocol, Version 1.0", RFC
+        2246, January 1999.
+
+   [6]  Franks, J., Hallam-Baker, P., Hostetler, J., Leach, P.,
+        Luotonen, A., Sink, E. and L. Stewart, "An Extension to HTTP :
+        Digest Access Authentication", RFC 2069, January 1997.
+
+   [7]  Berners Lee, T, Fielding, R. and L. Masinter, "Uniform Resource
+        Identifiers (URI): Generic Syntax", RFC 2396, August 1998.
+
+   [8]  Kaliski, B.,Robshaw, M., "Message Authentication with MD5",
+        CryptoBytes, Sping 1995, RSA Inc,
+        (http://www.rsa.com/rsalabs/pubs/cryptobytes/spring95/md5.htm)
+
+   [9]  Klensin, J., Catoe, R. and P. Krumviede, "IMAP/POP AUTHorize
+        Extension for Simple Challenge/Response", RFC 2195, September
+        1997.
+
+   [10] Morgan, B., Alvestrand, H., Hodges, J., Wahl, M.,
+        "Authentication Methods for LDAP", Work in Progress.
+
+
+
+
+Franks, et al.              Standards Track                    [Page 31]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+8 Authors' Addresses
+
+   John Franks
+   Professor of Mathematics
+   Department of Mathematics
+   Northwestern University
+   Evanston, IL 60208-2730, USA
+
+   EMail: john@math.nwu.edu
+
+
+   Phillip M. Hallam-Baker
+   Principal Consultant
+   Verisign Inc.
+   301 Edgewater Place
+   Suite 210
+   Wakefield MA 01880, USA
+
+   EMail: pbaker@verisign.com
+
+
+   Jeffery L. Hostetler
+   Software Craftsman
+   AbiSource, Inc.
+   6 Dunlap Court
+   Savoy, IL 61874
+
+   EMail: jeff@AbiSource.com
+
+
+   Scott D. Lawrence
+   Agranat Systems, Inc.
+   5 Clocktower Place, Suite 400
+   Maynard, MA 01754, USA
+
+   EMail: lawrence@agranat.com
+
+
+   Paul J. Leach
+   Microsoft Corporation
+   1 Microsoft Way
+   Redmond, WA 98052, USA
+
+   EMail: paulle@microsoft.com
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 32]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+   Ari Luotonen
+   Member of Technical Staff
+   Netscape Communications Corporation
+   501 East Middlefield Road
+   Mountain View, CA 94043, USA
+
+
+   Lawrence C. Stewart
+   Open Market, Inc.
+   215 First Street
+   Cambridge, MA  02142, USA
+
+   EMail: stewart@OpenMarket.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 33]
+
+RFC 2617                  HTTP Authentication                  June 1999
+
+
+9.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (1999).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Franks, et al.              Standards Track                    [Page 34]
+

--- a/rfcs/rfc3261.txt
+++ b/rfcs/rfc3261.txt
@@ -1,0 +1,15067 @@
+
+
+
+
+
+
+Network Working Group                                       J. Rosenberg
+Request for Comments: 3261                                   dynamicsoft
+Obsoletes: 2543                                           H. Schulzrinne
+Category: Standards Track                                    Columbia U.
+                                                            G. Camarillo
+                                                                Ericsson
+                                                             A. Johnston
+                                                                WorldCom
+                                                             J. Peterson
+                                                                 Neustar
+                                                               R. Sparks
+                                                             dynamicsoft
+                                                              M. Handley
+                                                                    ICIR
+                                                             E. Schooler
+                                                                    AT&T
+                                                               June 2002
+
+                    SIP: Session Initiation Protocol
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This document describes Session Initiation Protocol (SIP), an
+   application-layer control (signaling) protocol for creating,
+   modifying, and terminating sessions with one or more participants.
+   These sessions include Internet telephone calls, multimedia
+   distribution, and multimedia conferences.
+
+   SIP invitations used to create sessions carry session descriptions
+   that allow participants to agree on a set of compatible media types.
+   SIP makes use of elements called proxy servers to help route requests
+   to the user's current location, authenticate and authorize users for
+   services, implement provider call-routing policies, and provide
+   features to users.  SIP also provides a registration function that
+   allows users to upload their current locations for use by proxy
+   servers.  SIP runs on top of several different transport protocols.
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 1]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Table of Contents
+
+   1          Introduction ........................................    8
+   2          Overview of SIP Functionality .......................    9
+   3          Terminology .........................................   10
+   4          Overview of Operation ...............................   10
+   5          Structure of the Protocol ...........................   18
+   6          Definitions .........................................   20
+   7          SIP Messages ........................................   26
+   7.1        Requests ............................................   27
+   7.2        Responses ...........................................   28
+   7.3        Header Fields .......................................   29
+   7.3.1      Header Field Format .................................   30
+   7.3.2      Header Field Classification .........................   32
+   7.3.3      Compact Form ........................................   32
+   7.4        Bodies ..............................................   33
+   7.4.1      Message Body Type ...................................   33
+   7.4.2      Message Body Length .................................   33
+   7.5        Framing SIP Messages ................................   34
+   8          General User Agent Behavior .........................   34
+   8.1        UAC Behavior ........................................   35
+   8.1.1      Generating the Request ..............................   35
+   8.1.1.1    Request-URI .........................................   35
+   8.1.1.2    To ..................................................   36
+   8.1.1.3    From ................................................   37
+   8.1.1.4    Call-ID .............................................   37
+   8.1.1.5    CSeq ................................................   38
+   8.1.1.6    Max-Forwards ........................................   38
+   8.1.1.7    Via .................................................   39
+   8.1.1.8    Contact .............................................   40
+   8.1.1.9    Supported and Require ...............................   40
+   8.1.1.10   Additional Message Components .......................   41
+   8.1.2      Sending the Request .................................   41
+   8.1.3      Processing Responses ................................   42
+   8.1.3.1    Transaction Layer Errors ............................   42
+   8.1.3.2    Unrecognized Responses ..............................   42
+   8.1.3.3    Vias ................................................   43
+   8.1.3.4    Processing 3xx Responses ............................   43
+   8.1.3.5    Processing 4xx Responses ............................   45
+   8.2        UAS Behavior ........................................   46
+   8.2.1      Method Inspection ...................................   46
+   8.2.2      Header Inspection ...................................   46
+   8.2.2.1    To and Request-URI ..................................   46
+   8.2.2.2    Merged Requests .....................................   47
+   8.2.2.3    Require .............................................   47
+   8.2.3      Content Processing ..................................   48
+   8.2.4      Applying Extensions .................................   49
+   8.2.5      Processing the Request ..............................   49
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 2]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   8.2.6      Generating the Response .............................   49
+   8.2.6.1    Sending a Provisional Response ......................   49
+   8.2.6.2    Headers and Tags ....................................   50
+   8.2.7      Stateless UAS Behavior ..............................   50
+   8.3        Redirect Servers ....................................   51
+   9          Canceling a Request .................................   53
+   9.1        Client Behavior .....................................   53
+   9.2        Server Behavior .....................................   55
+   10         Registrations .......................................   56
+   10.1       Overview ............................................   56
+   10.2       Constructing the REGISTER Request ...................   57
+   10.2.1     Adding Bindings .....................................   59
+   10.2.1.1   Setting the Expiration Interval of Contact Addresses    60
+   10.2.1.2   Preferences among Contact Addresses .................   61
+   10.2.2     Removing Bindings ...................................   61
+   10.2.3     Fetching Bindings ...................................   61
+   10.2.4     Refreshing Bindings .................................   61
+   10.2.5     Setting the Internal Clock ..........................   62
+   10.2.6     Discovering a Registrar .............................   62
+   10.2.7     Transmitting a Request ..............................   62
+   10.2.8     Error Responses .....................................   63
+   10.3       Processing REGISTER Requests ........................   63
+   11         Querying for Capabilities ...........................   66
+   11.1       Construction of OPTIONS Request .....................   67
+   11.2       Processing of OPTIONS Request .......................   68
+   12         Dialogs .............................................   69
+   12.1       Creation of a Dialog ................................   70
+   12.1.1     UAS behavior ........................................   70
+   12.1.2     UAC Behavior ........................................   71
+   12.2       Requests within a Dialog ............................   72
+   12.2.1     UAC Behavior ........................................   73
+   12.2.1.1   Generating the Request ..............................   73
+   12.2.1.2   Processing the Responses ............................   75
+   12.2.2     UAS Behavior ........................................   76
+   12.3       Termination of a Dialog .............................   77
+   13         Initiating a Session ................................   77
+   13.1       Overview ............................................   77
+   13.2       UAC Processing ......................................   78
+   13.2.1     Creating the Initial INVITE .........................   78
+   13.2.2     Processing INVITE Responses .........................   81
+   13.2.2.1   1xx Responses .......................................   81
+   13.2.2.2   3xx Responses .......................................   81
+   13.2.2.3   4xx, 5xx and 6xx Responses ..........................   81
+   13.2.2.4   2xx Responses .......................................   82
+   13.3       UAS Processing ......................................   83
+   13.3.1     Processing of the INVITE ............................   83
+   13.3.1.1   Progress ............................................   84
+   13.3.1.2   The INVITE is Redirected ............................   84
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 3]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   13.3.1.3   The INVITE is Rejected ..............................   85
+   13.3.1.4   The INVITE is Accepted ..............................   85
+   14         Modifying an Existing Session .......................   86
+   14.1       UAC Behavior ........................................   86
+   14.2       UAS Behavior ........................................   88
+   15         Terminating a Session ...............................   89
+   15.1       Terminating a Session with a BYE Request ............   90
+   15.1.1     UAC Behavior ........................................   90
+   15.1.2     UAS Behavior ........................................   91
+   16         Proxy Behavior ......................................   91
+   16.1       Overview ............................................   91
+   16.2       Stateful Proxy ......................................   92
+   16.3       Request Validation ..................................   94
+   16.4       Route Information Preprocessing .....................   96
+   16.5       Determining Request Targets .........................   97
+   16.6       Request Forwarding ..................................   99
+   16.7       Response Processing .................................  107
+   16.8       Processing Timer C ..................................  114
+   16.9       Handling Transport Errors ...........................  115
+   16.10      CANCEL Processing ...................................  115
+   16.11      Stateless Proxy .....................................  116
+   16.12      Summary of Proxy Route Processing ...................  118
+   16.12.1    Examples ............................................  118
+   16.12.1.1  Basic SIP Trapezoid .................................  118
+   16.12.1.2  Traversing a Strict-Routing Proxy ...................  120
+   16.12.1.3  Rewriting Record-Route Header Field Values ..........  121
+   17         Transactions ........................................  122
+   17.1       Client Transaction ..................................  124
+   17.1.1     INVITE Client Transaction ...........................  125
+   17.1.1.1   Overview of INVITE Transaction ......................  125
+   17.1.1.2   Formal Description ..................................  125
+   17.1.1.3   Construction of the ACK Request .....................  129
+   17.1.2     Non-INVITE Client Transaction .......................  130
+   17.1.2.1   Overview of the non-INVITE Transaction ..............  130
+   17.1.2.2   Formal Description ..................................  131
+   17.1.3     Matching Responses to Client Transactions ...........  132
+   17.1.4     Handling Transport Errors ...........................  133
+   17.2       Server Transaction ..................................  134
+   17.2.1     INVITE Server Transaction ...........................  134
+   17.2.2     Non-INVITE Server Transaction .......................  137
+   17.2.3     Matching Requests to Server Transactions ............  138
+   17.2.4     Handling Transport Errors ...........................  141
+   18         Transport ...........................................  141
+   18.1       Clients .............................................  142
+   18.1.1     Sending Requests ....................................  142
+   18.1.2     Receiving Responses .................................  144
+   18.2       Servers .............................................  145
+   18.2.1     Receiving Requests ..................................  145
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 4]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   18.2.2     Sending Responses ...................................  146
+   18.3       Framing .............................................  147
+   18.4       Error Handling ......................................  147
+   19         Common Message Components ...........................  147
+   19.1       SIP and SIPS Uniform Resource Indicators ............  148
+   19.1.1     SIP and SIPS URI Components .........................  148
+   19.1.2     Character Escaping Requirements .....................  152
+   19.1.3     Example SIP and SIPS URIs ...........................  153
+   19.1.4     URI Comparison ......................................  153
+   19.1.5     Forming Requests from a URI .........................  156
+   19.1.6     Relating SIP URIs and tel URLs ......................  157
+   19.2       Option Tags .........................................  158
+   19.3       Tags ................................................  159
+   20         Header Fields .......................................  159
+   20.1       Accept ..............................................  161
+   20.2       Accept-Encoding .....................................  163
+   20.3       Accept-Language .....................................  164
+   20.4       Alert-Info ..........................................  164
+   20.5       Allow ...............................................  165
+   20.6       Authentication-Info .................................  165
+   20.7       Authorization .......................................  165
+   20.8       Call-ID .............................................  166
+   20.9       Call-Info ...........................................  166
+   20.10      Contact .............................................  167
+   20.11      Content-Disposition .................................  168
+   20.12      Content-Encoding ....................................  169
+   20.13      Content-Language ....................................  169
+   20.14      Content-Length ......................................  169
+   20.15      Content-Type ........................................  170
+   20.16      CSeq ................................................  170
+   20.17      Date ................................................  170
+   20.18      Error-Info ..........................................  171
+   20.19      Expires .............................................  171
+   20.20      From ................................................  172
+   20.21      In-Reply-To .........................................  172
+   20.22      Max-Forwards ........................................  173
+   20.23      Min-Expires .........................................  173
+   20.24      MIME-Version ........................................  173
+   20.25      Organization ........................................  174
+   20.26      Priority ............................................  174
+   20.27      Proxy-Authenticate ..................................  174
+   20.28      Proxy-Authorization .................................  175
+   20.29      Proxy-Require .......................................  175
+   20.30      Record-Route ........................................  175
+   20.31      Reply-To ............................................  176
+   20.32      Require .............................................  176
+   20.33      Retry-After .........................................  176
+   20.34      Route ...............................................  177
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 5]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   20.35      Server ..............................................  177
+   20.36      Subject .............................................  177
+   20.37      Supported ...........................................  178
+   20.38      Timestamp ...........................................  178
+   20.39      To ..................................................  178
+   20.40      Unsupported .........................................  179
+   20.41      User-Agent ..........................................  179
+   20.42      Via .................................................  179
+   20.43      Warning .............................................  180
+   20.44      WWW-Authenticate ....................................  182
+   21         Response Codes ......................................  182
+   21.1       Provisional 1xx .....................................  182
+   21.1.1     100 Trying ..........................................  183
+   21.1.2     180 Ringing .........................................  183
+   21.1.3     181 Call Is Being Forwarded .........................  183
+   21.1.4     182 Queued ..........................................  183
+   21.1.5     183 Session Progress ................................  183
+   21.2       Successful 2xx ......................................  183
+   21.2.1     200 OK ..............................................  183
+   21.3       Redirection 3xx .....................................  184
+   21.3.1     300 Multiple Choices ................................  184
+   21.3.2     301 Moved Permanently ...............................  184
+   21.3.3     302 Moved Temporarily ...............................  184
+   21.3.4     305 Use Proxy .......................................  185
+   21.3.5     380 Alternative Service .............................  185
+   21.4       Request Failure 4xx .................................  185
+   21.4.1     400 Bad Request .....................................  185
+   21.4.2     401 Unauthorized ....................................  185
+   21.4.3     402 Payment Required ................................  186
+   21.4.4     403 Forbidden .......................................  186
+   21.4.5     404 Not Found .......................................  186
+   21.4.6     405 Method Not Allowed ..............................  186
+   21.4.7     406 Not Acceptable ..................................  186
+   21.4.8     407 Proxy Authentication Required ...................  186
+   21.4.9     408 Request Timeout .................................  186
+   21.4.10    410 Gone ............................................  187
+   21.4.11    413 Request Entity Too Large ........................  187
+   21.4.12    414 Request-URI Too Long ............................  187
+   21.4.13    415 Unsupported Media Type ..........................  187
+   21.4.14    416 Unsupported URI Scheme ..........................  187
+   21.4.15    420 Bad Extension ...................................  187
+   21.4.16    421 Extension Required ..............................  188
+   21.4.17    423 Interval Too Brief ..............................  188
+   21.4.18    480 Temporarily Unavailable .........................  188
+   21.4.19    481 Call/Transaction Does Not Exist .................  188
+   21.4.20    482 Loop Detected ...................................  188
+   21.4.21    483 Too Many Hops ...................................  189
+   21.4.22    484 Address Incomplete ..............................  189
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 6]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   21.4.23    485 Ambiguous .......................................  189
+   21.4.24    486 Busy Here .......................................  189
+   21.4.25    487 Request Terminated ..............................  190
+   21.4.26    488 Not Acceptable Here .............................  190
+   21.4.27    491 Request Pending .................................  190
+   21.4.28    493 Undecipherable ..................................  190
+   21.5       Server Failure 5xx ..................................  190
+   21.5.1     500 Server Internal Error ...........................  190
+   21.5.2     501 Not Implemented .................................  191
+   21.5.3     502 Bad Gateway .....................................  191
+   21.5.4     503 Service Unavailable .............................  191
+   21.5.5     504 Server Time-out .................................  191
+   21.5.6     505 Version Not Supported ...........................  192
+   21.5.7     513 Message Too Large ...............................  192
+   21.6       Global Failures 6xx .................................  192
+   21.6.1     600 Busy Everywhere .................................  192
+   21.6.2     603 Decline .........................................  192
+   21.6.3     604 Does Not Exist Anywhere .........................  192
+   21.6.4     606 Not Acceptable ..................................  192
+   22         Usage of HTTP Authentication ........................  193
+   22.1       Framework ...........................................  193
+   22.2       User-to-User Authentication .........................  195
+   22.3       Proxy-to-User Authentication ........................  197
+   22.4       The Digest Authentication Scheme ....................  199
+   23         S/MIME ..............................................  201
+   23.1       S/MIME Certificates .................................  201
+   23.2       S/MIME Key Exchange .................................  202
+   23.3       Securing MIME bodies ................................  205
+   23.4       SIP Header Privacy and Integrity using S/MIME:
+              Tunneling SIP .......................................  207
+   23.4.1     Integrity and Confidentiality Properties of SIP
+              Headers .............................................  207
+   23.4.1.1   Integrity ...........................................  207
+   23.4.1.2   Confidentiality .....................................  208
+   23.4.2     Tunneling Integrity and Authentication ..............  209
+   23.4.3     Tunneling Encryption ................................  211
+   24         Examples ............................................  213
+   24.1       Registration ........................................  213
+   24.2       Session Setup .......................................  214
+   25         Augmented BNF for the SIP Protocol ..................  219
+   25.1       Basic Rules .........................................  219
+   26         Security Considerations: Threat Model and Security
+              Usage Recommendations ...............................  232
+   26.1       Attacks and Threat Models ...........................  233
+   26.1.1     Registration Hijacking ..............................  233
+   26.1.2     Impersonating a Server ..............................  234
+   26.1.3     Tampering with Message Bodies .......................  235
+   26.1.4     Tearing Down Sessions ...............................  235
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 7]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   26.1.5     Denial of Service and Amplification .................  236
+   26.2       Security Mechanisms .................................  237
+   26.2.1     Transport and Network Layer Security ................  238
+   26.2.2     SIPS URI Scheme .....................................  239
+   26.2.3     HTTP Authentication .................................  240
+   26.2.4     S/MIME ..............................................  240
+   26.3       Implementing Security Mechanisms ....................  241
+   26.3.1     Requirements for Implementers of SIP ................  241
+   26.3.2     Security Solutions ..................................  242
+   26.3.2.1   Registration ........................................  242
+   26.3.2.2   Interdomain Requests ................................  243
+   26.3.2.3   Peer-to-Peer Requests ...............................  245
+   26.3.2.4   DoS Protection ......................................  246
+   26.4       Limitations .........................................  247
+   26.4.1     HTTP Digest .........................................  247
+   26.4.2     S/MIME ..............................................  248
+   26.4.3     TLS .................................................  249
+   26.4.4     SIPS URIs ...........................................  249
+   26.5       Privacy .............................................  251
+   27         IANA Considerations .................................  252
+   27.1       Option Tags .........................................  252
+   27.2       Warn-Codes ..........................................  252
+   27.3       Header Field Names ..................................  253
+   27.4       Method and Response Codes ...........................  253
+   27.5       The "message/sip" MIME type.  .......................  254
+   27.6       New Content-Disposition Parameter Registrations .....  255
+   28         Changes From RFC 2543 ...............................  255
+   28.1       Major Functional Changes ............................  255
+   28.2       Minor Functional Changes ............................  260
+   29         Normative References ................................  261
+   30         Informative References ..............................  262
+   A          Table of Timer Values ...............................  265
+   Acknowledgments ................................................  266
+   Authors' Addresses .............................................  267
+   Full Copyright Statement .......................................  269
+
+1 Introduction
+
+   There are many applications of the Internet that require the creation
+   and management of a session, where a session is considered an
+   exchange of data between an association of participants.  The
+   implementation of these applications is complicated by the practices
+   of participants: users may move between endpoints, they may be
+   addressable by multiple names, and they may communicate in several
+   different media - sometimes simultaneously.  Numerous protocols have
+   been authored that carry various forms of real-time multimedia
+   session data such as voice, video, or text messages.  The Session
+   Initiation Protocol (SIP) works in concert with these protocols by
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 8]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   enabling Internet endpoints (called user agents) to discover one
+   another and to agree on a characterization of a session they would
+   like to share.  For locating prospective session participants, and
+   for other functions, SIP enables the creation of an infrastructure of
+   network hosts (called proxy servers) to which user agents can send
+   registrations, invitations to sessions, and other requests.  SIP is
+   an agile, general-purpose tool for creating, modifying, and
+   terminating sessions that works independently of underlying transport
+   protocols and without dependency on the type of session that is being
+   established.
+
+2 Overview of SIP Functionality
+
+   SIP is an application-layer control protocol that can establish,
+   modify, and terminate multimedia sessions (conferences) such as
+   Internet telephony calls.  SIP can also invite participants to
+   already existing sessions, such as multicast conferences.  Media can
+   be added to (and removed from) an existing session.  SIP
+   transparently supports name mapping and redirection services, which
+   supports personal mobility [27] - users can maintain a single
+   externally visible identifier regardless of their network location.
+
+   SIP supports five facets of establishing and terminating multimedia
+   communications:
+
+      User location: determination of the end system to be used for
+           communication;
+
+      User availability: determination of the willingness of the called
+           party to engage in communications;
+
+      User capabilities: determination of the media and media parameters
+           to be used;
+
+      Session setup: "ringing", establishment of session parameters at
+           both called and calling party;
+
+      Session management: including transfer and termination of
+           sessions, modifying session parameters, and invoking
+           services.
+
+   SIP is not a vertically integrated communications system.  SIP is
+   rather a component that can be used with other IETF protocols to
+   build a complete multimedia architecture.  Typically, these
+   architectures will include protocols such as the Real-time Transport
+   Protocol (RTP) (RFC 1889 [28]) for transporting real-time data and
+   providing QoS feedback, the Real-Time streaming protocol (RTSP) (RFC
+   2326 [29]) for controlling delivery of streaming media, the Media
+
+
+
+Rosenberg, et. al.          Standards Track                     [Page 9]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Gateway Control Protocol (MEGACO) (RFC 3015 [30]) for controlling
+   gateways to the Public Switched Telephone Network (PSTN), and the
+   Session Description Protocol (SDP) (RFC 2327 [1]) for describing
+   multimedia sessions.  Therefore, SIP should be used in conjunction
+   with other protocols in order to provide complete services to the
+   users.  However, the basic functionality and operation of SIP does
+   not depend on any of these protocols.
+
+   SIP does not provide services.  Rather, SIP provides primitives that
+   can be used to implement different services.  For example, SIP can
+   locate a user and deliver an opaque object to his current location.
+   If this primitive is used to deliver a session description written in
+   SDP, for instance, the endpoints can agree on the parameters of a
+   session.  If the same primitive is used to deliver a photo of the
+   caller as well as the session description, a "caller ID" service can
+   be easily implemented.  As this example shows, a single primitive is
+   typically used to provide several different services.
+
+   SIP does not offer conference control services such as floor control
+   or voting and does not prescribe how a conference is to be managed.
+   SIP can be used to initiate a session that uses some other conference
+   control protocol.  Since SIP messages and the sessions they establish
+   can pass through entirely different networks, SIP cannot, and does
+   not, provide any kind of network resource reservation capabilities.
+
+   The nature of the services provided make security particularly
+   important.  To that end, SIP provides a suite of security services,
+   which include denial-of-service prevention, authentication (both user
+   to user and proxy to user), integrity protection, and encryption and
+   privacy services.
+
+   SIP works with both IPv4 and IPv6.
+
+3 Terminology
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT
+   RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as
+   described in BCP 14, RFC 2119 [2] and indicate requirement levels for
+   compliant SIP implementations.
+
+4 Overview of Operation
+
+   This section introduces the basic operations of SIP using simple
+   examples.  This section is tutorial in nature and does not contain
+   any normative statements.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 10]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The first example shows the basic functions of SIP: location of an
+   end point, signal of a desire to communicate, negotiation of session
+   parameters to establish the session, and teardown of the session once
+   established.
+
+   Figure 1 shows a typical example of a SIP message exchange between
+   two users, Alice and Bob.  (Each message is labeled with the letter
+   "F" and a number for reference by the text.)  In this example, Alice
+   uses a SIP application on her PC (referred to as a softphone) to call
+   Bob on his SIP phone over the Internet.  Also shown are two SIP proxy
+   servers that act on behalf of Alice and Bob to facilitate the session
+   establishment.  This typical arrangement is often referred to as the
+   "SIP trapezoid" as shown by the geometric shape of the dotted lines
+   in Figure 1.
+
+   Alice "calls" Bob using his SIP identity, a type of Uniform Resource
+   Identifier (URI) called a SIP URI. SIP URIs are defined in Section
+   19.1.  It has a similar form to an email address, typically
+   containing a username and a host name.  In this case, it is
+   sip:bob@biloxi.com, where biloxi.com is the domain of Bob's SIP
+   service provider.  Alice has a SIP URI of sip:alice@atlanta.com.
+   Alice might have typed in Bob's URI or perhaps clicked on a hyperlink
+   or an entry in an address book.  SIP also provides a secure URI,
+   called a SIPS URI.  An example would be sips:bob@biloxi.com.  A call
+   made to a SIPS URI guarantees that secure, encrypted transport
+   (namely TLS) is used to carry all SIP messages from the caller to the
+   domain of the callee.  From there, the request is sent securely to
+   the callee, but with security mechanisms that depend on the policy of
+   the domain of the callee.
+
+   SIP is based on an HTTP-like request/response transaction model.
+   Each transaction consists of a request that invokes a particular
+   method, or function, on the server and at least one response.  In
+   this example, the transaction begins with Alice's softphone sending
+   an INVITE request addressed to Bob's SIP URI.  INVITE is an example
+   of a SIP method that specifies the action that the requestor (Alice)
+   wants the server (Bob) to take.  The INVITE request contains a number
+   of header fields.  Header fields are named attributes that provide
+   additional information about a message.  The ones present in an
+   INVITE include a unique identifier for the call, the destination
+   address, Alice's address, and information about the type of session
+   that Alice wishes to establish with Bob.  The INVITE (message F1 in
+   Figure 1) might look like this:
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 11]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                     atlanta.com  . . . biloxi.com
+                 .      proxy              proxy     .
+               .                                       .
+       Alice's  . . . . . . . . . . . . . . . . . . . .  Bob's
+      softphone                                        SIP Phone
+         |                |                |                |
+         |    INVITE F1   |                |                |
+         |--------------->|    INVITE F2   |                |
+         |  100 Trying F3 |--------------->|    INVITE F4   |
+         |<---------------|  100 Trying F5 |--------------->|
+         |                |<-------------- | 180 Ringing F6 |
+         |                | 180 Ringing F7 |<---------------|
+         | 180 Ringing F8 |<---------------|     200 OK F9  |
+         |<---------------|    200 OK F10  |<---------------|
+         |    200 OK F11  |<---------------|                |
+         |<---------------|                |                |
+         |                       ACK F12                    |
+         |------------------------------------------------->|
+         |                   Media Session                  |
+         |<================================================>|
+         |                       BYE F13                    |
+         |<-------------------------------------------------|
+         |                     200 OK F14                   |
+         |------------------------------------------------->|
+         |                                                  |
+
+         Figure 1: SIP session setup example with SIP trapezoid
+
+      INVITE sip:bob@biloxi.com SIP/2.0
+      Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bK776asdhds
+      Max-Forwards: 70
+      To: Bob <sip:bob@biloxi.com>
+      From: Alice <sip:alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710@pc33.atlanta.com
+      CSeq: 314159 INVITE
+      Contact: <sip:alice@pc33.atlanta.com>
+      Content-Type: application/sdp
+      Content-Length: 142
+
+      (Alice's SDP not shown)
+
+   The first line of the text-encoded message contains the method name
+   (INVITE).  The lines that follow are a list of header fields.  This
+   example contains a minimum required set.  The header fields are
+   briefly described below:
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 12]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Via contains the address (pc33.atlanta.com) at which Alice is
+   expecting to receive responses to this request.  It also contains a
+   branch parameter that identifies this transaction.
+
+   To contains a display name (Bob) and a SIP or SIPS URI
+   (sip:bob@biloxi.com) towards which the request was originally
+   directed.  Display names are described in RFC 2822 [3].
+
+   From also contains a display name (Alice) and a SIP or SIPS URI
+   (sip:alice@atlanta.com) that indicate the originator of the request.
+   This header field also has a tag parameter containing a random string
+   (1928301774) that was added to the URI by the softphone.  It is used
+   for identification purposes.
+
+   Call-ID contains a globally unique identifier for this call,
+   generated by the combination of a random string and the softphone's
+   host name or IP address.  The combination of the To tag, From tag,
+   and Call-ID completely defines a peer-to-peer SIP relationship
+   between Alice and Bob and is referred to as a dialog.
+
+   CSeq or Command Sequence contains an integer and a method name.  The
+   CSeq number is incremented for each new request within a dialog and
+   is a traditional sequence number.
+
+   Contact contains a SIP or SIPS URI that represents a direct route to
+   contact Alice, usually composed of a username at a fully qualified
+   domain name (FQDN).  While an FQDN is preferred, many end systems do
+   not have registered domain names, so IP addresses are permitted.
+   While the Via header field tells other elements where to send the
+   response, the Contact header field tells other elements where to send
+   future requests.
+
+   Max-Forwards serves to limit the number of hops a request can make on
+   the way to its destination.  It consists of an integer that is
+   decremented by one at each hop.
+
+   Content-Type contains a description of the message body (not shown).
+
+   Content-Length contains an octet (byte) count of the message body.
+
+   The complete set of SIP header fields is defined in Section 20.
+
+   The details of the session, such as the type of media, codec, or
+   sampling rate, are not described using SIP.  Rather, the body of a
+   SIP message contains a description of the session, encoded in some
+   other protocol format.  One such format is the Session Description
+   Protocol (SDP) (RFC 2327 [1]).  This SDP message (not shown in the
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 13]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   example) is carried by the SIP message in a way that is analogous to
+   a document attachment being carried by an email message, or a web
+   page being carried in an HTTP message.
+
+   Since the softphone does not know the location of Bob or the SIP
+   server in the biloxi.com domain, the softphone sends the INVITE to
+   the SIP server that serves Alice's domain, atlanta.com.  The address
+   of the atlanta.com SIP server could have been configured in Alice's
+   softphone, or it could have been discovered by DHCP, for example.
+
+   The atlanta.com SIP server is a type of SIP server known as a proxy
+   server.  A proxy server receives SIP requests and forwards them on
+   behalf of the requestor.  In this example, the proxy server receives
+   the INVITE request and sends a 100 (Trying) response back to Alice's
+   softphone.  The 100 (Trying) response indicates that the INVITE has
+   been received and that the proxy is working on her behalf to route
+   the INVITE to the destination.  Responses in SIP use a three-digit
+   code followed by a descriptive phrase.  This response contains the
+   same To, From, Call-ID, CSeq and branch parameter in the Via as the
+   INVITE, which allows Alice's softphone to correlate this response to
+   the sent INVITE.  The atlanta.com proxy server locates the proxy
+   server at biloxi.com, possibly by performing a particular type of DNS
+   (Domain Name Service) lookup to find the SIP server that serves the
+   biloxi.com domain.  This is described in [4].  As a result, it
+   obtains the IP address of the biloxi.com proxy server and forwards,
+   or proxies, the INVITE request there.  Before forwarding the request,
+   the atlanta.com proxy server adds an additional Via header field
+   value that contains its own address (the INVITE already contains
+   Alice's address in the first Via).  The biloxi.com proxy server
+   receives the INVITE and responds with a 100 (Trying) response back to
+   the atlanta.com proxy server to indicate that it has received the
+   INVITE and is processing the request.  The proxy server consults a
+   database, generically called a location service, that contains the
+   current IP address of Bob.  (We shall see in the next section how
+   this database can be populated.)  The biloxi.com proxy server adds
+   another Via header field value with its own address to the INVITE and
+   proxies it to Bob's SIP phone.
+
+   Bob's SIP phone receives the INVITE and alerts Bob to the incoming
+   call from Alice so that Bob can decide whether to answer the call,
+   that is, Bob's phone rings.  Bob's SIP phone indicates this in a 180
+   (Ringing) response, which is routed back through the two proxies in
+   the reverse direction.  Each proxy uses the Via header field to
+   determine where to send the response and removes its own address from
+   the top.  As a result, although DNS and location service lookups were
+   required to route the initial INVITE, the 180 (Ringing) response can
+   be returned to the caller without lookups or without state being
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 14]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   maintained in the proxies.  This also has the desirable property that
+   each proxy that sees the INVITE will also see all responses to the
+   INVITE.
+
+   When Alice's softphone receives the 180 (Ringing) response, it passes
+   this information to Alice, perhaps using an audio ringback tone or by
+   displaying a message on Alice's screen.
+
+   In this example, Bob decides to answer the call.  When he picks up
+   the handset, his SIP phone sends a 200 (OK) response to indicate that
+   the call has been answered.  The 200 (OK) contains a message body
+   with the SDP media description of the type of session that Bob is
+   willing to establish with Alice.  As a result, there is a two-phase
+   exchange of SDP messages: Alice sent one to Bob, and Bob sent one
+   back to Alice.  This two-phase exchange provides basic negotiation
+   capabilities and is based on a simple offer/answer model of SDP
+   exchange.  If Bob did not wish to answer the call or was busy on
+   another call, an error response would have been sent instead of the
+   200 (OK), which would have resulted in no media session being
+   established.  The complete list of SIP response codes is in Section
+   21.  The 200 (OK) (message F9 in Figure 1) might look like this as
+   Bob sends it out:
+
+      SIP/2.0 200 OK
+      Via: SIP/2.0/UDP server10.biloxi.com
+         ;branch=z9hG4bKnashds8;received=192.0.2.3
+      Via: SIP/2.0/UDP bigbox3.site3.atlanta.com
+         ;branch=z9hG4bK77ef4c2312983.1;received=192.0.2.2
+      Via: SIP/2.0/UDP pc33.atlanta.com
+         ;branch=z9hG4bK776asdhds ;received=192.0.2.1
+      To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+      From: Alice <sip:alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710@pc33.atlanta.com
+      CSeq: 314159 INVITE
+      Contact: <sip:bob@192.0.2.4>
+      Content-Type: application/sdp
+      Content-Length: 131
+
+      (Bob's SDP not shown)
+
+   The first line of the response contains the response code (200) and
+   the reason phrase (OK).  The remaining lines contain header fields.
+   The Via, To, From, Call-ID, and CSeq header fields are copied from
+   the INVITE request.  (There are three Via header field values - one
+   added by Alice's SIP phone, one added by the atlanta.com proxy, and
+   one added by the biloxi.com proxy.)  Bob's SIP phone has added a tag
+   parameter to the To header field.  This tag will be incorporated by
+   both endpoints into the dialog and will be included in all future
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 15]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   requests and responses in this call.  The Contact header field
+   contains a URI at which Bob can be directly reached at his SIP phone.
+   The Content-Type and Content-Length refer to the message body (not
+   shown) that contains Bob's SDP media information.
+
+   In addition to DNS and location service lookups shown in this
+   example, proxy servers can make flexible "routing decisions" to
+   decide where to send a request.  For example, if Bob's SIP phone
+   returned a 486 (Busy Here) response, the biloxi.com proxy server
+   could proxy the INVITE to Bob's voicemail server.  A proxy server can
+   also send an INVITE to a number of locations at the same time.  This
+   type of parallel search is known as forking.
+
+   In this case, the 200 (OK) is routed back through the two proxies and
+   is received by Alice's softphone, which then stops the ringback tone
+   and indicates that the call has been answered.  Finally, Alice's
+   softphone sends an acknowledgement message, ACK, to Bob's SIP phone
+   to confirm the reception of the final response (200 (OK)).  In this
+   example, the ACK is sent directly from Alice's softphone to Bob's SIP
+   phone, bypassing the two proxies.  This occurs because the endpoints
+   have learned each other's address from the Contact header fields
+   through the INVITE/200 (OK) exchange, which was not known when the
+   initial INVITE was sent.  The lookups performed by the two proxies
+   are no longer needed, so the proxies drop out of the call flow.  This
+   completes the INVITE/200/ACK three-way handshake used to establish
+   SIP sessions.  Full details on session setup are in Section 13.
+
+   Alice and Bob's media session has now begun, and they send media
+   packets using the format to which they agreed in the exchange of SDP.
+   In general, the end-to-end media packets take a different path from
+   the SIP signaling messages.
+
+   During the session, either Alice or Bob may decide to change the
+   characteristics of the media session.  This is accomplished by
+   sending a re-INVITE containing a new media description.  This re-
+   INVITE references the existing dialog so that the other party knows
+   that it is to modify an existing session instead of establishing a
+   new session.  The other party sends a 200 (OK) to accept the change.
+   The requestor responds to the 200 (OK) with an ACK.  If the other
+   party does not accept the change, he sends an error response such as
+   488 (Not Acceptable Here), which also receives an ACK.  However, the
+   failure of the re-INVITE does not cause the existing call to fail -
+   the session continues using the previously negotiated
+   characteristics.  Full details on session modification are in Section
+   14.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 16]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   At the end of the call, Bob disconnects (hangs up) first and
+   generates a BYE message.  This BYE is routed directly to Alice's
+   softphone, again bypassing the proxies.  Alice confirms receipt of
+   the BYE with a 200 (OK) response, which terminates the session and
+   the BYE transaction.  No ACK is sent - an ACK is only sent in
+   response to a response to an INVITE request.  The reasons for this
+   special handling for INVITE will be discussed later, but relate to
+   the reliability mechanisms in SIP, the length of time it can take for
+   a ringing phone to be answered, and forking.  For this reason,
+   request handling in SIP is often classified as either INVITE or non-
+   INVITE, referring to all other methods besides INVITE.  Full details
+   on session termination are in Section 15.
+
+   Section 24.2 describes the messages shown in Figure 1 in full.
+
+   In some cases, it may be useful for proxies in the SIP signaling path
+   to see all the messaging between the endpoints for the duration of
+   the session.  For example, if the biloxi.com proxy server wished to
+   remain in the SIP messaging path beyond the initial INVITE, it would
+   add to the INVITE a required routing header field known as Record-
+   Route that contained a URI resolving to the hostname or IP address of
+   the proxy.  This information would be received by both Bob's SIP
+   phone and (due to the Record-Route header field being passed back in
+   the 200 (OK)) Alice's softphone and stored for the duration of the
+   dialog.  The biloxi.com proxy server would then receive and proxy the
+   ACK, BYE, and 200 (OK) to the BYE.  Each proxy can independently
+   decide to receive subsequent messages, and those messages will pass
+   through all proxies that elect to receive it.  This capability is
+   frequently used for proxies that are providing mid-call features.
+
+   Registration is another common operation in SIP.  Registration is one
+   way that the biloxi.com server can learn the current location of Bob.
+   Upon initialization, and at periodic intervals, Bob's SIP phone sends
+   REGISTER messages to a server in the biloxi.com domain known as a SIP
+   registrar.  The REGISTER messages associate Bob's SIP or SIPS URI
+   (sip:bob@biloxi.com) with the machine into which he is currently
+   logged (conveyed as a SIP or SIPS URI in the Contact header field).
+   The registrar writes this association, also called a binding, to a
+   database, called the location service, where it can be used by the
+   proxy in the biloxi.com domain.  Often, a registrar server for a
+   domain is co-located with the proxy for that domain.  It is an
+   important concept that the distinction between types of SIP servers
+   is logical, not physical.
+
+   Bob is not limited to registering from a single device.  For example,
+   both his SIP phone at home and the one in the office could send
+   registrations.  This information is stored together in the location
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 17]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   service and allows a proxy to perform various types of searches to
+   locate Bob.  Similarly, more than one user can be registered on a
+   single device at the same time.
+
+   The location service is just an abstract concept.  It generally
+   contains information that allows a proxy to input a URI and receive a
+   set of zero or more URIs that tell the proxy where to send the
+   request.  Registrations are one way to create this information, but
+   not the only way.  Arbitrary mapping functions can be configured at
+   the discretion of the administrator.
+
+   Finally, it is important to note that in SIP, registration is used
+   for routing incoming SIP requests and has no role in authorizing
+   outgoing requests.  Authorization and authentication are handled in
+   SIP either on a request-by-request basis with a challenge/response
+   mechanism, or by using a lower layer scheme as discussed in Section
+   26.
+
+   The complete set of SIP message details for this registration example
+   is in Section 24.1.
+
+   Additional operations in SIP, such as querying for the capabilities
+   of a SIP server or client using OPTIONS, or canceling a pending
+   request using CANCEL, will be introduced in later sections.
+
+5 Structure of the Protocol
+
+   SIP is structured as a layered protocol, which means that its
+   behavior is described in terms of a set of fairly independent
+   processing stages with only a loose coupling between each stage.  The
+   protocol behavior is described as layers for the purpose of
+   presentation, allowing the description of functions common across
+   elements in a single section.  It does not dictate an implementation
+   in any way.  When we say that an element "contains" a layer, we mean
+   it is compliant to the set of rules defined by that layer.
+
+   Not every element specified by the protocol contains every layer.
+   Furthermore, the elements specified by SIP are logical elements, not
+   physical ones.  A physical realization can choose to act as different
+   logical elements, perhaps even on a transaction-by-transaction basis.
+
+   The lowest layer of SIP is its syntax and encoding.  Its encoding is
+   specified using an augmented Backus-Naur Form grammar (BNF).  The
+   complete BNF is specified in Section 25; an overview of a SIP
+   message's structure can be found in Section 7.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 18]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The second layer is the transport layer.  It defines how a client
+   sends requests and receives responses and how a server receives
+   requests and sends responses over the network.  All SIP elements
+   contain a transport layer.  The transport layer is described in
+   Section 18.
+
+   The third layer is the transaction layer.  Transactions are a
+   fundamental component of SIP.  A transaction is a request sent by a
+   client transaction (using the transport layer) to a server
+   transaction, along with all responses to that request sent from the
+   server transaction back to the client.  The transaction layer handles
+   application-layer retransmissions, matching of responses to requests,
+   and application-layer timeouts.  Any task that a user agent client
+   (UAC) accomplishes takes place using a series of transactions.
+   Discussion of transactions can be found in Section 17.  User agents
+   contain a transaction layer, as do stateful proxies.  Stateless
+   proxies do not contain a transaction layer.  The transaction layer
+   has a client component (referred to as a client transaction) and a
+   server component (referred to as a server transaction), each of which
+   are represented by a finite state machine that is constructed to
+   process a particular request.
+
+   The layer above the transaction layer is called the transaction user
+   (TU).  Each of the SIP entities, except the stateless proxy, is a
+   transaction user.  When a TU wishes to send a request, it creates a
+   client transaction instance and passes it the request along with the
+   destination IP address, port, and transport to which to send the
+   request.  A TU that creates a client transaction can also cancel it.
+   When a client cancels a transaction, it requests that the server stop
+   further processing, revert to the state that existed before the
+   transaction was initiated, and generate a specific error response to
+   that transaction.  This is done with a CANCEL request, which
+   constitutes its own transaction, but references the transaction to be
+   cancelled (Section 9).
+
+   The SIP elements, that is, user agent clients and servers, stateless
+   and stateful proxies and registrars, contain a core that
+   distinguishes them from each other.  Cores, except for the stateless
+   proxy, are transaction users.  While the behavior of the UAC and UAS
+   cores depends on the method, there are some common rules for all
+   methods (Section 8).  For a UAC, these rules govern the construction
+   of a request; for a UAS, they govern the processing of a request and
+   generating a response.  Since registrations play an important role in
+   SIP, a UAS that handles a REGISTER is given the special name
+   registrar.  Section 10 describes UAC and UAS core behavior for the
+   REGISTER method.  Section 11 describes UAC and UAS core behavior for
+   the OPTIONS method, used for determining the capabilities of a UA.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 19]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Certain other requests are sent within a dialog.  A dialog is a
+   peer-to-peer SIP relationship between two user agents that persists
+   for some time.  The dialog facilitates sequencing of messages and
+   proper routing of requests between the user agents.  The INVITE
+   method is the only way defined in this specification to establish a
+   dialog.  When a UAC sends a request that is within the context of a
+   dialog, it follows the common UAC rules as discussed in Section 8 but
+   also the rules for mid-dialog requests.  Section 12 discusses dialogs
+   and presents the procedures for their construction and maintenance,
+   in addition to construction of requests within a dialog.
+
+   The most important method in SIP is the INVITE method, which is used
+   to establish a session between participants.  A session is a
+   collection of participants, and streams of media between them, for
+   the purposes of communication.  Section 13 discusses how sessions are
+   initiated, resulting in one or more SIP dialogs.  Section 14
+   discusses how characteristics of that session are modified through
+   the use of an INVITE request within a dialog.  Finally, section 15
+   discusses how a session is terminated.
+
+   The procedures of Sections 8, 10, 11, 12, 13, 14, and 15 deal
+   entirely with the UA core (Section 9 describes cancellation, which
+   applies to both UA core and proxy core).  Section 16 discusses the
+   proxy element, which facilitates routing of messages between user
+   agents.
+
+6 Definitions
+
+   The following terms have special significance for SIP.
+
+      Address-of-Record: An address-of-record (AOR) is a SIP or SIPS URI
+         that points to a domain with a location service that can map
+         the URI to another URI where the user might be available.
+         Typically, the location service is populated through
+         registrations.  An AOR is frequently thought of as the "public
+         address" of the user.
+
+      Back-to-Back User Agent: A back-to-back user agent (B2BUA) is a
+         logical entity that receives a request and processes it as a
+         user agent server (UAS).  In order to determine how the request
+         should be answered, it acts as a user agent client (UAC) and
+         generates requests.  Unlike a proxy server, it maintains dialog
+         state and must participate in all requests sent on the dialogs
+         it has established.  Since it is a concatenation of a UAC and
+         UAS, no explicit definitions are needed for its behavior.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 20]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Call: A call is an informal term that refers to some communication
+         between peers, generally set up for the purposes of a
+         multimedia conversation.
+
+      Call Leg: Another name for a dialog [31]; no longer used in this
+         specification.
+
+      Call Stateful: A proxy is call stateful if it retains state for a
+         dialog from the initiating INVITE to the terminating BYE
+         request.  A call stateful proxy is always transaction stateful,
+         but the converse is not necessarily true.
+
+      Client: A client is any network element that sends SIP requests
+         and receives SIP responses.  Clients may or may not interact
+         directly with a human user.  User agent clients and proxies are
+         clients.
+
+      Conference: A multimedia session (see below) that contains
+         multiple participants.
+
+      Core: Core designates the functions specific to a particular type
+         of SIP entity, i.e., specific to either a stateful or stateless
+         proxy, a user agent or registrar.  All cores, except those for
+         the stateless proxy, are transaction users.
+
+      Dialog: A dialog is a peer-to-peer SIP relationship between two
+         UAs that persists for some time.  A dialog is established by
+         SIP messages, such as a 2xx response to an INVITE request.  A
+         dialog is identified by a call identifier, local tag, and a
+         remote tag.  A dialog was formerly known as a call leg in RFC
+         2543.
+
+      Downstream: A direction of message forwarding within a transaction
+         that refers to the direction that requests flow from the user
+         agent client to user agent server.
+
+      Final Response: A response that terminates a SIP transaction, as
+         opposed to a provisional response that does not.  All 2xx, 3xx,
+         4xx, 5xx and 6xx responses are final.
+
+      Header: A header is a component of a SIP message that conveys
+         information about the message.  It is structured as a sequence
+         of header fields.
+
+      Header Field: A header field is a component of the SIP message
+         header.  A header field can appear as one or more header field
+         rows. Header field rows consist of a header field name and zero
+         or more header field values. Multiple header field values on a
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 21]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         given header field row are separated by commas. Some header
+         fields can only have a single header field value, and as a
+         result, always appear as a single header field row.
+
+      Header Field Value: A header field value is a single value; a
+         header field consists of zero or more header field values.
+
+      Home Domain: The domain providing service to a SIP user.
+         Typically, this is the domain present in the URI in the
+         address-of-record of a registration.
+
+      Informational Response: Same as a provisional response.
+
+      Initiator, Calling Party, Caller: The party initiating a session
+         (and dialog) with an INVITE request.  A caller retains this
+         role from the time it sends the initial INVITE that established
+         a dialog until the termination of that dialog.
+
+      Invitation: An INVITE request.
+
+      Invitee, Invited User, Called Party, Callee: The party that
+         receives an INVITE request for the purpose of establishing a
+         new session.  A callee retains this role from the time it
+         receives the INVITE until the termination of the dialog
+         established by that INVITE.
+
+      Location Service: A location service is used by a SIP redirect or
+         proxy server to obtain information about a callee's possible
+         location(s).  It contains a list of bindings of address-of-
+         record keys to zero or more contact addresses.  The bindings
+         can be created and removed in many ways; this specification
+         defines a REGISTER method that updates the bindings.
+
+      Loop: A request that arrives at a proxy, is forwarded, and later
+         arrives back at the same proxy.  When it arrives the second
+         time, its Request-URI is identical to the first time, and other
+         header fields that affect proxy operation are unchanged, so
+         that the proxy would make the same processing decision on the
+         request it made the first time.  Looped requests are errors,
+         and the procedures for detecting them and handling them are
+         described by the protocol.
+
+      Loose Routing: A proxy is said to be loose routing if it follows
+         the procedures defined in this specification for processing of
+         the Route header field.  These procedures separate the
+         destination of the request (present in the Request-URI) from
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 22]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         the set of proxies that need to be visited along the way
+         (present in the Route header field).  A proxy compliant to
+         these mechanisms is also known as a loose router.
+
+      Message: Data sent between SIP elements as part of the protocol.
+         SIP messages are either requests or responses.
+
+      Method: The method is the primary function that a request is meant
+         to invoke on a server.  The method is carried in the request
+         message itself.  Example methods are INVITE and BYE.
+
+      Outbound Proxy: A proxy that receives requests from a client, even
+         though it may not be the server resolved by the Request-URI.
+         Typically, a UA is manually configured with an outbound proxy,
+         or can learn about one through auto-configuration protocols.
+
+      Parallel Search: In a parallel search, a proxy issues several
+         requests to possible user locations upon receiving an incoming
+         request.  Rather than issuing one request and then waiting for
+         the final response before issuing the next request as in a
+         sequential search, a parallel search issues requests without
+         waiting for the result of previous requests.
+
+      Provisional Response: A response used by the server to indicate
+         progress, but that does not terminate a SIP transaction.  1xx
+         responses are provisional, other responses are considered
+         final.
+
+      Proxy, Proxy Server: An intermediary entity that acts as both a
+         server and a client for the purpose of making requests on
+         behalf of other clients.  A proxy server primarily plays the
+         role of routing, which means its job is to ensure that a
+         request is sent to another entity "closer" to the targeted
+         user.  Proxies are also useful for enforcing policy (for
+         example, making sure a user is allowed to make a call).  A
+         proxy interprets, and, if necessary, rewrites specific parts of
+         a request message before forwarding it.
+
+      Recursion: A client recurses on a 3xx response when it generates a
+         new request to one or more of the URIs in the Contact header
+         field in the response.
+
+      Redirect Server: A redirect server is a user agent server that
+         generates 3xx responses to requests it receives, directing the
+         client to contact an alternate set of URIs.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 23]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Registrar: A registrar is a server that accepts REGISTER requests
+         and places the information it receives in those requests into
+         the location service for the domain it handles.
+
+      Regular Transaction: A regular transaction is any transaction with
+         a method other than INVITE, ACK, or CANCEL.
+
+      Request: A SIP message sent from a client to a server, for the
+         purpose of invoking a particular operation.
+
+      Response: A SIP message sent from a server to a client, for
+         indicating the status of a request sent from the client to the
+         server.
+
+      Ringback: Ringback is the signaling tone produced by the calling
+         party's application indicating that a called party is being
+         alerted (ringing).
+
+      Route Set: A route set is a collection of ordered SIP or SIPS URI
+         which represent a list of proxies that must be traversed when
+         sending a particular request.  A route set can be learned,
+         through headers like Record-Route, or it can be configured.
+
+      Server: A server is a network element that receives requests in
+         order to service them and sends back responses to those
+         requests.  Examples of servers are proxies, user agent servers,
+         redirect servers, and registrars.
+
+      Sequential Search: In a sequential search, a proxy server attempts
+         each contact address in sequence, proceeding to the next one
+         only after the previous has generated a final response.  A 2xx
+         or 6xx class final response always terminates a sequential
+         search.
+
+      Session: From the SDP specification: "A multimedia session is a
+         set of multimedia senders and receivers and the data streams
+         flowing from senders to receivers.  A multimedia conference is
+         an example of a multimedia session." (RFC 2327 [1]) (A session
+         as defined for SDP can comprise one or more RTP sessions.)  As
+         defined, a callee can be invited several times, by different
+         calls, to the same session.  If SDP is used, a session is
+         defined by the concatenation of the SDP user name, session id,
+         network type, address type, and address elements in the origin
+         field.
+
+      SIP Transaction: A SIP transaction occurs between a client and a
+         server and comprises all messages from the first request sent
+         from the client to the server up to a final (non-1xx) response
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 24]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         sent from the server to the client.  If the request is INVITE
+         and the final response is a non-2xx, the transaction also
+         includes an ACK to the response.  The ACK for a 2xx response to
+         an INVITE request is a separate transaction.
+
+      Spiral: A spiral is a SIP request that is routed to a proxy,
+         forwarded onwards, and arrives once again at that proxy, but
+         this time differs in a way that will result in a different
+         processing decision than the original request.  Typically, this
+         means that the request's Request-URI differs from its previous
+         arrival.  A spiral is not an error condition, unlike a loop.  A
+         typical cause for this is call forwarding.  A user calls
+         joe@example.com.  The example.com proxy forwards it to Joe's
+         PC, which in turn, forwards it to bob@example.com.  This
+         request is proxied back to the example.com proxy.  However,
+         this is not a loop.  Since the request is targeted at a
+         different user, it is considered a spiral, and is a valid
+         condition.
+
+      Stateful Proxy: A logical entity that maintains the client and
+         server transaction state machines defined by this specification
+         during the processing of a request, also known as a transaction
+         stateful proxy.  The behavior of a stateful proxy is further
+         defined in Section 16.  A (transaction) stateful proxy is not
+         the same as a call stateful proxy.
+
+      Stateless Proxy: A logical entity that does not maintain the
+         client or server transaction state machines defined in this
+         specification when it processes requests.  A stateless proxy
+         forwards every request it receives downstream and every
+         response it receives upstream.
+
+      Strict Routing: A proxy is said to be strict routing if it follows
+         the Route processing rules of RFC 2543 and many prior work in
+         progress versions of this RFC.  That rule caused proxies to
+         destroy the contents of the Request-URI when a Route header
+         field was present.  Strict routing behavior is not used in this
+         specification, in favor of a loose routing behavior.  Proxies
+         that perform strict routing are also known as strict routers.
+
+      Target Refresh Request: A target refresh request sent within a
+         dialog is defined as a request that can modify the remote
+         target of the dialog.
+
+      Transaction User (TU): The layer of protocol processing that
+         resides above the transaction layer.  Transaction users include
+         the UAC core, UAS core, and proxy core.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 25]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Upstream: A direction of message forwarding within a transaction
+         that refers to the direction that responses flow from the user
+         agent server back to the user agent client.
+
+      URL-encoded: A character string encoded according to RFC 2396,
+         Section 2.4 [5].
+
+      User Agent Client (UAC): A user agent client is a logical entity
+         that creates a new request, and then uses the client
+         transaction state machinery to send it.  The role of UAC lasts
+         only for the duration of that transaction.  In other words, if
+         a piece of software initiates a request, it acts as a UAC for
+         the duration of that transaction.  If it receives a request
+         later, it assumes the role of a user agent server for the
+         processing of that transaction.
+
+      UAC Core: The set of processing functions required of a UAC that
+         reside above the transaction and transport layers.
+
+      User Agent Server (UAS): A user agent server is a logical entity
+         that generates a response to a SIP request.  The response
+         accepts, rejects, or redirects the request.  This role lasts
+         only for the duration of that transaction.  In other words, if
+         a piece of software responds to a request, it acts as a UAS for
+         the duration of that transaction.  If it generates a request
+         later, it assumes the role of a user agent client for the
+         processing of that transaction.
+
+      UAS Core: The set of processing functions required at a UAS that
+         resides above the transaction and transport layers.
+
+      User Agent (UA): A logical entity that can act as both a user
+         agent client and user agent server.
+
+   The role of UAC and UAS, as well as proxy and redirect servers, are
+   defined on a transaction-by-transaction basis.  For example, the user
+   agent initiating a call acts as a UAC when sending the initial INVITE
+   request and as a UAS when receiving a BYE request from the callee.
+   Similarly, the same software can act as a proxy server for one
+   request and as a redirect server for the next request.
+
+   Proxy, location, and registrar servers defined above are logical
+   entities; implementations MAY combine them into a single application.
+
+7 SIP Messages
+
+   SIP is a text-based protocol and uses the UTF-8 charset (RFC 2279
+   [7]).
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 26]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   A SIP message is either a request from a client to a server, or a
+   response from a server to a client.
+
+   Both Request (section 7.1) and Response (section 7.2) messages use
+   the basic format of RFC 2822 [3], even though the syntax differs in
+   character set and syntax specifics.  (SIP allows header fields that
+   would not be valid RFC 2822 header fields, for example.)  Both types
+   of messages consist of a start-line, one or more header fields, an
+   empty line indicating the end of the header fields, and an optional
+   message-body.
+
+         generic-message  =  start-line
+                             *message-header
+                             CRLF
+                             [ message-body ]
+         start-line       =  Request-Line / Status-Line
+
+   The start-line, each message-header line, and the empty line MUST be
+   terminated by a carriage-return line-feed sequence (CRLF).  Note that
+   the empty line MUST be present even if the message-body is not.
+
+   Except for the above difference in character sets, much of SIP's
+   message and header field syntax is identical to HTTP/1.1.  Rather
+   than repeating the syntax and semantics here, we use [HX.Y] to refer
+   to Section X.Y of the current HTTP/1.1 specification (RFC 2616 [8]).
+
+   However, SIP is not an extension of HTTP.
+
+7.1 Requests
+
+   SIP requests are distinguished by having a Request-Line for a start-
+   line.  A Request-Line contains a method name, a Request-URI, and the
+   protocol version separated by a single space (SP) character.
+
+   The Request-Line ends with CRLF.  No CR or LF are allowed except in
+   the end-of-line CRLF sequence.  No linear whitespace (LWS) is allowed
+   in any of the elements.
+
+         Request-Line  =  Method SP Request-URI SP SIP-Version CRLF
+
+      Method: This specification defines six methods: REGISTER for
+           registering contact information, INVITE, ACK, and CANCEL for
+           setting up sessions, BYE for terminating sessions, and
+           OPTIONS for querying servers about their capabilities.  SIP
+           extensions, documented in standards track RFCs, may define
+           additional methods.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 27]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Request-URI: The Request-URI is a SIP or SIPS URI as described in
+           Section 19.1 or a general URI (RFC 2396 [5]).  It indicates
+           the user or service to which this request is being addressed.
+           The Request-URI MUST NOT contain unescaped spaces or control
+           characters and MUST NOT be enclosed in "<>".
+
+           SIP elements MAY support Request-URIs with schemes other than
+           "sip" and "sips", for example the "tel" URI scheme of RFC
+           2806 [9].  SIP elements MAY translate non-SIP URIs using any
+           mechanism at their disposal, resulting in SIP URI, SIPS URI,
+           or some other scheme.
+
+      SIP-Version: Both request and response messages include the
+           version of SIP in use, and follow [H3.1] (with HTTP replaced
+           by SIP, and HTTP/1.1 replaced by SIP/2.0) regarding version
+           ordering, compliance requirements, and upgrading of version
+           numbers.  To be compliant with this specification,
+           applications sending SIP messages MUST include a SIP-Version
+           of "SIP/2.0".  The SIP-Version string is case-insensitive,
+           but implementations MUST send upper-case.
+
+           Unlike HTTP/1.1, SIP treats the version number as a literal
+           string.  In practice, this should make no difference.
+
+7.2 Responses
+
+   SIP responses are distinguished from requests by having a Status-Line
+   as their start-line.  A Status-Line consists of the protocol version
+   followed by a numeric Status-Code and its associated textual phrase,
+   with each element separated by a single SP character.
+
+   No CR or LF is allowed except in the final CRLF sequence.
+
+      Status-Line  =  SIP-Version SP Status-Code SP Reason-Phrase CRLF
+
+   The Status-Code is a 3-digit integer result code that indicates the
+   outcome of an attempt to understand and satisfy a request.  The
+   Reason-Phrase is intended to give a short textual description of the
+   Status-Code.  The Status-Code is intended for use by automata,
+   whereas the Reason-Phrase is intended for the human user.  A client
+   is not required to examine or display the Reason-Phrase.
+
+   While this specification suggests specific wording for the reason
+   phrase, implementations MAY choose other text, for example, in the
+   language indicated in the Accept-Language header field of the
+   request.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 28]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The first digit of the Status-Code defines the class of response.
+   The last two digits do not have any categorization role.  For this
+   reason, any response with a status code between 100 and 199 is
+   referred to as a "1xx response", any response with a status code
+   between 200 and 299 as a "2xx response", and so on.  SIP/2.0 allows
+   six values for the first digit:
+
+      1xx: Provisional -- request received, continuing to process the
+           request;
+
+      2xx: Success -- the action was successfully received, understood,
+           and accepted;
+
+      3xx: Redirection -- further action needs to be taken in order to
+           complete the request;
+
+      4xx: Client Error -- the request contains bad syntax or cannot be
+           fulfilled at this server;
+
+      5xx: Server Error -- the server failed to fulfill an apparently
+           valid request;
+
+      6xx: Global Failure -- the request cannot be fulfilled at any
+           server.
+
+   Section 21 defines these classes and describes the individual codes.
+
+7.3 Header Fields
+
+   SIP header fields are similar to HTTP header fields in both syntax
+   and semantics.  In particular, SIP header fields follow the [H4.2]
+   definitions of syntax for the message-header and the rules for
+   extending header fields over multiple lines.  However, the latter is
+   specified in HTTP with implicit whitespace and folding.  This
+   specification conforms to RFC 2234 [10] and uses only explicit
+   whitespace and folding as an integral part of the grammar.
+
+   [H4.2] also specifies that multiple header fields of the same field
+   name whose value is a comma-separated list can be combined into one
+   header field.  That applies to SIP as well, but the specific rule is
+   different because of the different grammars.  Specifically, any SIP
+   header whose grammar is of the form
+
+      header  =  "header-name" HCOLON header-value *(COMMA header-value)
+
+   allows for combining header fields of the same name into a comma-
+   separated list.  The Contact header field allows a comma-separated
+   list unless the header field value is "*".
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 29]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+7.3.1 Header Field Format
+
+   Header fields follow the same generic header format as that given in
+   Section 2.2 of RFC 2822 [3].  Each header field consists of a field
+   name followed by a colon (":") and the field value.
+
+      field-name: field-value
+
+   The formal grammar for a message-header specified in Section 25
+   allows for an arbitrary amount of whitespace on either side of the
+   colon; however, implementations should avoid spaces between the field
+   name and the colon and use a single space (SP) between the colon and
+   the field-value.
+
+      Subject:            lunch
+      Subject      :      lunch
+      Subject            :lunch
+      Subject: lunch
+
+   Thus, the above are all valid and equivalent, but the last is the
+   preferred form.
+
+   Header fields can be extended over multiple lines by preceding each
+   extra line with at least one SP or horizontal tab (HT).  The line
+   break and the whitespace at the beginning of the next line are
+   treated as a single SP character.  Thus, the following are
+   equivalent:
+
+      Subject: I know you're there, pick up the phone and talk to me!
+      Subject: I know you're there,
+               pick up the phone
+               and talk to me!
+
+   The relative order of header fields with different field names is not
+   significant.  However, it is RECOMMENDED that header fields which are
+   needed for proxy processing (Via, Route, Record-Route, Proxy-Require,
+   Max-Forwards, and Proxy-Authorization, for example) appear towards
+   the top of the message to facilitate rapid parsing.  The relative
+   order of header field rows with the same field name is important.
+   Multiple header field rows with the same field-name MAY be present in
+   a message if and only if the entire field-value for that header field
+   is defined as a comma-separated list (that is, if follows the grammar
+   defined in Section 7.3).  It MUST be possible to combine the multiple
+   header field rows into one "field-name: field-value" pair, without
+   changing the semantics of the message, by appending each subsequent
+   field-value to the first, each separated by a comma.  The exceptions
+   to this rule are the WWW-Authenticate, Authorization, Proxy-
+   Authenticate, and Proxy-Authorization header fields.  Multiple header
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 30]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   field rows with these names MAY be present in a message, but since
+   their grammar does not follow the general form listed in Section 7.3,
+   they MUST NOT be combined into a single header field row.
+
+   Implementations MUST be able to process multiple header field rows
+   with the same name in any combination of the single-value-per-line or
+   comma-separated value forms.
+
+   The following groups of header field rows are valid and equivalent:
+
+      Route: <sip:alice@atlanta.com>
+      Subject: Lunch
+      Route: <sip:bob@biloxi.com>
+      Route: <sip:carol@chicago.com>
+
+      Route: <sip:alice@atlanta.com>, <sip:bob@biloxi.com>
+      Route: <sip:carol@chicago.com>
+      Subject: Lunch
+
+      Subject: Lunch
+      Route: <sip:alice@atlanta.com>, <sip:bob@biloxi.com>,
+             <sip:carol@chicago.com>
+
+   Each of the following blocks is valid but not equivalent to the
+   others:
+
+      Route: <sip:alice@atlanta.com>
+      Route: <sip:bob@biloxi.com>
+      Route: <sip:carol@chicago.com>
+
+      Route: <sip:bob@biloxi.com>
+      Route: <sip:alice@atlanta.com>
+      Route: <sip:carol@chicago.com>
+
+      Route: <sip:alice@atlanta.com>,<sip:carol@chicago.com>,
+             <sip:bob@biloxi.com>
+
+   The format of a header field-value is defined per header-name.  It
+   will always be either an opaque sequence of TEXT-UTF8 octets, or a
+   combination of whitespace, tokens, separators, and quoted strings.
+   Many existing header fields will adhere to the general form of a
+   value followed by a semi-colon separated sequence of parameter-name,
+   parameter-value pairs:
+
+         field-name: field-value *(;parameter-name=parameter-value)
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 31]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Even though an arbitrary number of parameter pairs may be attached to
+   a header field value, any given parameter-name MUST NOT appear more
+   than once.
+
+   When comparing header fields, field names are always case-
+   insensitive.  Unless otherwise stated in the definition of a
+   particular header field, field values, parameter names, and parameter
+   values are case-insensitive.  Tokens are always case-insensitive.
+   Unless specified otherwise, values expressed as quoted strings are
+   case-sensitive.  For example,
+
+      Contact: <sip:alice@atlanta.com>;expires=3600
+
+   is equivalent to
+
+      CONTACT: <sip:alice@atlanta.com>;ExPiReS=3600
+
+   and
+
+      Content-Disposition: session;handling=optional
+
+   is equivalent to
+
+      content-disposition: Session;HANDLING=OPTIONAL
+
+   The following two header fields are not equivalent:
+
+      Warning: 370 devnull "Choose a bigger pipe"
+      Warning: 370 devnull "CHOOSE A BIGGER PIPE"
+
+7.3.2 Header Field Classification
+
+   Some header fields only make sense in requests or responses.  These
+   are called request header fields and response header fields,
+   respectively.  If a header field appears in a message not matching
+   its category (such as a request header field in a response), it MUST
+   be ignored.  Section 20 defines the classification of each header
+   field.
+
+7.3.3 Compact Form
+
+   SIP provides a mechanism to represent common header field names in an
+   abbreviated form.  This may be useful when messages would otherwise
+   become too large to be carried on the transport available to it
+   (exceeding the maximum transmission unit (MTU) when using UDP, for
+   example).  These compact forms are defined in Section 20.  A compact
+   form MAY be substituted for the longer form of a header field name at
+   any time without changing the semantics of the message.  A header
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 32]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   field name MAY appear in both long and short forms within the same
+   message.  Implementations MUST accept both the long and short forms
+   of each header name.
+
+7.4 Bodies
+
+   Requests, including new requests defined in extensions to this
+   specification, MAY contain message bodies unless otherwise noted.
+   The interpretation of the body depends on the request method.
+
+   For response messages, the request method and the response status
+   code determine the type and interpretation of any message body.  All
+   responses MAY include a body.
+
+7.4.1 Message Body Type
+
+   The Internet media type of the message body MUST be given by the
+   Content-Type header field.  If the body has undergone any encoding
+   such as compression, then this MUST be indicated by the Content-
+   Encoding header field; otherwise, Content-Encoding MUST be omitted.
+   If applicable, the character set of the message body is indicated as
+   part of the Content-Type header-field value.
+
+   The "multipart" MIME type defined in RFC 2046 [11] MAY be used within
+   the body of the message.  Implementations that send requests
+   containing multipart message bodies MUST send a session description
+   as a non-multipart message body if the remote implementation requests
+   this through an Accept header field that does not contain multipart.
+
+   SIP messages MAY contain binary bodies or body parts. When no
+   explicit charset parameter is provided by the sender, media subtypes
+   of the "text" type are defined to have a default charset value of
+   "UTF-8".
+
+7.4.2 Message Body Length
+
+   The body length in bytes is provided by the Content-Length header
+   field.  Section 20.14 describes the necessary contents of this header
+   field in detail.
+
+   The "chunked" transfer encoding of HTTP/1.1 MUST NOT be used for SIP.
+   (Note: The chunked encoding modifies the body of a message in order
+   to transfer it as a series of chunks, each with its own size
+   indicator.)
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 33]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+7.5 Framing SIP Messages
+
+   Unlike HTTP, SIP implementations can use UDP or other unreliable
+   datagram protocols.  Each such datagram carries one request or
+   response.  See Section 18 on constraints on usage of unreliable
+   transports.
+
+   Implementations processing SIP messages over stream-oriented
+   transports MUST ignore any CRLF appearing before the start-line
+   [H4.1].
+
+      The Content-Length header field value is used to locate the end of
+      each SIP message in a stream.  It will always be present when SIP
+      messages are sent over stream-oriented transports.
+
+8 General User Agent Behavior
+
+   A user agent represents an end system.  It contains a user agent
+   client (UAC), which generates requests, and a user agent server
+   (UAS), which responds to them.  A UAC is capable of generating a
+   request based on some external stimulus (the user clicking a button,
+   or a signal on a PSTN line) and processing a response.  A UAS is
+   capable of receiving a request and generating a response based on
+   user input, external stimulus, the result of a program execution, or
+   some other mechanism.
+
+   When a UAC sends a request, the request passes through some number of
+   proxy servers, which forward the request towards the UAS. When the
+   UAS generates a response, the response is forwarded towards the UAC.
+
+   UAC and UAS procedures depend strongly on two factors.  First, based
+   on whether the request or response is inside or outside of a dialog,
+   and second, based on the method of a request.  Dialogs are discussed
+   thoroughly in Section 12; they represent a peer-to-peer relationship
+   between user agents and are established by specific SIP methods, such
+   as INVITE.
+
+   In this section, we discuss the method-independent rules for UAC and
+   UAS behavior when processing requests that are outside of a dialog.
+   This includes, of course, the requests which themselves establish a
+   dialog.
+
+   Security procedures for requests and responses outside of a dialog
+   are described in Section 26.  Specifically, mechanisms exist for the
+   UAS and UAC to mutually authenticate.  A limited set of privacy
+   features are also supported through encryption of bodies using
+   S/MIME.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 34]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.1 UAC Behavior
+
+   This section covers UAC behavior outside of a dialog.
+
+8.1.1 Generating the Request
+
+   A valid SIP request formulated by a UAC MUST, at a minimum, contain
+   the following header fields: To, From, CSeq, Call-ID, Max-Forwards,
+   and Via; all of these header fields are mandatory in all SIP
+   requests.  These six header fields are the fundamental building
+   blocks of a SIP message, as they jointly provide for most of the
+   critical message routing services including the addressing of
+   messages, the routing of responses, limiting message propagation,
+   ordering of messages, and the unique identification of transactions.
+   These header fields are in addition to the mandatory request line,
+   which contains the method, Request-URI, and SIP version.
+
+   Examples of requests sent outside of a dialog include an INVITE to
+   establish a session (Section 13) and an OPTIONS to query for
+   capabilities (Section 11).
+
+8.1.1.1 Request-URI
+
+   The initial Request-URI of the message SHOULD be set to the value of
+   the URI in the To field.  One notable exception is the REGISTER
+   method; behavior for setting the Request-URI of REGISTER is given in
+   Section 10.  It may also be undesirable for privacy reasons or
+   convenience to set these fields to the same value (especially if the
+   originating UA expects that the Request-URI will be changed during
+   transit).
+
+   In some special circumstances, the presence of a pre-existing route
+   set can affect the Request-URI of the message.  A pre-existing route
+   set is an ordered set of URIs that identify a chain of servers, to
+   which a UAC will send outgoing requests that are outside of a dialog.
+   Commonly, they are configured on the UA by a user or service provider
+   manually, or through some other non-SIP mechanism.  When a provider
+   wishes to configure a UA with an outbound proxy, it is RECOMMENDED
+   that this be done by providing it with a pre-existing route set with
+   a single URI, that of the outbound proxy.
+
+   When a pre-existing route set is present, the procedures for
+   populating the Request-URI and Route header field detailed in Section
+   12.2.1.1 MUST be followed (even though there is no dialog), using the
+   desired Request-URI as the remote target URI.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 35]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.1.1.2 To
+
+   The To header field first and foremost specifies the desired
+   "logical" recipient of the request, or the address-of-record of the
+   user or resource that is the target of this request.  This may or may
+   not be the ultimate recipient of the request.  The To header field
+   MAY contain a SIP or SIPS URI, but it may also make use of other URI
+   schemes (the tel URL (RFC 2806 [9]), for example) when appropriate.
+   All SIP implementations MUST support the SIP URI scheme.  Any
+   implementation that supports TLS MUST support the SIPS URI scheme.
+   The To header field allows for a display name.
+
+   A UAC may learn how to populate the To header field for a particular
+   request in a number of ways.  Usually the user will suggest the To
+   header field through a human interface, perhaps inputting the URI
+   manually or selecting it from some sort of address book.  Frequently,
+   the user will not enter a complete URI, but rather a string of digits
+   or letters (for example, "bob").  It is at the discretion of the UA
+   to choose how to interpret this input.  Using the string to form the
+   user part of a SIP URI implies that the UA wishes the name to be
+   resolved in the domain to the right-hand side (RHS) of the at-sign in
+   the SIP URI (for instance, sip:bob@example.com).  Using the string to
+   form the user part of a SIPS URI implies that the UA wishes to
+   communicate securely, and that the name is to be resolved in the
+   domain to the RHS of the at-sign.  The RHS will frequently be the
+   home domain of the requestor, which allows for the home domain to
+   process the outgoing request.  This is useful for features like
+   "speed dial" that require interpretation of the user part in the home
+   domain.  The tel URL may be used when the UA does not wish to specify
+   the domain that should interpret a telephone number that has been
+   input by the user.  Rather, each domain through which the request
+   passes would be given that opportunity.  As an example, a user in an
+   airport might log in and send requests through an outbound proxy in
+   the airport.  If they enter "411" (this is the phone number for local
+   directory assistance in the United States), that needs to be
+   interpreted and processed by the outbound proxy in the airport, not
+   the user's home domain.  In this case, tel:411 would be the right
+   choice.
+
+   A request outside of a dialog MUST NOT contain a To tag; the tag in
+   the To field of a request identifies the peer of the dialog.  Since
+   no dialog is established, no tag is present.
+
+   For further information on the To header field, see Section 20.39.
+   The following is an example of a valid To header field:
+
+      To: Carol <sip:carol@chicago.com>
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 36]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.1.1.3 From
+
+   The From header field indicates the logical identity of the initiator
+   of the request, possibly the user's address-of-record.  Like the To
+   header field, it contains a URI and optionally a display name.  It is
+   used by SIP elements to determine which processing rules to apply to
+   a request (for example, automatic call rejection).  As such, it is
+   very important that the From URI not contain IP addresses or the FQDN
+   of the host on which the UA is running, since these are not logical
+   names.
+
+   The From header field allows for a display name.  A UAC SHOULD use
+   the display name "Anonymous", along with a syntactically correct, but
+   otherwise meaningless URI (like sip:thisis@anonymous.invalid), if the
+   identity of the client is to remain hidden.
+
+   Usually, the value that populates the From header field in requests
+   generated by a particular UA is pre-provisioned by the user or by the
+   administrators of the user's local domain.  If a particular UA is
+   used by multiple users, it might have switchable profiles that
+   include a URI corresponding to the identity of the profiled user.
+   Recipients of requests can authenticate the originator of a request
+   in order to ascertain that they are who their From header field
+   claims they are (see Section 22 for more on authentication).
+
+   The From field MUST contain a new "tag" parameter, chosen by the UAC.
+   See Section 19.3 for details on choosing a tag.
+
+   For further information on the From header field, see Section 20.20.
+   Examples:
+
+      From: "Bob" <sips:bob@biloxi.com> ;tag=a48s
+      From: sip:+12125551212@phone2net.com;tag=887s
+      From: Anonymous <sip:c8oqz84zk7z@privacy.org>;tag=hyh8
+
+8.1.1.4 Call-ID
+
+   The Call-ID header field acts as a unique identifier to group
+   together a series of messages.  It MUST be the same for all requests
+   and responses sent by either UA in a dialog.  It SHOULD be the same
+   in each registration from a UA.
+
+   In a new request created by a UAC outside of any dialog, the Call-ID
+   header field MUST be selected by the UAC as a globally unique
+   identifier over space and time unless overridden by method-specific
+   behavior.  All SIP UAs must have a means to guarantee that the Call-
+   ID header fields they produce will not be inadvertently generated by
+   any other UA.  Note that when requests are retried after certain
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 37]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   failure responses that solicit an amendment to a request (for
+   example, a challenge for authentication), these retried requests are
+   not considered new requests, and therefore do not need new Call-ID
+   header fields; see Section 8.1.3.5.
+
+   Use of cryptographically random identifiers (RFC 1750 [12]) in the
+   generation of Call-IDs is RECOMMENDED.  Implementations MAY use the
+   form "localid@host".  Call-IDs are case-sensitive and are simply
+   compared byte-by-byte.
+
+      Using cryptographically random identifiers provides some
+      protection against session hijacking and reduces the likelihood of
+      unintentional Call-ID collisions.
+
+   No provisioning or human interface is required for the selection of
+   the Call-ID header field value for a request.
+
+   For further information on the Call-ID header field, see Section
+   20.8.
+
+   Example:
+
+      Call-ID: f81d4fae-7dec-11d0-a765-00a0c91e6bf6@foo.bar.com
+
+8.1.1.5 CSeq
+
+   The CSeq header field serves as a way to identify and order
+   transactions.  It consists of a sequence number and a method.  The
+   method MUST match that of the request.  For non-REGISTER requests
+   outside of a dialog, the sequence number value is arbitrary.  The
+   sequence number value MUST be expressible as a 32-bit unsigned
+   integer and MUST be less than 2**31.  As long as it follows the above
+   guidelines, a client may use any mechanism it would like to select
+   CSeq header field values.
+
+   Section 12.2.1.1 discusses construction of the CSeq for requests
+   within a dialog.
+
+   Example:
+
+      CSeq: 4711 INVITE
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 38]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.1.1.6 Max-Forwards
+
+   The Max-Forwards header field serves to limit the number of hops a
+   request can transit on the way to its destination.  It consists of an
+   integer that is decremented by one at each hop.  If the Max-Forwards
+   value reaches 0 before the request reaches its destination, it will
+   be rejected with a 483(Too Many Hops) error response.
+
+   A UAC MUST insert a Max-Forwards header field into each request it
+   originates with a value that SHOULD be 70.  This number was chosen to
+   be sufficiently large to guarantee that a request would not be
+   dropped in any SIP network when there were no loops, but not so large
+   as to consume proxy resources when a loop does occur.  Lower values
+   should be used with caution and only in networks where topologies are
+   known by the UA.
+
+8.1.1.7 Via
+
+   The Via header field indicates the transport used for the transaction
+   and identifies the location where the response is to be sent.  A Via
+   header field value is added only after the transport that will be
+   used to reach the next hop has been selected (which may involve the
+   usage of the procedures in [4]).
+
+   When the UAC creates a request, it MUST insert a Via into that
+   request.  The protocol name and protocol version in the header field
+   MUST be SIP and 2.0, respectively.  The Via header field value MUST
+   contain a branch parameter.  This parameter is used to identify the
+   transaction created by that request.  This parameter is used by both
+   the client and the server.
+
+   The branch parameter value MUST be unique across space and time for
+   all requests sent by the UA.  The exceptions to this rule are CANCEL
+   and ACK for non-2xx responses.  As discussed below, a CANCEL request
+   will have the same value of the branch parameter as the request it
+   cancels.  As discussed in Section 17.1.1.3, an ACK for a non-2xx
+   response will also have the same branch ID as the INVITE whose
+   response it acknowledges.
+
+      The uniqueness property of the branch ID parameter, to facilitate
+      its use as a transaction ID, was not part of RFC 2543.
+
+   The branch ID inserted by an element compliant with this
+   specification MUST always begin with the characters "z9hG4bK".  These
+   7 characters are used as a magic cookie (7 is deemed sufficient to
+   ensure that an older RFC 2543 implementation would not pick such a
+   value), so that servers receiving the request can determine that the
+   branch ID was constructed in the fashion described by this
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 39]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   specification (that is, globally unique).  Beyond this requirement,
+   the precise format of the branch token is implementation-defined.
+
+   The Via header maddr, ttl, and sent-by components will be set when
+   the request is processed by the transport layer (Section 18).
+
+   Via processing for proxies is described in Section 16.6 Item 8 and
+   Section 16.7 Item 3.
+
+8.1.1.8 Contact
+
+   The Contact header field provides a SIP or SIPS URI that can be used
+   to contact that specific instance of the UA for subsequent requests.
+   The Contact header field MUST be present and contain exactly one SIP
+   or SIPS URI in any request that can result in the establishment of a
+   dialog.  For the methods defined in this specification, that includes
+   only the INVITE request.  For these requests, the scope of the
+   Contact is global.  That is, the Contact header field value contains
+   the URI at which the UA would like to receive requests, and this URI
+   MUST be valid even if used in subsequent requests outside of any
+   dialogs.
+
+   If the Request-URI or top Route header field value contains a SIPS
+   URI, the Contact header field MUST contain a SIPS URI as well.
+
+   For further information on the Contact header field, see Section
+   20.10.
+
+8.1.1.9 Supported and Require
+
+   If the UAC supports extensions to SIP that can be applied by the
+   server to the response, the UAC SHOULD include a Supported header
+   field in the request listing the option tags (Section 19.2) for those
+   extensions.
+
+   The option tags listed MUST only refer to extensions defined in
+   standards-track RFCs.  This is to prevent servers from insisting that
+   clients implement non-standard, vendor-defined features in order to
+   receive service.  Extensions defined by experimental and
+   informational RFCs are explicitly excluded from usage with the
+   Supported header field in a request, since they too are often used to
+   document vendor-defined extensions.
+
+   If the UAC wishes to insist that a UAS understand an extension that
+   the UAC will apply to the request in order to process the request, it
+   MUST insert a Require header field into the request listing the
+   option tag for that extension.  If the UAC wishes to apply an
+   extension to the request and insist that any proxies that are
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 40]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   traversed understand that extension, it MUST insert a Proxy-Require
+   header field into the request listing the option tag for that
+   extension.
+
+   As with the Supported header field, the option tags in the Require
+   and Proxy-Require header fields MUST only refer to extensions defined
+   in standards-track RFCs.
+
+8.1.1.10 Additional Message Components
+
+   After a new request has been created, and the header fields described
+   above have been properly constructed, any additional optional header
+   fields are added, as are any header fields specific to the method.
+
+   SIP requests MAY contain a MIME-encoded message-body.  Regardless of
+   the type of body that a request contains, certain header fields must
+   be formulated to characterize the contents of the body.  For further
+   information on these header fields, see Sections 20.11 through 20.15.
+
+8.1.2 Sending the Request
+
+   The destination for the request is then computed.  Unless there is
+   local policy specifying otherwise, the destination MUST be determined
+   by applying the DNS procedures described in [4] as follows.  If the
+   first element in the route set indicated a strict router (resulting
+   in forming the request as described in Section 12.2.1.1), the
+   procedures MUST be applied to the Request-URI of the request.
+   Otherwise, the procedures are applied to the first Route header field
+   value in the request (if one exists), or to the request's Request-URI
+   if there is no Route header field present.  These procedures yield an
+   ordered set of address, port, and transports to attempt.  Independent
+   of which URI is used as input to the procedures of [4], if the
+   Request-URI specifies a SIPS resource, the UAC MUST follow the
+   procedures of [4] as if the input URI were a SIPS URI.
+
+   Local policy MAY specify an alternate set of destinations to attempt.
+   If the Request-URI contains a SIPS URI, any alternate destinations
+   MUST be contacted with TLS.  Beyond that, there are no restrictions
+   on the alternate destinations if the request contains no Route header
+   field.  This provides a simple alternative to a pre-existing route
+   set as a way to specify an outbound proxy.  However, that approach
+   for configuring an outbound proxy is NOT RECOMMENDED; a pre-existing
+   route set with a single URI SHOULD be used instead.  If the request
+   contains a Route header field, the request SHOULD be sent to the
+   locations derived from its topmost value, but MAY be sent to any
+   server that the UA is certain will honor the Route and Request-URI
+   policies specified in this document (as opposed to those in RFC
+   2543).  In particular, a UAC configured with an outbound proxy SHOULD
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 41]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   attempt to send the request to the location indicated in the first
+   Route header field value instead of adopting the policy of sending
+   all messages to the outbound proxy.
+
+      This ensures that outbound proxies that do not add Record-Route
+      header field values will drop out of the path of subsequent
+      requests.  It allows endpoints that cannot resolve the first Route
+      URI to delegate that task to an outbound proxy.
+
+   The UAC SHOULD follow the procedures defined in [4] for stateful
+   elements, trying each address until a server is contacted.  Each try
+   constitutes a new transaction, and therefore each carries a different
+   topmost Via header field value with a new branch parameter.
+   Furthermore, the transport value in the Via header field is set to
+   whatever transport was determined for the target server.
+
+8.1.3 Processing Responses
+
+   Responses are first processed by the transport layer and then passed
+   up to the transaction layer.  The transaction layer performs its
+   processing and then passes the response up to the TU.  The majority
+   of response processing in the TU is method specific.  However, there
+   are some general behaviors independent of the method.
+
+8.1.3.1 Transaction Layer Errors
+
+   In some cases, the response returned by the transaction layer will
+   not be a SIP message, but rather a transaction layer error.  When a
+   timeout error is received from the transaction layer, it MUST be
+   treated as if a 408 (Request Timeout) status code has been received.
+   If a fatal transport error is reported by the transport layer
+   (generally, due to fatal ICMP errors in UDP or connection failures in
+   TCP), the condition MUST be treated as a 503 (Service Unavailable)
+   status code.
+
+8.1.3.2 Unrecognized Responses
+
+   A UAC MUST treat any final response it does not recognize as being
+   equivalent to the x00 response code of that class, and MUST be able
+   to process the x00 response code for all classes.  For example, if a
+   UAC receives an unrecognized response code of 431, it can safely
+   assume that there was something wrong with its request and treat the
+   response as if it had received a 400 (Bad Request) response code.  A
+   UAC MUST treat any provisional response different than 100 that it
+   does not recognize as 183 (Session Progress).  A UAC MUST be able to
+   process 100 and 183 responses.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 42]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.1.3.3 Vias
+
+   If more than one Via header field value is present in a response, the
+   UAC SHOULD discard the message.
+
+      The presence of additional Via header field values that precede
+      the originator of the request suggests that the message was
+      misrouted or possibly corrupted.
+
+8.1.3.4 Processing 3xx Responses
+
+   Upon receipt of a redirection response (for example, a 301 response
+   status code), clients SHOULD use the URI(s) in the Contact header
+   field to formulate one or more new requests based on the redirected
+   request.  This process is similar to that of a proxy recursing on a
+   3xx class response as detailed in Sections 16.5 and 16.6.  A client
+   starts with an initial target set containing exactly one URI, the
+   Request-URI of the original request.  If a client wishes to formulate
+   new requests based on a 3xx class response to that request, it places
+   the URIs to try into the target set.  Subject to the restrictions in
+   this specification, a client can choose which Contact URIs it places
+   into the target set.  As with proxy recursion, a client processing
+   3xx class responses MUST NOT add any given URI to the target set more
+   than once.  If the original request had a SIPS URI in the Request-
+   URI, the client MAY choose to recurse to a non-SIPS URI, but SHOULD
+   inform the user of the redirection to an insecure URI.
+
+      Any new request may receive 3xx responses themselves containing
+      the original URI as a contact.  Two locations can be configured to
+      redirect to each other.  Placing any given URI in the target set
+      only once prevents infinite redirection loops.
+
+   As the target set grows, the client MAY generate new requests to the
+   URIs in any order.  A common mechanism is to order the set by the "q"
+   parameter value from the Contact header field value.  Requests to the
+   URIs MAY be generated serially or in parallel.  One approach is to
+   process groups of decreasing q-values serially and process the URIs
+   in each q-value group in parallel.  Another is to perform only serial
+   processing in decreasing q-value order, arbitrarily choosing between
+   contacts of equal q-value.
+
+   If contacting an address in the list results in a failure, as defined
+   in the next paragraph, the element moves to the next address in the
+   list, until the list is exhausted.  If the list is exhausted, then
+   the request has failed.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 43]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Failures SHOULD be detected through failure response codes (codes
+   greater than 399); for network errors the client transaction will
+   report any transport layer failures to the transaction user.  Note
+   that some response codes (detailed in 8.1.3.5) indicate that the
+   request can be retried; requests that are reattempted should not be
+   considered failures.
+
+   When a failure for a particular contact address is received, the
+   client SHOULD try the next contact address.  This will involve
+   creating a new client transaction to deliver a new request.
+
+   In order to create a request based on a contact address in a 3xx
+   response, a UAC MUST copy the entire URI from the target set into the
+   Request-URI, except for the "method-param" and "header" URI
+   parameters (see Section 19.1.1 for a definition of these parameters).
+   It uses the "header" parameters to create header field values for the
+   new request, overwriting header field values associated with the
+   redirected request in accordance with the guidelines in Section
+   19.1.5.
+
+   Note that in some instances, header fields that have been
+   communicated in the contact address may instead append to existing
+   request header fields in the original redirected request.  As a
+   general rule, if the header field can accept a comma-separated list
+   of values, then the new header field value MAY be appended to any
+   existing values in the original redirected request.  If the header
+   field does not accept multiple values, the value in the original
+   redirected request MAY be overwritten by the header field value
+   communicated in the contact address.  For example, if a contact
+   address is returned with the following value:
+
+      sip:user@host?Subject=foo&Call-Info=<http://www.foo.com>
+
+   Then any Subject header field in the original redirected request is
+   overwritten, but the HTTP URL is merely appended to any existing
+   Call-Info header field values.
+
+   It is RECOMMENDED that the UAC reuse the same To, From, and Call-ID
+   used in the original redirected request, but the UAC MAY also choose
+   to update the Call-ID header field value for new requests, for
+   example.
+
+   Finally, once the new request has been constructed, it is sent using
+   a new client transaction, and therefore MUST have a new branch ID in
+   the top Via field as discussed in Section 8.1.1.7.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 44]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   In all other respects, requests sent upon receipt of a redirect
+   response SHOULD re-use the header fields and bodies of the original
+   request.
+
+   In some instances, Contact header field values may be cached at UAC
+   temporarily or permanently depending on the status code received and
+   the presence of an expiration interval; see Sections 21.3.2 and
+   21.3.3.
+
+8.1.3.5 Processing 4xx Responses
+
+   Certain 4xx response codes require specific UA processing,
+   independent of the method.
+
+   If a 401 (Unauthorized) or 407 (Proxy Authentication Required)
+   response is received, the UAC SHOULD follow the authorization
+   procedures of Section 22.2 and Section 22.3 to retry the request with
+   credentials.
+
+   If a 413 (Request Entity Too Large) response is received (Section
+   21.4.11), the request contained a body that was longer than the UAS
+   was willing to accept.  If possible, the UAC SHOULD retry the
+   request, either omitting the body or using one of a smaller length.
+
+   If a 415 (Unsupported Media Type) response is received (Section
+   21.4.13), the request contained media types not supported by the UAS.
+   The UAC SHOULD retry sending the request, this time only using
+   content with types listed in the Accept header field in the response,
+   with encodings listed in the Accept-Encoding header field in the
+   response, and with languages listed in the Accept-Language in the
+   response.
+
+   If a 416 (Unsupported URI Scheme) response is received (Section
+   21.4.14), the Request-URI used a URI scheme not supported by the
+   server.  The client SHOULD retry the request, this time, using a SIP
+   URI.
+
+   If a 420 (Bad Extension) response is received (Section 21.4.15), the
+   request contained a Require or Proxy-Require header field listing an
+   option-tag for a feature not supported by a proxy or UAS.  The UAC
+   SHOULD retry the request, this time omitting any extensions listed in
+   the Unsupported header field in the response.
+
+   In all of the above cases, the request is retried by creating a new
+   request with the appropriate modifications.  This new request
+   constitutes a new transaction and SHOULD have the same value of the
+   Call-ID, To, and From of the previous request, but the CSeq should
+   contain a new sequence number that is one higher than the previous.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 45]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   With other 4xx responses, including those yet to be defined, a retry
+   may or may not be possible depending on the method and the use case.
+
+8.2 UAS Behavior
+
+   When a request outside of a dialog is processed by a UAS, there is a
+   set of processing rules that are followed, independent of the method.
+   Section 12 gives guidance on how a UAS can tell whether a request is
+   inside or outside of a dialog.
+
+   Note that request processing is atomic.  If a request is accepted,
+   all state changes associated with it MUST be performed.  If it is
+   rejected, all state changes MUST NOT be performed.
+
+   UASs SHOULD process the requests in the order of the steps that
+   follow in this section (that is, starting with authentication, then
+   inspecting the method, the header fields, and so on throughout the
+   remainder of this section).
+
+8.2.1 Method Inspection
+
+   Once a request is authenticated (or authentication is skipped), the
+   UAS MUST inspect the method of the request.  If the UAS recognizes
+   but does not support the method of a request, it MUST generate a 405
+   (Method Not Allowed) response.  Procedures for generating responses
+   are described in Section 8.2.6.  The UAS MUST also add an Allow
+   header field to the 405 (Method Not Allowed) response.  The Allow
+   header field MUST list the set of methods supported by the UAS
+   generating the message.  The Allow header field is presented in
+   Section 20.5.
+
+   If the method is one supported by the server, processing continues.
+
+8.2.2 Header Inspection
+
+   If a UAS does not understand a header field in a request (that is,
+   the header field is not defined in this specification or in any
+   supported extension), the server MUST ignore that header field and
+   continue processing the message.  A UAS SHOULD ignore any malformed
+   header fields that are not necessary for processing requests.
+
+8.2.2.1 To and Request-URI
+
+   The To header field identifies the original recipient of the request
+   designated by the user identified in the From field.  The original
+   recipient may or may not be the UAS processing the request, due to
+   call forwarding or other proxy operations.  A UAS MAY apply any
+   policy it wishes to determine whether to accept requests when the To
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 46]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   header field is not the identity of the UAS.  However, it is
+   RECOMMENDED that a UAS accept requests even if they do not recognize
+   the URI scheme (for example, a tel: URI) in the To header field, or
+   if the To header field does not address a known or current user of
+   this UAS.  If, on the other hand, the UAS decides to reject the
+   request, it SHOULD generate a response with a 403 (Forbidden) status
+   code and pass it to the server transaction for transmission.
+
+   However, the Request-URI identifies the UAS that is to process the
+   request.  If the Request-URI uses a scheme not supported by the UAS,
+   it SHOULD reject the request with a 416 (Unsupported URI Scheme)
+   response.  If the Request-URI does not identify an address that the
+   UAS is willing to accept requests for, it SHOULD reject the request
+   with a 404 (Not Found) response.  Typically, a UA that uses the
+   REGISTER method to bind its address-of-record to a specific contact
+   address will see requests whose Request-URI equals that contact
+   address.  Other potential sources of received Request-URIs include
+   the Contact header fields of requests and responses sent by the UA
+   that establish or refresh dialogs.
+
+8.2.2.2 Merged Requests
+
+   If the request has no tag in the To header field, the UAS core MUST
+   check the request against ongoing transactions.  If the From tag,
+   Call-ID, and CSeq exactly match those associated with an ongoing
+   transaction, but the request does not match that transaction (based
+   on the matching rules in Section 17.2.3), the UAS core SHOULD
+   generate a 482 (Loop Detected) response and pass it to the server
+   transaction.
+
+      The same request has arrived at the UAS more than once, following
+      different paths, most likely due to forking.  The UAS processes
+      the first such request received and responds with a 482 (Loop
+      Detected) to the rest of them.
+
+8.2.2.3 Require
+
+   Assuming the UAS decides that it is the proper element to process the
+   request, it examines the Require header field, if present.
+
+   The Require header field is used by a UAC to tell a UAS about SIP
+   extensions that the UAC expects the UAS to support in order to
+   process the request properly.  Its format is described in Section
+   20.32.  If a UAS does not understand an option-tag listed in a
+   Require header field, it MUST respond by generating a response with
+   status code 420 (Bad Extension).  The UAS MUST add an Unsupported
+   header field, and list in it those options it does not understand
+   amongst those in the Require header field of the request.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 47]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Note that Require and Proxy-Require MUST NOT be used in a SIP CANCEL
+   request, or in an ACK request sent for a non-2xx response.  These
+   header fields MUST be ignored if they are present in these requests.
+
+   An ACK request for a 2xx response MUST contain only those Require and
+   Proxy-Require values that were present in the initial request.
+
+   Example:
+
+      UAC->UAS:   INVITE sip:watson@bell-telephone.com SIP/2.0
+                  Require: 100rel
+
+      UAS->UAC:   SIP/2.0 420 Bad Extension
+                  Unsupported: 100rel
+
+      This behavior ensures that the client-server interaction will
+      proceed without delay when all options are understood by both
+      sides, and only slow down if options are not understood (as in the
+      example above).  For a well-matched client-server pair, the
+      interaction proceeds quickly, saving a round-trip often required
+      by negotiation mechanisms.  In addition, it also removes ambiguity
+      when the client requires features that the server does not
+      understand.  Some features, such as call handling fields, are only
+      of interest to end systems.
+
+8.2.3 Content Processing
+
+   Assuming the UAS understands any extensions required by the client,
+   the UAS examines the body of the message, and the header fields that
+   describe it.  If there are any bodies whose type (indicated by the
+   Content-Type), language (indicated by the Content-Language) or
+   encoding (indicated by the Content-Encoding) are not understood, and
+   that body part is not optional (as indicated by the Content-
+   Disposition header field), the UAS MUST reject the request with a 415
+   (Unsupported Media Type) response.  The response MUST contain an
+   Accept header field listing the types of all bodies it understands,
+   in the event the request contained bodies of types not supported by
+   the UAS.  If the request contained content encodings not understood
+   by the UAS, the response MUST contain an Accept-Encoding header field
+   listing the encodings understood by the UAS.  If the request
+   contained content with languages not understood by the UAS, the
+   response MUST contain an Accept-Language header field indicating the
+   languages understood by the UAS.  Beyond these checks, body handling
+   depends on the method and type.  For further information on the
+   processing of content-specific header fields, see Section 7.4 as well
+   as Section 20.11 through 20.15.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 48]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+8.2.4 Applying Extensions
+
+   A UAS that wishes to apply some extension when generating the
+   response MUST NOT do so unless support for that extension is
+   indicated in the Supported header field in the request.  If the
+   desired extension is not supported, the server SHOULD rely only on
+   baseline SIP and any other extensions supported by the client.  In
+   rare circumstances, where the server cannot process the request
+   without the extension, the server MAY send a 421 (Extension Required)
+   response.  This response indicates that the proper response cannot be
+   generated without support of a specific extension.  The needed
+   extension(s) MUST be included in a Require header field in the
+   response.  This behavior is NOT RECOMMENDED, as it will generally
+   break interoperability.
+
+   Any extensions applied to a non-421 response MUST be listed in a
+   Require header field included in the response.  Of course, the server
+   MUST NOT apply extensions not listed in the Supported header field in
+   the request.  As a result of this, the Require header field in a
+   response will only ever contain option tags defined in standards-
+   track RFCs.
+
+8.2.5 Processing the Request
+
+   Assuming all of the checks in the previous subsections are passed,
+   the UAS processing becomes method-specific.  Section 10 covers the
+   REGISTER request, Section 11 covers the OPTIONS request, Section 13
+   covers the INVITE request, and Section 15 covers the BYE request.
+
+8.2.6 Generating the Response
+
+   When a UAS wishes to construct a response to a request, it follows
+   the general procedures detailed in the following subsections.
+   Additional behaviors specific to the response code in question, which
+   are not detailed in this section, may also be required.
+
+   Once all procedures associated with the creation of a response have
+   been completed, the UAS hands the response back to the server
+   transaction from which it received the request.
+
+8.2.6.1 Sending a Provisional Response
+
+   One largely non-method-specific guideline for the generation of
+   responses is that UASs SHOULD NOT issue a provisional response for a
+   non-INVITE request.  Rather, UASs SHOULD generate a final response to
+   a non-INVITE request as soon as possible.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 49]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   When a 100 (Trying) response is generated, any Timestamp header field
+   present in the request MUST be copied into this 100 (Trying)
+   response.  If there is a delay in generating the response, the UAS
+   SHOULD add a delay value into the Timestamp value in the response.
+   This value MUST contain the difference between the time of sending of
+   the response and receipt of the request, measured in seconds.
+
+8.2.6.2 Headers and Tags
+
+   The From field of the response MUST equal the From header field of
+   the request.  The Call-ID header field of the response MUST equal the
+   Call-ID header field of the request.  The CSeq header field of the
+   response MUST equal the CSeq field of the request.  The Via header
+   field values in the response MUST equal the Via header field values
+   in the request and MUST maintain the same ordering.
+
+   If a request contained a To tag in the request, the To header field
+   in the response MUST equal that of the request.  However, if the To
+   header field in the request did not contain a tag, the URI in the To
+   header field in the response MUST equal the URI in the To header
+   field; additionally, the UAS MUST add a tag to the To header field in
+   the response (with the exception of the 100 (Trying) response, in
+   which a tag MAY be present).  This serves to identify the UAS that is
+   responding, possibly resulting in a component of a dialog ID.  The
+   same tag MUST be used for all responses to that request, both final
+   and provisional (again excepting the 100 (Trying)).  Procedures for
+   the generation of tags are defined in Section 19.3.
+
+8.2.7 Stateless UAS Behavior
+
+   A stateless UAS is a UAS that does not maintain transaction state.
+   It replies to requests normally, but discards any state that would
+   ordinarily be retained by a UAS after a response has been sent.  If a
+   stateless UAS receives a retransmission of a request, it regenerates
+   the response and resends it, just as if it were replying to the first
+   instance of the request. A UAS cannot be stateless unless the request
+   processing for that method would always result in the same response
+   if the requests are identical. This rules out stateless registrars,
+   for example.  Stateless UASs do not use a transaction layer; they
+   receive requests directly from the transport layer and send responses
+   directly to the transport layer.
+
+   The stateless UAS role is needed primarily to handle unauthenticated
+   requests for which a challenge response is issued.  If
+   unauthenticated requests were handled statefully, then malicious
+   floods of unauthenticated requests could create massive amounts of
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 50]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   transaction state that might slow or completely halt call processing
+   in a UAS, effectively creating a denial of service condition; for
+   more information see Section 26.1.5.
+
+   The most important behaviors of a stateless UAS are the following:
+
+      o  A stateless UAS MUST NOT send provisional (1xx) responses.
+
+      o  A stateless UAS MUST NOT retransmit responses.
+
+      o  A stateless UAS MUST ignore ACK requests.
+
+      o  A stateless UAS MUST ignore CANCEL requests.
+
+      o  To header tags MUST be generated for responses in a stateless
+         manner - in a manner that will generate the same tag for the
+         same request consistently.  For information on tag construction
+         see Section 19.3.
+
+   In all other respects, a stateless UAS behaves in the same manner as
+   a stateful UAS.  A UAS can operate in either a stateful or stateless
+   mode for each new request.
+
+8.3 Redirect Servers
+
+   In some architectures it may be desirable to reduce the processing
+   load on proxy servers that are responsible for routing requests, and
+   improve signaling path robustness, by relying on redirection.
+
+   Redirection allows servers to push routing information for a request
+   back in a response to the client, thereby taking themselves out of
+   the loop of further messaging for this transaction while still aiding
+   in locating the target of the request.  When the originator of the
+   request receives the redirection, it will send a new request based on
+   the URI(s) it has received.  By propagating URIs from the core of the
+   network to its edges, redirection allows for considerable network
+   scalability.
+
+   A redirect server is logically constituted of a server transaction
+   layer and a transaction user that has access to a location service of
+   some kind (see Section 10 for more on registrars and location
+   services).  This location service is effectively a database
+   containing mappings between a single URI and a set of one or more
+   alternative locations at which the target of that URI can be found.
+
+   A redirect server does not issue any SIP requests of its own.  After
+   receiving a request other than CANCEL, the server either refuses the
+   request or gathers the list of alternative locations from the
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 51]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   location service and returns a final response of class 3xx.  For
+   well-formed CANCEL requests, it SHOULD return a 2xx response.  This
+   response ends the SIP transaction.  The redirect server maintains
+   transaction state for an entire SIP transaction.  It is the
+   responsibility of clients to detect forwarding loops between redirect
+   servers.
+
+   When a redirect server returns a 3xx response to a request, it
+   populates the list of (one or more) alternative locations into the
+   Contact header field.  An "expires" parameter to the Contact header
+   field values may also be supplied to indicate the lifetime of the
+   Contact data.
+
+   The Contact header field contains URIs giving the new locations or
+   user names to try, or may simply specify additional transport
+   parameters.  A 301 (Moved Permanently) or 302 (Moved Temporarily)
+   response may also give the same location and username that was
+   targeted by the initial request but specify additional transport
+   parameters such as a different server or multicast address to try, or
+   a change of SIP transport from UDP to TCP or vice versa.
+
+   However, redirect servers MUST NOT redirect a request to a URI equal
+   to the one in the Request-URI; instead, provided that the URI does
+   not point to itself, the server MAY proxy the request to the
+   destination URI, or MAY reject it with a 404.
+
+      If a client is using an outbound proxy, and that proxy actually
+      redirects requests, a potential arises for infinite redirection
+      loops.
+
+   Note that a Contact header field value MAY also refer to a different
+   resource than the one originally called.  For example, a SIP call
+   connected to PSTN gateway may need to deliver a special informational
+   announcement such as "The number you have dialed has been changed."
+
+   A Contact response header field can contain any suitable URI
+   indicating where the called party can be reached, not limited to SIP
+   URIs.  For example, it could contain URIs for phones, fax, or irc (if
+   they were defined) or a mailto:  (RFC 2368 [32]) URL.  Section 26.4.4
+   discusses implications and limitations of redirecting a SIPS URI to a
+   non-SIPS URI.
+
+   The "expires" parameter of a Contact header field value indicates how
+   long the URI is valid.  The value of the parameter is a number
+   indicating seconds.  If this parameter is not provided, the value of
+   the Expires header field determines how long the URI is valid.
+   Malformed values SHOULD be treated as equivalent to 3600.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 52]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      This provides a modest level of backwards compatibility with RFC
+      2543, which allowed absolute times in this header field.  If an
+      absolute time is received, it will be treated as malformed, and
+      then default to 3600.
+
+   Redirect servers MUST ignore features that are not understood
+   (including unrecognized header fields, any unknown option tags in
+   Require, or even method names) and proceed with the redirection of
+   the request in question.
+
+9 Canceling a Request
+
+   The previous section has discussed general UA behavior for generating
+   requests and processing responses for requests of all methods.  In
+   this section, we discuss a general purpose method, called CANCEL.
+
+   The CANCEL request, as the name implies, is used to cancel a previous
+   request sent by a client.  Specifically, it asks the UAS to cease
+   processing the request and to generate an error response to that
+   request.  CANCEL has no effect on a request to which a UAS has
+   already given a final response.  Because of this, it is most useful
+   to CANCEL requests to which it can take a server long time to
+   respond.  For this reason, CANCEL is best for INVITE requests, which
+   can take a long time to generate a response.  In that usage, a UAS
+   that receives a CANCEL request for an INVITE, but has not yet sent a
+   final response, would "stop ringing", and then respond to the INVITE
+   with a specific error response (a 487).
+
+   CANCEL requests can be constructed and sent by both proxies and user
+   agent clients.  Section 15 discusses under what conditions a UAC
+   would CANCEL an INVITE request, and Section 16.10 discusses proxy
+   usage of CANCEL.
+
+   A stateful proxy responds to a CANCEL, rather than simply forwarding
+   a response it would receive from a downstream element.  For that
+   reason, CANCEL is referred to as a "hop-by-hop" request, since it is
+   responded to at each stateful proxy hop.
+
+9.1 Client Behavior
+
+   A CANCEL request SHOULD NOT be sent to cancel a request other than
+   INVITE.
+
+      Since requests other than INVITE are responded to immediately,
+      sending a CANCEL for a non-INVITE request would always create a
+      race condition.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 53]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The following procedures are used to construct a CANCEL request.  The
+   Request-URI, Call-ID, To, the numeric part of CSeq, and From header
+   fields in the CANCEL request MUST be identical to those in the
+   request being cancelled, including tags.  A CANCEL constructed by a
+   client MUST have only a single Via header field value matching the
+   top Via value in the request being cancelled.  Using the same values
+   for these header fields allows the CANCEL to be matched with the
+   request it cancels (Section 9.2 indicates how such matching occurs).
+   However, the method part of the CSeq header field MUST have a value
+   of CANCEL.  This allows it to be identified and processed as a
+   transaction in its own right (See Section 17).
+
+   If the request being cancelled contains a Route header field, the
+   CANCEL request MUST include that Route header field's values.
+
+      This is needed so that stateless proxies are able to route CANCEL
+      requests properly.
+
+   The CANCEL request MUST NOT contain any Require or Proxy-Require
+   header fields.
+
+   Once the CANCEL is constructed, the client SHOULD check whether it
+   has received any response (provisional or final) for the request
+   being cancelled (herein referred to as the "original request").
+
+   If no provisional response has been received, the CANCEL request MUST
+   NOT be sent; rather, the client MUST wait for the arrival of a
+   provisional response before sending the request.  If the original
+   request has generated a final response, the CANCEL SHOULD NOT be
+   sent, as it is an effective no-op, since CANCEL has no effect on
+   requests that have already generated a final response.  When the
+   client decides to send the CANCEL, it creates a client transaction
+   for the CANCEL and passes it the CANCEL request along with the
+   destination address, port, and transport.  The destination address,
+   port, and transport for the CANCEL MUST be identical to those used to
+   send the original request.
+
+      If it was allowed to send the CANCEL before receiving a response
+      for the previous request, the server could receive the CANCEL
+      before the original request.
+
+   Note that both the transaction corresponding to the original request
+   and the CANCEL transaction will complete independently.  However, a
+   UAC canceling a request cannot rely on receiving a 487 (Request
+   Terminated) response for the original request, as an RFC 2543-
+   compliant UAS will not generate such a response.  If there is no
+   final response for the original request in 64*T1 seconds (T1 is
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 54]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   defined in Section 17.1.1.1), the client SHOULD then consider the
+   original transaction cancelled and SHOULD destroy the client
+   transaction handling the original request.
+
+9.2 Server Behavior
+
+   The CANCEL method requests that the TU at the server side cancel a
+   pending transaction.  The TU determines the transaction to be
+   cancelled by taking the CANCEL request, and then assuming that the
+   request method is anything but CANCEL or ACK and applying the
+   transaction matching procedures of Section 17.2.3.  The matching
+   transaction is the one to be cancelled.
+
+   The processing of a CANCEL request at a server depends on the type of
+   server.  A stateless proxy will forward it, a stateful proxy might
+   respond to it and generate some CANCEL requests of its own, and a UAS
+   will respond to it.  See Section 16.10 for proxy treatment of CANCEL.
+
+   A UAS first processes the CANCEL request according to the general UAS
+   processing described in Section 8.2.  However, since CANCEL requests
+   are hop-by-hop and cannot be resubmitted, they cannot be challenged
+   by the server in order to get proper credentials in an Authorization
+   header field.  Note also that CANCEL requests do not contain a
+   Require header field.
+
+   If the UAS did not find a matching transaction for the CANCEL
+   according to the procedure above, it SHOULD respond to the CANCEL
+   with a 481 (Call Leg/Transaction Does Not Exist).  If the transaction
+   for the original request still exists, the behavior of the UAS on
+   receiving a CANCEL request depends on whether it has already sent a
+   final response for the original request.  If it has, the CANCEL
+   request has no effect on the processing of the original request, no
+   effect on any session state, and no effect on the responses generated
+   for the original request.  If the UAS has not issued a final response
+   for the original request, its behavior depends on the method of the
+   original request.  If the original request was an INVITE, the UAS
+   SHOULD immediately respond to the INVITE with a 487 (Request
+   Terminated).  A CANCEL request has no impact on the processing of
+   transactions with any other method defined in this specification.
+
+   Regardless of the method of the original request, as long as the
+   CANCEL matched an existing transaction, the UAS answers the CANCEL
+   request itself with a 200 (OK) response.  This response is
+   constructed following the procedures described in Section 8.2.6
+   noting that the To tag of the response to the CANCEL and the To tag
+   in the response to the original request SHOULD be the same.  The
+   response to CANCEL is passed to the server transaction for
+   transmission.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 55]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+10 Registrations
+
+10.1 Overview
+
+   SIP offers a discovery capability.  If a user wants to initiate a
+   session with another user, SIP must discover the current host(s) at
+   which the destination user is reachable.  This discovery process is
+   frequently accomplished by SIP network elements such as proxy servers
+   and redirect servers which are responsible for receiving a request,
+   determining where to send it based on knowledge of the location of
+   the user, and then sending it there.  To do this, SIP network
+   elements consult an abstract service known as a location service,
+   which provides address bindings for a particular domain.  These
+   address bindings map an incoming SIP or SIPS URI, sip:bob@biloxi.com,
+   for example, to one or more URIs that are somehow "closer" to the
+   desired user, sip:bob@engineering.biloxi.com, for example.
+   Ultimately, a proxy will consult a location service that maps a
+   received URI to the user agent(s) at which the desired recipient is
+   currently residing.
+
+   Registration creates bindings in a location service for a particular
+   domain that associates an address-of-record URI with one or more
+   contact addresses.  Thus, when a proxy for that domain receives a
+   request whose Request-URI matches the address-of-record, the proxy
+   will forward the request to the contact addresses registered to that
+   address-of-record.  Generally, it only makes sense to register an
+   address-of-record at a domain's location service when requests for
+   that address-of-record would be routed to that domain.  In most
+   cases, this means that the domain of the registration will need to
+   match the domain in the URI of the address-of-record.
+
+   There are many ways by which the contents of the location service can
+   be established.  One way is administratively.  In the above example,
+   Bob is known to be a member of the engineering department through
+   access to a corporate database.  However, SIP provides a mechanism
+   for a UA to create a binding explicitly.  This mechanism is known as
+   registration.
+
+   Registration entails sending a REGISTER request to a special type of
+   UAS known as a registrar.  A registrar acts as the front end to the
+   location service for a domain, reading and writing mappings based on
+   the contents of REGISTER requests.  This location service is then
+   typically consulted by a proxy server that is responsible for routing
+   requests for that domain.
+
+   An illustration of the overall registration process is given in
+   Figure 2.  Note that the registrar and proxy server are logical roles
+   that can be played by a single device in a network; for purposes of
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 56]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   clarity the two are separated in this illustration.  Also note that
+   UAs may send requests through a proxy server in order to reach a
+   registrar if the two are separate elements.
+
+   SIP does not mandate a particular mechanism for implementing the
+   location service.  The only requirement is that a registrar for some
+   domain MUST be able to read and write data to the location service,
+   and a proxy or a redirect server for that domain MUST be capable of
+   reading that same data.  A registrar MAY be co-located with a
+   particular SIP proxy server for the same domain.
+
+10.2 Constructing the REGISTER Request
+
+   REGISTER requests add, remove, and query bindings.  A REGISTER
+   request can add a new binding between an address-of-record and one or
+   more contact addresses.  Registration on behalf of a particular
+   address-of-record can be performed by a suitably authorized third
+   party.  A client can also remove previous bindings or query to
+   determine which bindings are currently in place for an address-of-
+   record.
+
+   Except as noted, the construction of the REGISTER request and the
+   behavior of clients sending a REGISTER request is identical to the
+   general UAC behavior described in Section 8.1 and Section 17.1.
+
+   A REGISTER request does not establish a dialog.  A UAC MAY include a
+   Route header field in a REGISTER request based on a pre-existing
+   route set as described in Section 8.1.  The Record-Route header field
+   has no meaning in REGISTER requests or responses, and MUST be ignored
+   if present.  In particular, the UAC MUST NOT create a new route set
+   based on the presence or absence of a Record-Route header field in
+   any response to a REGISTER request.
+
+   The following header fields, except Contact, MUST be included in a
+   REGISTER request.  A Contact header field MAY be included:
+
+      Request-URI: The Request-URI names the domain of the location
+           service for which the registration is meant (for example,
+           "sip:chicago.com").  The "userinfo" and "@" components of the
+           SIP URI MUST NOT be present.
+
+      To: The To header field contains the address of record whose
+           registration is to be created, queried, or modified.  The To
+           header field and the Request-URI field typically differ, as
+           the former contains a user name.  This address-of-record MUST
+           be a SIP URI or SIPS URI.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 57]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      From: The From header field contains the address-of-record of the
+           person responsible for the registration.  The value is the
+           same as the To header field unless the request is a third-
+           party registration.
+
+      Call-ID: All registrations from a UAC SHOULD use the same Call-ID
+           header field value for registrations sent to a particular
+           registrar.
+
+           If the same client were to use different Call-ID values, a
+           registrar could not detect whether a delayed REGISTER request
+           might have arrived out of order.
+
+      CSeq: The CSeq value guarantees proper ordering of REGISTER
+           requests.  A UA MUST increment the CSeq value by one for each
+           REGISTER request with the same Call-ID.
+
+      Contact: REGISTER requests MAY contain a Contact header field with
+           zero or more values containing address bindings.
+
+   UAs MUST NOT send a new registration (that is, containing new Contact
+   header field values, as opposed to a retransmission) until they have
+   received a final response from the registrar for the previous one or
+   the previous REGISTER request has timed out.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 58]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                                                 bob
+                                               +----+
+                                               | UA |
+                                               |    |
+                                               +----+
+                                                  |
+                                                  |3)INVITE
+                                                  |   carol@chicago.com
+         chicago.com        +--------+            V
+         +---------+ 2)Store|Location|4)Query +-----+
+         |Registrar|=======>| Service|<=======|Proxy|sip.chicago.com
+         +---------+        +--------+=======>+-----+
+               A                      5)Resp      |
+               |                                  |
+               |                                  |
+     1)REGISTER|                                  |
+               |                                  |
+            +----+                                |
+            | UA |<-------------------------------+
+   cube2214a|    |                            6)INVITE
+            +----+                    carol@cube2214a.chicago.com
+             carol
+
+                      Figure 2: REGISTER example
+
+      The following Contact header parameters have a special meaning in
+           REGISTER requests:
+
+      action: The "action" parameter from RFC 2543 has been deprecated.
+           UACs SHOULD NOT use the "action" parameter.
+
+      expires: The "expires" parameter indicates how long the UA would
+           like the binding to be valid.  The value is a number
+           indicating seconds.  If this parameter is not provided, the
+           value of the Expires header field is used instead.
+           Implementations MAY treat values larger than 2**32-1
+           (4294967295 seconds or 136 years) as equivalent to 2**32-1.
+           Malformed values SHOULD be treated as equivalent to 3600.
+
+10.2.1 Adding Bindings
+
+   The REGISTER request sent to a registrar includes the contact
+   address(es) to which SIP requests for the address-of-record should be
+   forwarded.  The address-of-record is included in the To header field
+   of the REGISTER request.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 59]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The Contact header field values of the request typically consist of
+   SIP or SIPS URIs that identify particular SIP endpoints (for example,
+   "sip:carol@cube2214a.chicago.com"), but they MAY use any URI scheme.
+   A SIP UA can choose to register telephone numbers (with the tel URL,
+   RFC 2806 [9]) or email addresses (with a mailto URL, RFC 2368 [32])
+   as Contacts for an address-of-record, for example.
+
+   For example, Carol, with address-of-record "sip:carol@chicago.com",
+   would register with the SIP registrar of the domain chicago.com.  Her
+   registrations would then be used by a proxy server in the chicago.com
+   domain to route requests for Carol's address-of-record to her SIP
+   endpoint.
+
+   Once a client has established bindings at a registrar, it MAY send
+   subsequent registrations containing new bindings or modifications to
+   existing bindings as necessary.  The 2xx response to the REGISTER
+   request will contain, in a Contact header field, a complete list of
+   bindings that have been registered for this address-of-record at this
+   registrar.
+
+   If the address-of-record in the To header field of a REGISTER request
+   is a SIPS URI, then any Contact header field values in the request
+   SHOULD also be SIPS URIs.  Clients should only register non-SIPS URIs
+   under a SIPS address-of-record when the security of the resource
+   represented by the contact address is guaranteed by other means.
+   This may be applicable to URIs that invoke protocols other than SIP,
+   or SIP devices secured by protocols other than TLS.
+
+   Registrations do not need to update all bindings.  Typically, a UA
+   only updates its own contact addresses.
+
+10.2.1.1 Setting the Expiration Interval of Contact Addresses
+
+   When a client sends a REGISTER request, it MAY suggest an expiration
+   interval that indicates how long the client would like the
+   registration to be valid.  (As described in Section 10.3, the
+   registrar selects the actual time interval based on its local
+   policy.)
+
+   There are two ways in which a client can suggest an expiration
+   interval for a binding: through an Expires header field or an
+   "expires" Contact header parameter.  The latter allows expiration
+   intervals to be suggested on a per-binding basis when more than one
+   binding is given in a single REGISTER request, whereas the former
+   suggests an expiration interval for all Contact header field values
+   that do not contain the "expires" parameter.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 60]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If neither mechanism for expressing a suggested expiration time is
+   present in a REGISTER, the client is indicating its desire for the
+   server to choose.
+
+10.2.1.2 Preferences among Contact Addresses
+
+   If more than one Contact is sent in a REGISTER request, the
+   registering UA intends to associate all of the URIs in these Contact
+   header field values with the address-of-record present in the To
+   field.  This list can be prioritized with the "q" parameter in the
+   Contact header field.  The "q" parameter indicates a relative
+   preference for the particular Contact header field value compared to
+   other bindings for this address-of-record.  Section 16.6 describes
+   how a proxy server uses this preference indication.
+
+10.2.2 Removing Bindings
+
+   Registrations are soft state and expire unless refreshed, but can
+   also be explicitly removed.  A client can attempt to influence the
+   expiration interval selected by the registrar as described in Section
+   10.2.1.  A UA requests the immediate removal of a binding by
+   specifying an expiration interval of "0" for that contact address in
+   a REGISTER request.  UAs SHOULD support this mechanism so that
+   bindings can be removed before their expiration interval has passed.
+
+   The REGISTER-specific Contact header field value of "*" applies to
+   all registrations, but it MUST NOT be used unless the Expires header
+   field is present with a value of "0".
+
+      Use of the "*" Contact header field value allows a registering UA
+      to remove all bindings associated with an address-of-record
+      without knowing their precise values.
+
+10.2.3 Fetching Bindings
+
+   A success response to any REGISTER request contains the complete list
+   of existing bindings, regardless of whether the request contained a
+   Contact header field.  If no Contact header field is present in a
+   REGISTER request, the list of bindings is left unchanged.
+
+10.2.4 Refreshing Bindings
+
+   Each UA is responsible for refreshing the bindings that it has
+   previously established.  A UA SHOULD NOT refresh bindings set up by
+   other UAs.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 61]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The 200 (OK) response from the registrar contains a list of Contact
+   fields enumerating all current bindings.  The UA compares each
+   contact address to see if it created the contact address, using
+   comparison rules in Section 19.1.4.  If so, it updates the expiration
+   time interval according to the expires parameter or, if absent, the
+   Expires field value.  The UA then issues a REGISTER request for each
+   of its bindings before the expiration interval has elapsed.  It MAY
+   combine several updates into one REGISTER request.
+
+   A UA SHOULD use the same Call-ID for all registrations during a
+   single boot cycle.  Registration refreshes SHOULD be sent to the same
+   network address as the original registration, unless redirected.
+
+10.2.5 Setting the Internal Clock
+
+   If the response for a REGISTER request contains a Date header field,
+   the client MAY use this header field to learn the current time in
+   order to set any internal clocks.
+
+10.2.6 Discovering a Registrar
+
+   UAs can use three ways to determine the address to which to send
+   registrations:  by configuration, using the address-of-record, and
+   multicast.  A UA can be configured, in ways beyond the scope of this
+   specification, with a registrar address.  If there is no configured
+   registrar address, the UA SHOULD use the host part of the address-
+   of-record as the Request-URI and address the request there, using the
+   normal SIP server location mechanisms [4].  For example, the UA for
+   the user "sip:carol@chicago.com" addresses the REGISTER request to
+   "sip:chicago.com".
+
+   Finally, a UA can be configured to use multicast.  Multicast
+   registrations are addressed to the well-known "all SIP servers"
+   multicast address "sip.mcast.net" (224.0.1.75 for IPv4).  No well-
+   known IPv6 multicast address has been allocated; such an allocation
+   will be documented separately when needed.  SIP UAs MAY listen to
+   that address and use it to become aware of the location of other
+   local users (see [33]); however, they do not respond to the request.
+
+      Multicast registration may be inappropriate in some environments,
+      for example, if multiple businesses share the same local area
+      network.
+
+10.2.7 Transmitting a Request
+
+   Once the REGISTER method has been constructed, and the destination of
+   the message identified, UACs follow the procedures described in
+   Section 8.1.2 to hand off the REGISTER to the transaction layer.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 62]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If the transaction layer returns a timeout error because the REGISTER
+   yielded no response, the UAC SHOULD NOT immediately re-attempt a
+   registration to the same registrar.
+
+      An immediate re-attempt is likely to also timeout.  Waiting some
+      reasonable time interval for the conditions causing the timeout to
+      be corrected reduces unnecessary load on the network.  No specific
+      interval is mandated.
+
+10.2.8 Error Responses
+
+   If a UA receives a 423 (Interval Too Brief) response, it MAY retry
+   the registration after making the expiration interval of all contact
+   addresses in the REGISTER request equal to or greater than the
+   expiration interval within the Min-Expires header field of the 423
+   (Interval Too Brief) response.
+
+10.3 Processing REGISTER Requests
+
+   A registrar is a UAS that responds to REGISTER requests and maintains
+   a list of bindings that are accessible to proxy servers and redirect
+   servers within its administrative domain.  A registrar handles
+   requests according to Section 8.2 and Section 17.2, but it accepts
+   only REGISTER requests.  A registrar MUST not generate 6xx responses.
+
+   A registrar MAY redirect REGISTER requests as appropriate.  One
+   common usage would be for a registrar listening on a multicast
+   interface to redirect multicast REGISTER requests to its own unicast
+   interface with a 302 (Moved Temporarily) response.
+
+   Registrars MUST ignore the Record-Route header field if it is
+   included in a REGISTER request.  Registrars MUST NOT include a
+   Record-Route header field in any response to a REGISTER request.
+
+      A registrar might receive a request that traversed a proxy which
+      treats REGISTER as an unknown request and which added a Record-
+      Route header field value.
+
+   A registrar has to know (for example, through configuration) the set
+   of domain(s) for which it maintains bindings.  REGISTER requests MUST
+   be processed by a registrar in the order that they are received.
+   REGISTER requests MUST also be processed atomically, meaning that a
+   particular REGISTER request is either processed completely or not at
+   all.  Each REGISTER message MUST be processed independently of any
+   other registration or binding changes.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 63]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   When receiving a REGISTER request, a registrar follows these steps:
+
+      1. The registrar inspects the Request-URI to determine whether it
+         has access to bindings for the domain identified in the
+         Request-URI.  If not, and if the server also acts as a proxy
+         server, the server SHOULD forward the request to the addressed
+         domain, following the general behavior for proxying messages
+         described in Section 16.
+
+      2. To guarantee that the registrar supports any necessary
+         extensions, the registrar MUST process the Require header field
+         values as described for UASs in Section 8.2.2.
+
+      3. A registrar SHOULD authenticate the UAC.  Mechanisms for the
+         authentication of SIP user agents are described in Section 22.
+         Registration behavior in no way overrides the generic
+         authentication framework for SIP.  If no authentication
+         mechanism is available, the registrar MAY take the From address
+         as the asserted identity of the originator of the request.
+
+      4. The registrar SHOULD determine if the authenticated user is
+         authorized to modify registrations for this address-of-record.
+         For example, a registrar might consult an authorization
+         database that maps user names to a list of addresses-of-record
+         for which that user has authorization to modify bindings.  If
+         the authenticated user is not authorized to modify bindings,
+         the registrar MUST return a 403 (Forbidden) and skip the
+         remaining steps.
+
+         In architectures that support third-party registration, one
+         entity may be responsible for updating the registrations
+         associated with multiple addresses-of-record.
+
+      5. The registrar extracts the address-of-record from the To header
+         field of the request.  If the address-of-record is not valid
+         for the domain in the Request-URI, the registrar MUST send a
+         404 (Not Found) response and skip the remaining steps.  The URI
+         MUST then be converted to a canonical form.  To do that, all
+         URI parameters MUST be removed (including the user-param), and
+         any escaped characters MUST be converted to their unescaped
+         form.  The result serves as an index into the list of bindings.
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 64]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      6. The registrar checks whether the request contains the Contact
+         header field.  If not, it skips to the last step.  If the
+         Contact header field is present, the registrar checks if there
+         is one Contact field value that contains the special value "*"
+         and an Expires field.  If the request has additional Contact
+         fields or an expiration time other than zero, the request is
+         invalid, and the server MUST return a 400 (Invalid Request) and
+         skip the remaining steps.  If not, the registrar checks whether
+         the Call-ID agrees with the value stored for each binding.  If
+         not, it MUST remove the binding.  If it does agree, it MUST
+         remove the binding only if the CSeq in the request is higher
+         than the value stored for that binding.  Otherwise, the update
+         MUST be aborted and the request fails.
+
+      7. The registrar now processes each contact address in the Contact
+         header field in turn.  For each address, it determines the
+         expiration interval as follows:
+
+         -  If the field value has an "expires" parameter, that value
+            MUST be taken as the requested expiration.
+
+         -  If there is no such parameter, but the request has an
+            Expires header field, that value MUST be taken as the
+            requested expiration.
+
+         -  If there is neither, a locally-configured default value MUST
+            be taken as the requested expiration.
+
+         The registrar MAY choose an expiration less than the requested
+         expiration interval.  If and only if the requested expiration
+         interval is greater than zero AND smaller than one hour AND
+         less than a registrar-configured minimum, the registrar MAY
+         reject the registration with a response of 423 (Interval Too
+         Brief).  This response MUST contain a Min-Expires header field
+         that states the minimum expiration interval the registrar is
+         willing to honor.  It then skips the remaining steps.
+
+         Allowing the registrar to set the registration interval
+         protects it against excessively frequent registration refreshes
+         while limiting the state that it needs to maintain and
+         decreasing the likelihood of registrations going stale.  The
+         expiration interval of a registration is frequently used in the
+         creation of services.  An example is a follow-me service, where
+         the user may only be available at a terminal for a brief
+         period.  Therefore, registrars should accept brief
+         registrations; a request should only be rejected if the
+         interval is so short that the refreshes would degrade registrar
+         performance.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 65]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         For each address, the registrar then searches the list of
+         current bindings using the URI comparison rules.  If the
+         binding does not exist, it is tentatively added.  If the
+         binding does exist, the registrar checks the Call-ID value.  If
+         the Call-ID value in the existing binding differs from the
+         Call-ID value in the request, the binding MUST be removed if
+         the expiration time is zero and updated otherwise.  If they are
+         the same, the registrar compares the CSeq value.  If the value
+         is higher than that of the existing binding, it MUST update or
+         remove the binding as above.  If not, the update MUST be
+         aborted and the request fails.
+
+         This algorithm ensures that out-of-order requests from the same
+         UA are ignored.
+
+         Each binding record records the Call-ID and CSeq values from
+         the request.
+
+         The binding updates MUST be committed (that is, made visible to
+         the proxy or redirect server) if and only if all binding
+         updates and additions succeed.  If any one of them fails (for
+         example, because the back-end database commit failed), the
+         request MUST fail with a 500 (Server Error) response and all
+         tentative binding updates MUST be removed.
+
+      8. The registrar returns a 200 (OK) response.  The response MUST
+         contain Contact header field values enumerating all current
+         bindings.  Each Contact value MUST feature an "expires"
+         parameter indicating its expiration interval chosen by the
+         registrar.  The response SHOULD include a Date header field.
+
+11 Querying for Capabilities
+
+   The SIP method OPTIONS allows a UA to query another UA or a proxy
+   server as to its capabilities.  This allows a client to discover
+   information about the supported methods, content types, extensions,
+   codecs, etc. without "ringing" the other party.  For example, before
+   a client inserts a Require header field into an INVITE listing an
+   option that it is not certain the destination UAS supports, the
+   client can query the destination UAS with an OPTIONS to see if this
+   option is returned in a Supported header field.  All UAs MUST support
+   the OPTIONS method.
+
+   The target of the OPTIONS request is identified by the Request-URI,
+   which could identify another UA or a SIP server.  If the OPTIONS is
+   addressed to a proxy server, the Request-URI is set without a user
+   part, similar to the way a Request-URI is set for a REGISTER request.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 66]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Alternatively, a server receiving an OPTIONS request with a Max-
+   Forwards header field value of 0 MAY respond to the request
+   regardless of the Request-URI.
+
+      This behavior is common with HTTP/1.1.  This behavior can be used
+      as a "traceroute" functionality to check the capabilities of
+      individual hop servers by sending a series of OPTIONS requests
+      with incremented Max-Forwards values.
+
+   As is the case for general UA behavior, the transaction layer can
+   return a timeout error if the OPTIONS yields no response.  This may
+   indicate that the target is unreachable and hence unavailable.
+
+   An OPTIONS request MAY be sent as part of an established dialog to
+   query the peer on capabilities that may be utilized later in the
+   dialog.
+
+11.1 Construction of OPTIONS Request
+
+   An OPTIONS request is constructed using the standard rules for a SIP
+   request as discussed in Section 8.1.1.
+
+   A Contact header field MAY be present in an OPTIONS.
+
+   An Accept header field SHOULD be included to indicate the type of
+   message body the UAC wishes to receive in the response.  Typically,
+   this is set to a format that is used to describe the media
+   capabilities of a UA, such as SDP (application/sdp).
+
+   The response to an OPTIONS request is assumed to be scoped to the
+   Request-URI in the original request.  However, only when an OPTIONS
+   is sent as part of an established dialog is it guaranteed that future
+   requests will be received by the server that generated the OPTIONS
+   response.
+
+   Example OPTIONS request:
+
+      OPTIONS sip:carol@chicago.com SIP/2.0
+      Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKhjhs8ass877
+      Max-Forwards: 70
+      To: <sip:carol@chicago.com>
+      From: Alice <sip:alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710
+      CSeq: 63104 OPTIONS
+      Contact: <sip:alice@pc33.atlanta.com>
+      Accept: application/sdp
+      Content-Length: 0
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 67]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+11.2 Processing of OPTIONS Request
+
+   The response to an OPTIONS is constructed using the standard rules
+   for a SIP response as discussed in Section 8.2.6.  The response code
+   chosen MUST be the same that would have been chosen had the request
+   been an INVITE.  That is, a 200 (OK) would be returned if the UAS is
+   ready to accept a call, a 486 (Busy Here) would be returned if the
+   UAS is busy, etc.  This allows an OPTIONS request to be used to
+   determine the basic state of a UAS, which can be an indication of
+   whether the UAS will accept an INVITE request.
+
+   An OPTIONS request received within a dialog generates a 200 (OK)
+   response that is identical to one constructed outside a dialog and
+   does not have any impact on the dialog.
+
+   This use of OPTIONS has limitations due to the differences in proxy
+   handling of OPTIONS and INVITE requests.  While a forked INVITE can
+   result in multiple 200 (OK) responses being returned, a forked
+   OPTIONS will only result in a single 200 (OK) response, since it is
+   treated by proxies using the non-INVITE handling.  See Section 16.7
+   for the normative details.
+
+   If the response to an OPTIONS is generated by a proxy server, the
+   proxy returns a 200 (OK), listing the capabilities of the server.
+   The response does not contain a message body.
+
+   Allow, Accept, Accept-Encoding, Accept-Language, and Supported header
+   fields SHOULD be present in a 200 (OK) response to an OPTIONS
+   request.  If the response is generated by a proxy, the Allow header
+   field SHOULD be omitted as it is ambiguous since a proxy is method
+   agnostic.  Contact header fields MAY be present in a 200 (OK)
+   response and have the same semantics as in a 3xx response.  That is,
+   they may list a set of alternative names and methods of reaching the
+   user.  A Warning header field MAY be present.
+
+   A message body MAY be sent, the type of which is determined by the
+   Accept header field in the OPTIONS request (application/sdp is the
+   default if the Accept header field is not present).  If the types
+   include one that can describe media capabilities, the UAS SHOULD
+   include a body in the response for that purpose.  Details on the
+   construction of such a body in the case of application/sdp are
+   described in [13].
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 68]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example OPTIONS response generated by a UAS (corresponding to the
+   request in Section 11.1):
+
+      SIP/2.0 200 OK
+      Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKhjhs8ass877
+       ;received=192.0.2.4
+      To: <sip:carol@chicago.com>;tag=93810874
+      From: Alice <sip:alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710
+      CSeq: 63104 OPTIONS
+      Contact: <sip:carol@chicago.com>
+      Contact: <mailto:carol@chicago.com>
+      Allow: INVITE, ACK, CANCEL, OPTIONS, BYE
+      Accept: application/sdp
+      Accept-Encoding: gzip
+      Accept-Language: en
+      Supported: foo
+      Content-Type: application/sdp
+      Content-Length: 274
+
+      (SDP not shown)
+
+12 Dialogs
+
+   A key concept for a user agent is that of a dialog.  A dialog
+   represents a peer-to-peer SIP relationship between two user agents
+   that persists for some time.  The dialog facilitates sequencing of
+   messages between the user agents and proper routing of requests
+   between both of them.  The dialog represents a context in which to
+   interpret SIP messages.  Section 8 discussed method independent UA
+   processing for requests and responses outside of a dialog.  This
+   section discusses how those requests and responses are used to
+   construct a dialog, and then how subsequent requests and responses
+   are sent within a dialog.
+
+   A dialog is identified at each UA with a dialog ID, which consists of
+   a Call-ID value, a local tag and a remote tag.  The dialog ID at each
+   UA involved in the dialog is not the same.  Specifically, the local
+   tag at one UA is identical to the remote tag at the peer UA.  The
+   tags are opaque tokens that facilitate the generation of unique
+   dialog IDs.
+
+   A dialog ID is also associated with all responses and with any
+   request that contains a tag in the To field.  The rules for computing
+   the dialog ID of a message depend on whether the SIP element is a UAC
+   or UAS.  For a UAC, the Call-ID value of the dialog ID is set to the
+   Call-ID of the message, the remote tag is set to the tag in the To
+   field of the message, and the local tag is set to the tag in the From
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 69]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   field of the message (these rules apply to both requests and
+   responses).  As one would expect for a UAS, the Call-ID value of the
+   dialog ID is set to the Call-ID of the message, the remote tag is set
+   to the tag in the From field of the message, and the local tag is set
+   to the tag in the To field of the message.
+
+   A dialog contains certain pieces of state needed for further message
+   transmissions within the dialog.  This state consists of the dialog
+   ID, a local sequence number (used to order requests from the UA to
+   its peer), a remote sequence number (used to order requests from its
+   peer to the UA), a local URI, a remote URI, remote target, a boolean
+   flag called "secure", and a route set, which is an ordered list of
+   URIs.  The route set is the list of servers that need to be traversed
+   to send a request to the peer.  A dialog can also be in the "early"
+   state, which occurs when it is created with a provisional response,
+   and then transition to the "confirmed" state when a 2xx final
+   response arrives.  For other responses, or if no response arrives at
+   all on that dialog, the early dialog terminates.
+
+12.1 Creation of a Dialog
+
+   Dialogs are created through the generation of non-failure responses
+   to requests with specific methods.  Within this specification, only
+   2xx and 101-199 responses with a To tag, where the request was
+   INVITE, will establish a dialog.  A dialog established by a non-final
+   response to a request is in the "early" state and it is called an
+   early dialog.  Extensions MAY define other means for creating
+   dialogs.  Section 13 gives more details that are specific to the
+   INVITE method.  Here, we describe the process for creation of dialog
+   state that is not dependent on the method.
+
+   UAs MUST assign values to the dialog ID components as described
+   below.
+
+12.1.1 UAS behavior
+
+   When a UAS responds to a request with a response that establishes a
+   dialog (such as a 2xx to INVITE), the UAS MUST copy all Record-Route
+   header field values from the request into the response (including the
+   URIs, URI parameters, and any Record-Route header field parameters,
+   whether they are known or unknown to the UAS) and MUST maintain the
+   order of those values.  The UAS MUST add a Contact header field to
+   the response.  The Contact header field contains an address where the
+   UAS would like to be contacted for subsequent requests in the dialog
+   (which includes the ACK for a 2xx response in the case of an INVITE).
+   Generally, the host portion of this URI is the IP address or FQDN of
+   the host.  The URI provided in the Contact header field MUST be a SIP
+   or SIPS URI.  If the request that initiated the dialog contained a
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 70]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   SIPS URI in the Request-URI or in the top Record-Route header field
+   value, if there was any, or the Contact header field if there was no
+   Record-Route header field, the Contact header field in the response
+   MUST be a SIPS URI.  The URI SHOULD have global scope (that is, the
+   same URI can be used in messages outside this dialog).  The same way,
+   the scope of the URI in the Contact header field of the INVITE is not
+   limited to this dialog either.  It can therefore be used in messages
+   to the UAC even outside this dialog.
+
+   The UAS then constructs the state of the dialog.  This state MUST be
+   maintained for the duration of the dialog.
+
+   If the request arrived over TLS, and the Request-URI contained a SIPS
+   URI, the "secure" flag is set to TRUE.
+
+   The route set MUST be set to the list of URIs in the Record-Route
+   header field from the request, taken in order and preserving all URI
+   parameters.  If no Record-Route header field is present in the
+   request, the route set MUST be set to the empty set.  This route set,
+   even if empty, overrides any pre-existing route set for future
+   requests in this dialog.  The remote target MUST be set to the URI
+   from the Contact header field of the request.
+
+   The remote sequence number MUST be set to the value of the sequence
+   number in the CSeq header field of the request.  The local sequence
+   number MUST be empty.  The call identifier component of the dialog ID
+   MUST be set to the value of the Call-ID in the request.  The local
+   tag component of the dialog ID MUST be set to the tag in the To field
+   in the response to the request (which always includes a tag), and the
+   remote tag component of the dialog ID MUST be set to the tag from the
+   From field in the request.  A UAS MUST be prepared to receive a
+   request without a tag in the From field, in which case the tag is
+   considered to have a value of null.
+
+      This is to maintain backwards compatibility with RFC 2543, which
+      did not mandate From tags.
+
+   The remote URI MUST be set to the URI in the From field, and the
+   local URI MUST be set to the URI in the To field.
+
+12.1.2 UAC Behavior
+
+   When a UAC sends a request that can establish a dialog (such as an
+   INVITE) it MUST provide a SIP or SIPS URI with global scope (i.e.,
+   the same SIP URI can be used in messages outside this dialog) in the
+   Contact header field of the request.  If the request has a Request-
+   URI or a topmost Route header field value with a SIPS URI, the
+   Contact header field MUST contain a SIPS URI.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 71]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   When a UAC receives a response that establishes a dialog, it
+   constructs the state of the dialog.  This state MUST be maintained
+   for the duration of the dialog.
+
+   If the request was sent over TLS, and the Request-URI contained a
+   SIPS URI, the "secure" flag is set to TRUE.
+
+   The route set MUST be set to the list of URIs in the Record-Route
+   header field from the response, taken in reverse order and preserving
+   all URI parameters.  If no Record-Route header field is present in
+   the response, the route set MUST be set to the empty set.  This route
+   set, even if empty, overrides any pre-existing route set for future
+   requests in this dialog.  The remote target MUST be set to the URI
+   from the Contact header field of the response.
+
+   The local sequence number MUST be set to the value of the sequence
+   number in the CSeq header field of the request.  The remote sequence
+   number MUST be empty (it is established when the remote UA sends a
+   request within the dialog).  The call identifier component of the
+   dialog ID MUST be set to the value of the Call-ID in the request.
+   The local tag component of the dialog ID MUST be set to the tag in
+   the From field in the request, and the remote tag component of the
+   dialog ID MUST be set to the tag in the To field of the response.  A
+   UAC MUST be prepared to receive a response without a tag in the To
+   field, in which case the tag is considered to have a value of null.
+
+      This is to maintain backwards compatibility with RFC 2543, which
+      did not mandate To tags.
+
+   The remote URI MUST be set to the URI in the To field, and the local
+   URI MUST be set to the URI in the From field.
+
+12.2 Requests within a Dialog
+
+   Once a dialog has been established between two UAs, either of them
+   MAY initiate new transactions as needed within the dialog.  The UA
+   sending the request will take the UAC role for the transaction.  The
+   UA receiving the request will take the UAS role.  Note that these may
+   be different roles than the UAs held during the transaction that
+   established the dialog.
+
+   Requests within a dialog MAY contain Record-Route and Contact header
+   fields.  However, these requests do not cause the dialog's route set
+   to be modified, although they may modify the remote target URI.
+   Specifically, requests that are not target refresh requests do not
+   modify the dialog's remote target URI, and requests that are target
+   refresh requests do.  For dialogs that have been established with an
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 72]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   INVITE, the only target refresh request defined is re-INVITE (see
+   Section 14).  Other extensions may define different target refresh
+   requests for dialogs established in other ways.
+
+      Note that an ACK is NOT a target refresh request.
+
+   Target refresh requests only update the dialog's remote target URI,
+   and not the route set formed from the Record-Route.  Updating the
+   latter would introduce severe backwards compatibility problems with
+   RFC 2543-compliant systems.
+
+12.2.1 UAC Behavior
+
+12.2.1.1 Generating the Request
+
+   A request within a dialog is constructed by using many of the
+   components of the state stored as part of the dialog.
+
+   The URI in the To field of the request MUST be set to the remote URI
+   from the dialog state.  The tag in the To header field of the request
+   MUST be set to the remote tag of the dialog ID.  The From URI of the
+   request MUST be set to the local URI from the dialog state.  The tag
+   in the From header field of the request MUST be set to the local tag
+   of the dialog ID.  If the value of the remote or local tags is null,
+   the tag parameter MUST be omitted from the To or From header fields,
+   respectively.
+
+      Usage of the URI from the To and From fields in the original
+      request within subsequent requests is done for backwards
+      compatibility with RFC 2543, which used the URI for dialog
+      identification.  In this specification, only the tags are used for
+      dialog identification.  It is expected that mandatory reflection
+      of the original To and From URI in mid-dialog requests will be
+      deprecated in a subsequent revision of this specification.
+
+   The Call-ID of the request MUST be set to the Call-ID of the dialog.
+   Requests within a dialog MUST contain strictly monotonically
+   increasing and contiguous CSeq sequence numbers (increasing-by-one)
+   in each direction (excepting ACK and CANCEL of course, whose numbers
+   equal the requests being acknowledged or cancelled).  Therefore, if
+   the local sequence number is not empty, the value of the local
+   sequence number MUST be incremented by one, and this value MUST be
+   placed into the CSeq header field.  If the local sequence number is
+   empty, an initial value MUST be chosen using the guidelines of
+   Section 8.1.1.5.  The method field in the CSeq header field value
+   MUST match the method of the request.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 73]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      With a length of 32 bits, a client could generate, within a single
+      call, one request a second for about 136 years before needing to
+      wrap around.  The initial value of the sequence number is chosen
+      so that subsequent requests within the same call will not wrap
+      around.  A non-zero initial value allows clients to use a time-
+      based initial sequence number.  A client could, for example,
+      choose the 31 most significant bits of a 32-bit second clock as an
+      initial sequence number.
+
+   The UAC uses the remote target and route set to build the Request-URI
+   and Route header field of the request.
+
+   If the route set is empty, the UAC MUST place the remote target URI
+   into the Request-URI.  The UAC MUST NOT add a Route header field to
+   the request.
+
+   If the route set is not empty, and the first URI in the route set
+   contains the lr parameter (see Section 19.1.1), the UAC MUST place
+   the remote target URI into the Request-URI and MUST include a Route
+   header field containing the route set values in order, including all
+   parameters.
+
+   If the route set is not empty, and its first URI does not contain the
+   lr parameter, the UAC MUST place the first URI from the route set
+   into the Request-URI, stripping any parameters that are not allowed
+   in a Request-URI.  The UAC MUST add a Route header field containing
+   the remainder of the route set values in order, including all
+   parameters.  The UAC MUST then place the remote target URI into the
+   Route header field as the last value.
+
+   For example, if the remote target is sip:user@remoteua and the route
+   set contains:
+
+      <sip:proxy1>,<sip:proxy2>,<sip:proxy3;lr>,<sip:proxy4>
+
+   The request will be formed with the following Request-URI and Route
+   header field:
+
+   METHOD sip:proxy1
+   Route: <sip:proxy2>,<sip:proxy3;lr>,<sip:proxy4>,<sip:user@remoteua>
+
+      If the first URI of the route set does not contain the lr
+      parameter, the proxy indicated does not understand the routing
+      mechanisms described in this document and will act as specified in
+      RFC 2543, replacing the Request-URI with the first Route header
+      field value it receives while forwarding the message.  Placing the
+      Request-URI at the end of the Route header field preserves the
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 74]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      information in that Request-URI across the strict router (it will
+      be returned to the Request-URI when the request reaches a loose-
+      router).
+
+   A UAC SHOULD include a Contact header field in any target refresh
+   requests within a dialog, and unless there is a need to change it,
+   the URI SHOULD be the same as used in previous requests within the
+   dialog.  If the "secure" flag is true, that URI MUST be a SIPS URI.
+   As discussed in Section 12.2.2, a Contact header field in a target
+   refresh request updates the remote target URI.  This allows a UA to
+   provide a new contact address, should its address change during the
+   duration of the dialog.
+
+   However, requests that are not target refresh requests do not affect
+   the remote target URI for the dialog.
+
+   The rest of the request is formed as described in Section 8.1.1.
+
+   Once the request has been constructed, the address of the server is
+   computed and the request is sent, using the same procedures for
+   requests outside of a dialog (Section 8.1.2).
+
+      The procedures in Section 8.1.2 will normally result in the
+      request being sent to the address indicated by the topmost Route
+      header field value or the Request-URI if no Route header field is
+      present.  Subject to certain restrictions, they allow the request
+      to be sent to an alternate address (such as a default outbound
+      proxy not represented in the route set).
+
+12.2.1.2 Processing the Responses
+
+   The UAC will receive responses to the request from the transaction
+   layer.  If the client transaction returns a timeout, this is treated
+   as a 408 (Request Timeout) response.
+
+   The behavior of a UAC that receives a 3xx response for a request sent
+   within a dialog is the same as if the request had been sent outside a
+   dialog.  This behavior is described in Section 8.1.3.4.
+
+      Note, however, that when the UAC tries alternative locations, it
+      still uses the route set for the dialog to build the Route header
+      of the request.
+
+   When a UAC receives a 2xx response to a target refresh request, it
+   MUST replace the dialog's remote target URI with the URI from the
+   Contact header field in that response, if present.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 75]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If the response for a request within a dialog is a 481
+   (Call/Transaction Does Not Exist) or a 408 (Request Timeout), the UAC
+   SHOULD terminate the dialog.  A UAC SHOULD also terminate a dialog if
+   no response at all is received for the request (the client
+   transaction would inform the TU about the timeout.)
+
+      For INVITE initiated dialogs, terminating the dialog consists of
+      sending a BYE.
+
+12.2.2 UAS Behavior
+
+   Requests sent within a dialog, as any other requests, are atomic.  If
+   a particular request is accepted by the UAS, all the state changes
+   associated with it are performed.  If the request is rejected, none
+   of the state changes are performed.
+
+      Note that some requests, such as INVITEs, affect several pieces of
+      state.
+
+   The UAS will receive the request from the transaction layer.  If the
+   request has a tag in the To header field, the UAS core computes the
+   dialog identifier corresponding to the request and compares it with
+   existing dialogs.  If there is a match, this is a mid-dialog request.
+   In that case, the UAS first applies the same processing rules for
+   requests outside of a dialog, discussed in Section 8.2.
+
+   If the request has a tag in the To header field, but the dialog
+   identifier does not match any existing dialogs, the UAS may have
+   crashed and restarted, or it may have received a request for a
+   different (possibly failed) UAS (the UASs can construct the To tags
+   so that a UAS can identify that the tag was for a UAS for which it is
+   providing recovery).  Another possibility is that the incoming
+   request has been simply misrouted.  Based on the To tag, the UAS MAY
+   either accept or reject the request.  Accepting the request for
+   acceptable To tags provides robustness, so that dialogs can persist
+   even through crashes.  UAs wishing to support this capability must
+   take into consideration some issues such as choosing monotonically
+   increasing CSeq sequence numbers even across reboots, reconstructing
+   the route set, and accepting out-of-range RTP timestamps and sequence
+   numbers.
+
+   If the UAS wishes to reject the request because it does not wish to
+   recreate the dialog, it MUST respond to the request with a 481
+   (Call/Transaction Does Not Exist) status code and pass that to the
+   server transaction.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 76]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Requests that do not change in any way the state of a dialog may be
+   received within a dialog (for example, an OPTIONS request).  They are
+   processed as if they had been received outside the dialog.
+
+   If the remote sequence number is empty, it MUST be set to the value
+   of the sequence number in the CSeq header field value in the request.
+   If the remote sequence number was not empty, but the sequence number
+   of the request is lower than the remote sequence number, the request
+   is out of order and MUST be rejected with a 500 (Server Internal
+   Error) response.  If the remote sequence number was not empty, and
+   the sequence number of the request is greater than the remote
+   sequence number, the request is in order.  It is possible for the
+   CSeq sequence number to be higher than the remote sequence number by
+   more than one.  This is not an error condition, and a UAS SHOULD be
+   prepared to receive and process requests with CSeq values more than
+   one higher than the previous received request.  The UAS MUST then set
+   the remote sequence number to the value of the sequence number in the
+   CSeq header field value in the request.
+
+      If a proxy challenges a request generated by the UAC, the UAC has
+      to resubmit the request with credentials.  The resubmitted request
+      will have a new CSeq number.  The UAS will never see the first
+      request, and thus, it will notice a gap in the CSeq number space.
+      Such a gap does not represent any error condition.
+
+   When a UAS receives a target refresh request, it MUST replace the
+   dialog's remote target URI with the URI from the Contact header field
+   in that request, if present.
+
+12.3 Termination of a Dialog
+
+   Independent of the method, if a request outside of a dialog generates
+   a non-2xx final response, any early dialogs created through
+   provisional responses to that request are terminated.  The mechanism
+   for terminating confirmed dialogs is method specific.  In this
+   specification, the BYE method terminates a session and the dialog
+   associated with it.  See Section 15 for details.
+
+13 Initiating a Session
+
+13.1 Overview
+
+   When a user agent client desires to initiate a session (for example,
+   audio, video, or a game), it formulates an INVITE request.  The
+   INVITE request asks a server to establish a session.  This request
+   may be forwarded by proxies, eventually arriving at one or more UAS
+   that can potentially accept the invitation.  These UASs will
+   frequently need to query the user about whether to accept the
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 77]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   invitation.  After some time, those UASs can accept the invitation
+   (meaning the session is to be established) by sending a 2xx response.
+   If the invitation is not accepted, a 3xx, 4xx, 5xx or 6xx response is
+   sent, depending on the reason for the rejection.  Before sending a
+   final response, the UAS can also send provisional responses (1xx) to
+   advise the UAC of progress in contacting the called user.
+
+   After possibly receiving one or more provisional responses, the UAC
+   will get one or more 2xx responses or one non-2xx final response.
+   Because of the protracted amount of time it can take to receive final
+   responses to INVITE, the reliability mechanisms for INVITE
+   transactions differ from those of other requests (like OPTIONS).
+   Once it receives a final response, the UAC needs to send an ACK for
+   every final response it receives.  The procedure for sending this ACK
+   depends on the type of response.  For final responses between 300 and
+   699, the ACK processing is done in the transaction layer and follows
+   one set of rules (See Section 17).  For 2xx responses, the ACK is
+   generated by the UAC core.
+
+   A 2xx response to an INVITE establishes a session, and it also
+   creates a dialog between the UA that issued the INVITE and the UA
+   that generated the 2xx response.  Therefore, when multiple 2xx
+   responses are received from different remote UAs (because the INVITE
+   forked), each 2xx establishes a different dialog.  All these dialogs
+   are part of the same call.
+
+   This section provides details on the establishment of a session using
+   INVITE.  A UA that supports INVITE MUST also support ACK, CANCEL and
+   BYE.
+
+13.2 UAC Processing
+
+13.2.1 Creating the Initial INVITE
+
+   Since the initial INVITE represents a request outside of a dialog,
+   its construction follows the procedures of Section 8.1.1.  Additional
+   processing is required for the specific case of INVITE.
+
+   An Allow header field (Section 20.5) SHOULD be present in the INVITE.
+   It indicates what methods can be invoked within a dialog, on the UA
+   sending the INVITE, for the duration of the dialog.  For example, a
+   UA capable of receiving INFO requests within a dialog [34] SHOULD
+   include an Allow header field listing the INFO method.
+
+   A Supported header field (Section 20.37) SHOULD be present in the
+   INVITE.  It enumerates all the extensions understood by the UAC.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 78]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   An Accept (Section 20.1) header field MAY be present in the INVITE.
+   It indicates which Content-Types are acceptable to the UA, in both
+   the response received by it, and in any subsequent requests sent to
+   it within dialogs established by the INVITE.  The Accept header field
+   is especially useful for indicating support of various session
+   description formats.
+
+   The UAC MAY add an Expires header field (Section 20.19) to limit the
+   validity of the invitation.  If the time indicated in the Expires
+   header field is reached and no final answer for the INVITE has been
+   received, the UAC core SHOULD generate a CANCEL request for the
+   INVITE, as per Section 9.
+
+   A UAC MAY also find it useful to add, among others, Subject (Section
+   20.36), Organization (Section 20.25) and User-Agent (Section 20.41)
+   header fields.  They all contain information related to the INVITE.
+
+   The UAC MAY choose to add a message body to the INVITE.  Section
+   8.1.1.10 deals with how to construct the header fields -- Content-
+   Type among others -- needed to describe the message body.
+
+   There are special rules for message bodies that contain a session
+   description - their corresponding Content-Disposition is "session".
+   SIP uses an offer/answer model where one UA sends a session
+   description, called the offer, which contains a proposed description
+   of the session.  The offer indicates the desired communications means
+   (audio, video, games), parameters of those means (such as codec
+   types) and addresses for receiving media from the answerer.  The
+   other UA responds with another session description, called the
+   answer, which indicates which communications means are accepted, the
+   parameters that apply to those means, and addresses for receiving
+   media from the offerer. An offer/answer exchange is within the
+   context of a dialog, so that if a SIP INVITE results in multiple
+   dialogs, each is a separate offer/answer exchange.  The offer/answer
+   model defines restrictions on when offers and answers can be made
+   (for example, you cannot make a new offer while one is in progress).
+   This results in restrictions on where the offers and answers can
+   appear in SIP messages.  In this specification, offers and answers
+   can only appear in INVITE requests and responses, and ACK.  The usage
+   of offers and answers is further restricted.  For the initial INVITE
+   transaction, the rules are:
+
+      o  The initial offer MUST be in either an INVITE or, if not there,
+         in the first reliable non-failure message from the UAS back to
+         the UAC.  In this specification, that is the final 2xx
+         response.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 79]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      o  If the initial offer is in an INVITE, the answer MUST be in a
+         reliable non-failure message from UAS back to UAC which is
+         correlated to that INVITE.  For this specification, that is
+         only the final 2xx response to that INVITE.  That same exact
+         answer MAY also be placed in any provisional responses sent
+         prior to the answer.  The UAC MUST treat the first session
+         description it receives as the answer, and MUST ignore any
+         session descriptions in subsequent responses to the initial
+         INVITE.
+
+      o  If the initial offer is in the first reliable non-failure
+         message from the UAS back to UAC, the answer MUST be in the
+         acknowledgement for that message (in this specification, ACK
+         for a 2xx response).
+
+      o  After having sent or received an answer to the first offer, the
+         UAC MAY generate subsequent offers in requests based on rules
+         specified for that method, but only if it has received answers
+         to any previous offers, and has not sent any offers to which it
+         hasn't gotten an answer.
+
+      o  Once the UAS has sent or received an answer to the initial
+         offer, it MUST NOT generate subsequent offers in any responses
+         to the initial INVITE.  This means that a UAS based on this
+         specification alone can never generate subsequent offers until
+         completion of the initial transaction.
+
+   Concretely, the above rules specify two exchanges for UAs compliant
+   to this specification alone - the offer is in the INVITE, and the
+   answer in the 2xx (and possibly in a 1xx as well, with the same
+   value), or the offer is in the 2xx, and the answer is in the ACK.
+   All user agents that support INVITE MUST support these two exchanges.
+
+   The Session Description Protocol (SDP) (RFC 2327 [1]) MUST be
+   supported by all user agents as a means to describe sessions, and its
+   usage for constructing offers and answers MUST follow the procedures
+   defined in [13].
+
+   The restrictions of the offer-answer model just described only apply
+   to bodies whose Content-Disposition header field value is "session".
+   Therefore, it is possible that both the INVITE and the ACK contain a
+   body message (for example, the INVITE carries a photo (Content-
+   Disposition: render) and the ACK a session description (Content-
+   Disposition: session)).
+
+   If the Content-Disposition header field is missing, bodies of
+   Content-Type application/sdp imply the disposition "session", while
+   other content types imply "render".
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 80]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Once the INVITE has been created, the UAC follows the procedures
+   defined for sending requests outside of a dialog (Section 8).  This
+   results in the construction of a client transaction that will
+   ultimately send the request and deliver responses to the UAC.
+
+13.2.2 Processing INVITE Responses
+
+   Once the INVITE has been passed to the INVITE client transaction, the
+   UAC waits for responses for the INVITE.  If the INVITE client
+   transaction returns a timeout rather than a response the TU acts as
+   if a 408 (Request Timeout) response had been received, as described
+   in Section 8.1.3.
+
+13.2.2.1 1xx Responses
+
+   Zero, one or multiple provisional responses may arrive before one or
+   more final responses are received.  Provisional responses for an
+   INVITE request can create "early dialogs".  If a provisional response
+   has a tag in the To field, and if the dialog ID of the response does
+   not match an existing dialog, one is constructed using the procedures
+   defined in Section 12.1.2.
+
+   The early dialog will only be needed if the UAC needs to send a
+   request to its peer within the dialog before the initial INVITE
+   transaction completes.  Header fields present in a provisional
+   response are applicable as long as the dialog is in the early state
+   (for example, an Allow header field in a provisional response
+   contains the methods that can be used in the dialog while this is in
+   the early state).
+
+13.2.2.2 3xx Responses
+
+   A 3xx response may contain one or more Contact header field values
+   providing new addresses where the callee might be reachable.
+   Depending on the status code of the 3xx response (see Section 21.3),
+   the UAC MAY choose to try those new addresses.
+
+13.2.2.3 4xx, 5xx and 6xx Responses
+
+   A single non-2xx final response may be received for the INVITE.  4xx,
+   5xx and 6xx responses may contain a Contact header field value
+   indicating the location where additional information about the error
+   can be found.  Subsequent final responses (which would only arrive
+   under error conditions) MUST be ignored.
+
+   All early dialogs are considered terminated upon reception of the
+   non-2xx final response.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 81]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   After having received the non-2xx final response the UAC core
+   considers the INVITE transaction completed.  The INVITE client
+   transaction handles the generation of ACKs for the response (see
+   Section 17).
+
+13.2.2.4 2xx Responses
+
+   Multiple 2xx responses may arrive at the UAC for a single INVITE
+   request due to a forking proxy.  Each response is distinguished by
+   the tag parameter in the To header field, and each represents a
+   distinct dialog, with a distinct dialog identifier.
+
+   If the dialog identifier in the 2xx response matches the dialog
+   identifier of an existing dialog, the dialog MUST be transitioned to
+   the "confirmed" state, and the route set for the dialog MUST be
+   recomputed based on the 2xx response using the procedures of Section
+   12.2.1.2.  Otherwise, a new dialog in the "confirmed" state MUST be
+   constructed using the procedures of Section 12.1.2.
+
+      Note that the only piece of state that is recomputed is the route
+      set.  Other pieces of state such as the highest sequence numbers
+      (remote and local) sent within the dialog are not recomputed.  The
+      route set only is recomputed for backwards compatibility.  RFC
+      2543 did not mandate mirroring of the Record-Route header field in
+      a 1xx, only 2xx.  However, we cannot update the entire state of
+      the dialog, since mid-dialog requests may have been sent within
+      the early dialog, modifying the sequence numbers, for example.
+
+   The UAC core MUST generate an ACK request for each 2xx received from
+   the transaction layer.  The header fields of the ACK are constructed
+   in the same way as for any request sent within a dialog (see Section
+   12) with the exception of the CSeq and the header fields related to
+   authentication.  The sequence number of the CSeq header field MUST be
+   the same as the INVITE being acknowledged, but the CSeq method MUST
+   be ACK.  The ACK MUST contain the same credentials as the INVITE.  If
+   the 2xx contains an offer (based on the rules above), the ACK MUST
+   carry an answer in its body.  If the offer in the 2xx response is not
+   acceptable, the UAC core MUST generate a valid answer in the ACK and
+   then send a BYE immediately.
+
+   Once the ACK has been constructed, the procedures of [4] are used to
+   determine the destination address, port and transport.  However, the
+   request is passed to the transport layer directly for transmission,
+   rather than a client transaction.  This is because the UAC core
+   handles retransmissions of the ACK, not the transaction layer.  The
+   ACK MUST be passed to the client transport every time a
+   retransmission of the 2xx final response that triggered the ACK
+   arrives.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 82]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The UAC core considers the INVITE transaction completed 64*T1 seconds
+   after the reception of the first 2xx response.  At this point all the
+   early dialogs that have not transitioned to established dialogs are
+   terminated.  Once the INVITE transaction is considered completed by
+   the UAC core, no more new 2xx responses are expected to arrive.
+
+   If, after acknowledging any 2xx response to an INVITE, the UAC does
+   not want to continue with that dialog, then the UAC MUST terminate
+   the dialog by sending a BYE request as described in Section 15.
+
+13.3 UAS Processing
+
+13.3.1 Processing of the INVITE
+
+   The UAS core will receive INVITE requests from the transaction layer.
+   It first performs the request processing procedures of Section 8.2,
+   which are applied for both requests inside and outside of a dialog.
+
+   Assuming these processing states are completed without generating a
+   response, the UAS core performs the additional processing steps:
+
+      1. If the request is an INVITE that contains an Expires header
+         field, the UAS core sets a timer for the number of seconds
+         indicated in the header field value.  When the timer fires, the
+         invitation is considered to be expired.  If the invitation
+         expires before the UAS has generated a final response, a 487
+         (Request Terminated) response SHOULD be generated.
+
+      2. If the request is a mid-dialog request, the method-independent
+         processing described in Section 12.2.2 is first applied.  It
+         might also modify the session; Section 14 provides details.
+
+      3. If the request has a tag in the To header field but the dialog
+         identifier does not match any of the existing dialogs, the UAS
+         may have crashed and restarted, or may have received a request
+         for a different (possibly failed) UAS.  Section 12.2.2 provides
+         guidelines to achieve a robust behavior under such a situation.
+
+   Processing from here forward assumes that the INVITE is outside of a
+   dialog, and is thus for the purposes of establishing a new session.
+
+   The INVITE may contain a session description, in which case the UAS
+   is being presented with an offer for that session.  It is possible
+   that the user is already a participant in that session, even though
+   the INVITE is outside of a dialog.  This can happen when a user is
+   invited to the same multicast conference by multiple other
+   participants.  If desired, the UAS MAY use identifiers within the
+   session description to detect this duplication.  For example, SDP
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 83]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   contains a session id and version number in the origin (o) field.  If
+   the user is already a member of the session, and the session
+   parameters contained in the session description have not changed, the
+   UAS MAY silently accept the INVITE (that is, send a 2xx response
+   without prompting the user).
+
+   If the INVITE does not contain a session description, the UAS is
+   being asked to participate in a session, and the UAC has asked that
+   the UAS provide the offer of the session.  It MUST provide the offer
+   in its first non-failure reliable message back to the UAC.  In this
+   specification, that is a 2xx response to the INVITE.
+
+   The UAS can indicate progress, accept, redirect, or reject the
+   invitation.  In all of these cases, it formulates a response using
+   the procedures described in Section 8.2.6.
+
+13.3.1.1 Progress
+
+   If the UAS is not able to answer the invitation immediately, it can
+   choose to indicate some kind of progress to the UAC (for example, an
+   indication that a phone is ringing).  This is accomplished with a
+   provisional response between 101 and 199.  These provisional
+   responses establish early dialogs and therefore follow the procedures
+   of Section 12.1.1 in addition to those of Section 8.2.6.  A UAS MAY
+   send as many provisional responses as it likes.  Each of these MUST
+   indicate the same dialog ID.  However, these will not be delivered
+   reliably.
+
+   If the UAS desires an extended period of time to answer the INVITE,
+   it will need to ask for an "extension" in order to prevent proxies
+   from canceling the transaction.  A proxy has the option of canceling
+   a transaction when there is a gap of 3 minutes between responses in a
+   transaction.  To prevent cancellation, the UAS MUST send a non-100
+   provisional response at every minute, to handle the possibility of
+   lost provisional responses.
+
+      An INVITE transaction can go on for extended durations when the
+      user is placed on hold, or when interworking with PSTN systems
+      which allow communications to take place without answering the
+      call.  The latter is common in Interactive Voice Response (IVR)
+      systems.
+
+13.3.1.2 The INVITE is Redirected
+
+   If the UAS decides to redirect the call, a 3xx response is sent.  A
+   300 (Multiple Choices), 301 (Moved Permanently) or 302 (Moved
+   Temporarily) response SHOULD contain a Contact header field
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 84]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   containing one or more URIs of new addresses to be tried.  The
+   response is passed to the INVITE server transaction, which will deal
+   with its retransmissions.
+
+13.3.1.3 The INVITE is Rejected
+
+   A common scenario occurs when the callee is currently not willing or
+   able to take additional calls at this end system.  A 486 (Busy Here)
+   SHOULD be returned in such a scenario.  If the UAS knows that no
+   other end system will be able to accept this call, a 600 (Busy
+   Everywhere) response SHOULD be sent instead.  However, it is unlikely
+   that a UAS will be able to know this in general, and thus this
+   response will not usually be used.  The response is passed to the
+   INVITE server transaction, which will deal with its retransmissions.
+
+   A UAS rejecting an offer contained in an INVITE SHOULD return a 488
+   (Not Acceptable Here) response.  Such a response SHOULD include a
+   Warning header field value explaining why the offer was rejected.
+
+13.3.1.4 The INVITE is Accepted
+
+   The UAS core generates a 2xx response.  This response establishes a
+   dialog, and therefore follows the procedures of Section 12.1.1 in
+   addition to those of Section 8.2.6.
+
+   A 2xx response to an INVITE SHOULD contain the Allow header field and
+   the Supported header field, and MAY contain the Accept header field.
+   Including these header fields allows the UAC to determine the
+   features and extensions supported by the UAS for the duration of the
+   call, without probing.
+
+   If the INVITE request contained an offer, and the UAS had not yet
+   sent an answer, the 2xx MUST contain an answer.  If the INVITE did
+   not contain an offer, the 2xx MUST contain an offer if the UAS had
+   not yet sent an offer.
+
+   Once the response has been constructed, it is passed to the INVITE
+   server transaction.  Note, however, that the INVITE server
+   transaction will be destroyed as soon as it receives this final
+   response and passes it to the transport.  Therefore, it is necessary
+   to periodically pass the response directly to the transport until the
+   ACK arrives.  The 2xx response is passed to the transport with an
+   interval that starts at T1 seconds and doubles for each
+   retransmission until it reaches T2 seconds (T1 and T2 are defined in
+   Section 17).  Response retransmissions cease when an ACK request for
+   the response is received.  This is independent of whatever transport
+   protocols are used to send the response.
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 85]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Since 2xx is retransmitted end-to-end, there may be hops between
+      UAS and UAC that are UDP.  To ensure reliable delivery across
+      these hops, the response is retransmitted periodically even if the
+      transport at the UAS is reliable.
+
+   If the server retransmits the 2xx response for 64*T1 seconds without
+   receiving an ACK, the dialog is confirmed, but the session SHOULD be
+   terminated.  This is accomplished with a BYE, as described in Section
+   15.
+
+14 Modifying an Existing Session
+
+   A successful INVITE request (see Section 13) establishes both a
+   dialog between two user agents and a session using the offer-answer
+   model.  Section 12 explains how to modify an existing dialog using a
+   target refresh request (for example, changing the remote target URI
+   of the dialog).  This section describes how to modify the actual
+   session.  This modification can involve changing addresses or ports,
+   adding a media stream, deleting a media stream, and so on.  This is
+   accomplished by sending a new INVITE request within the same dialog
+   that established the session.  An INVITE request sent within an
+   existing dialog is known as a re-INVITE.
+
+      Note that a single re-INVITE can modify the dialog and the
+      parameters of the session at the same time.
+
+   Either the caller or callee can modify an existing session.
+
+   The behavior of a UA on detection of media failure is a matter of
+   local policy.  However, automated generation of re-INVITE or BYE is
+   NOT RECOMMENDED to avoid flooding the network with traffic when there
+   is congestion.  In any case, if these messages are sent
+   automatically, they SHOULD be sent after some randomized interval.
+
+      Note that the paragraph above refers to automatically generated
+      BYEs and re-INVITEs.  If the user hangs up upon media failure, the
+      UA would send a BYE request as usual.
+
+14.1 UAC Behavior
+
+   The same offer-answer model that applies to session descriptions in
+   INVITEs (Section 13.2.1) applies to re-INVITEs.  As a result, a UAC
+   that wants to add a media stream, for example, will create a new
+   offer that contains this media stream, and send that in an INVITE
+   request to its peer.  It is important to note that the full
+   description of the session, not just the change, is sent.  This
+   supports stateless session processing in various elements, and
+   supports failover and recovery capabilities.  Of course, a UAC MAY
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 86]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   send a re-INVITE with no session description, in which case the first
+   reliable non-failure response to the re-INVITE will contain the offer
+   (in this specification, that is a 2xx response).
+
+   If the session description format has the capability for version
+   numbers, the offerer SHOULD indicate that the version of the session
+   description has changed.
+
+   The To, From, Call-ID, CSeq, and Request-URI of a re-INVITE are set
+   following the same rules as for regular requests within an existing
+   dialog, described in Section 12.
+
+   A UAC MAY choose not to add an Alert-Info header field or a body with
+   Content-Disposition "alert" to re-INVITEs because UASs do not
+   typically alert the user upon reception of a re-INVITE.
+
+   Unlike an INVITE, which can fork, a re-INVITE will never fork, and
+   therefore, only ever generate a single final response.  The reason a
+   re-INVITE will never fork is that the Request-URI identifies the
+   target as the UA instance it established the dialog with, rather than
+   identifying an address-of-record for the user.
+
+   Note that a UAC MUST NOT initiate a new INVITE transaction within a
+   dialog while another INVITE transaction is in progress in either
+   direction.
+
+      1. If there is an ongoing INVITE client transaction, the TU MUST
+         wait until the transaction reaches the completed or terminated
+         state before initiating the new INVITE.
+
+      2. If there is an ongoing INVITE server transaction, the TU MUST
+         wait until the transaction reaches the confirmed or terminated
+         state before initiating the new INVITE.
+
+   However, a UA MAY initiate a regular transaction while an INVITE
+   transaction is in progress.  A UA MAY also initiate an INVITE
+   transaction while a regular transaction is in progress.
+
+   If a UA receives a non-2xx final response to a re-INVITE, the session
+   parameters MUST remain unchanged, as if no re-INVITE had been issued.
+   Note that, as stated in Section 12.2.1.2, if the non-2xx final
+   response is a 481 (Call/Transaction Does Not Exist), or a 408
+   (Request Timeout), or no response at all is received for the re-
+   INVITE (that is, a timeout is returned by the INVITE client
+   transaction), the UAC will terminate the dialog.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 87]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If a UAC receives a 491 response to a re-INVITE, it SHOULD start a
+   timer with a value T chosen as follows:
+
+      1. If the UAC is the owner of the Call-ID of the dialog ID
+         (meaning it generated the value), T has a randomly chosen value
+         between 2.1 and 4 seconds in units of 10 ms.
+
+      2. If the UAC is not the owner of the Call-ID of the dialog ID, T
+         has a randomly chosen value of between 0 and 2 seconds in units
+         of 10 ms.
+
+   When the timer fires, the UAC SHOULD attempt the re-INVITE once more,
+   if it still desires for that session modification to take place.  For
+   example, if the call was already hung up with a BYE, the re-INVITE
+   would not take place.
+
+   The rules for transmitting a re-INVITE and for generating an ACK for
+   a 2xx response to re-INVITE are the same as for the initial INVITE
+   (Section 13.2.1).
+
+14.2 UAS Behavior
+
+   Section 13.3.1 describes the procedure for distinguishing incoming
+   re-INVITEs from incoming initial INVITEs and handling a re-INVITE for
+   an existing dialog.
+
+   A UAS that receives a second INVITE before it sends the final
+   response to a first INVITE with a lower CSeq sequence number on the
+   same dialog MUST return a 500 (Server Internal Error) response to the
+   second INVITE and MUST include a Retry-After header field with a
+   randomly chosen value of between 0 and 10 seconds.
+
+   A UAS that receives an INVITE on a dialog while an INVITE it had sent
+   on that dialog is in progress MUST return a 491 (Request Pending)
+   response to the received INVITE.
+
+   If a UA receives a re-INVITE for an existing dialog, it MUST check
+   any version identifiers in the session description or, if there are
+   no version identifiers, the content of the session description to see
+   if it has changed.  If the session description has changed, the UAS
+   MUST adjust the session parameters accordingly, possibly after asking
+   the user for confirmation.
+
+      Versioning of the session description can be used to accommodate
+      the capabilities of new arrivals to a conference, add or delete
+      media, or change from a unicast to a multicast conference.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 88]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If the new session description is not acceptable, the UAS can reject
+   it by returning a 488 (Not Acceptable Here) response for the re-
+   INVITE.  This response SHOULD include a Warning header field.
+
+   If a UAS generates a 2xx response and never receives an ACK, it
+   SHOULD generate a BYE to terminate the dialog.
+
+   A UAS MAY choose not to generate 180 (Ringing) responses for a re-
+   INVITE because UACs do not typically render this information to the
+   user.  For the same reason, UASs MAY choose not to use an Alert-Info
+   header field or a body with Content-Disposition "alert" in responses
+   to a re-INVITE.
+
+   A UAS providing an offer in a 2xx (because the INVITE did not contain
+   an offer) SHOULD construct the offer as if the UAS were making a
+   brand new call, subject to the constraints of sending an offer that
+   updates an existing session, as described in [13] in the case of SDP.
+   Specifically, this means that it SHOULD include as many media formats
+   and media types that the UA is willing to support.  The UAS MUST
+   ensure that the session description overlaps with its previous
+   session description in media formats, transports, or other parameters
+   that require support from the peer.  This is to avoid the need for
+   the peer to reject the session description.  If, however, it is
+   unacceptable to the UAC, the UAC SHOULD generate an answer with a
+   valid session description, and then send a BYE to terminate the
+   session.
+
+15 Terminating a Session
+
+   This section describes the procedures for terminating a session
+   established by SIP.  The state of the session and the state of the
+   dialog are very closely related.  When a session is initiated with an
+   INVITE, each 1xx or 2xx response from a distinct UAS creates a
+   dialog, and if that response completes the offer/answer exchange, it
+   also creates a session.  As a result, each session is "associated"
+   with a single dialog - the one which resulted in its creation.  If an
+   initial INVITE generates a non-2xx final response, that terminates
+   all sessions (if any) and all dialogs (if any) that were created
+   through responses to the request.  By virtue of completing the
+   transaction, a non-2xx final response also prevents further sessions
+   from being created as a result of the INVITE.  The BYE request is
+   used to terminate a specific session or attempted session.  In this
+   case, the specific session is the one with the peer UA on the other
+   side of the dialog.  When a BYE is received on a dialog, any session
+   associated with that dialog SHOULD terminate.  A UA MUST NOT send a
+   BYE outside of a dialog.  The caller's UA MAY send a BYE for either
+   confirmed or early dialogs, and the callee's UA MAY send a BYE on
+   confirmed dialogs, but MUST NOT send a BYE on early dialogs.
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 89]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   However, the callee's UA MUST NOT send a BYE on a confirmed dialog
+   until it has received an ACK for its 2xx response or until the server
+   transaction times out.  If no SIP extensions have defined other
+   application layer states associated with the dialog, the BYE also
+   terminates the dialog.
+
+   The impact of a non-2xx final response to INVITE on dialogs and
+   sessions makes the use of CANCEL attractive.  The CANCEL attempts to
+   force a non-2xx response to the INVITE (in particular, a 487).
+   Therefore, if a UAC wishes to give up on its call attempt entirely,
+   it can send a CANCEL.  If the INVITE results in 2xx final response(s)
+   to the INVITE, this means that a UAS accepted the invitation while
+   the CANCEL was in progress.  The UAC MAY continue with the sessions
+   established by any 2xx responses, or MAY terminate them with BYE.
+
+      The notion of "hanging up" is not well defined within SIP.  It is
+      specific to a particular, albeit common, user interface.
+      Typically, when the user hangs up, it indicates a desire to
+      terminate the attempt to establish a session, and to terminate any
+      sessions already created.  For the caller's UA, this would imply a
+      CANCEL request if the initial INVITE has not generated a final
+      response, and a BYE to all confirmed dialogs after a final
+      response.  For the callee's UA, it would typically imply a BYE;
+      presumably, when the user picked up the phone, a 2xx was
+      generated, and so hanging up would result in a BYE after the ACK
+      is received.  This does not mean a user cannot hang up before
+      receipt of the ACK, it just means that the software in his phone
+      needs to maintain state for a short while in order to clean up
+      properly.  If the particular UI allows for the user to reject a
+      call before its answered, a 403 (Forbidden) is a good way to
+      express that.  As per the rules above, a BYE can't be sent.
+
+15.1 Terminating a Session with a BYE Request
+
+15.1.1 UAC Behavior
+
+   A BYE request is constructed as would any other request within a
+   dialog, as described in Section 12.
+
+   Once the BYE is constructed, the UAC core creates a new non-INVITE
+   client transaction, and passes it the BYE request.  The UAC MUST
+   consider the session terminated (and therefore stop sending or
+   listening for media) as soon as the BYE request is passed to the
+   client transaction.  If the response for the BYE is a 481
+   (Call/Transaction Does Not Exist) or a 408 (Request Timeout) or no
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 90]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   response at all is received for the BYE (that is, a timeout is
+   returned by the client transaction), the UAC MUST consider the
+   session and the dialog terminated.
+
+15.1.2 UAS Behavior
+
+   A UAS first processes the BYE request according to the general UAS
+   processing described in Section 8.2.  A UAS core receiving a BYE
+   request checks if it matches an existing dialog.  If the BYE does not
+   match an existing dialog, the UAS core SHOULD generate a 481
+   (Call/Transaction Does Not Exist) response and pass that to the
+   server transaction.
+
+      This rule means that a BYE sent without tags by a UAC will be
+      rejected.  This is a change from RFC 2543, which allowed BYE
+      without tags.
+
+   A UAS core receiving a BYE request for an existing dialog MUST follow
+   the procedures of Section 12.2.2 to process the request.  Once done,
+   the UAS SHOULD terminate the session (and therefore stop sending and
+   listening for media).  The only case where it can elect not to are
+   multicast sessions, where participation is possible even if the other
+   participant in the dialog has terminated its involvement in the
+   session.  Whether or not it ends its participation on the session,
+   the UAS core MUST generate a 2xx response to the BYE, and MUST pass
+   that to the server transaction for transmission.
+
+   The UAS MUST still respond to any pending requests received for that
+   dialog.  It is RECOMMENDED that a 487 (Request Terminated) response
+   be generated to those pending requests.
+
+16 Proxy Behavior
+
+16.1 Overview
+
+   SIP proxies are elements that route SIP requests to user agent
+   servers and SIP responses to user agent clients.  A request may
+   traverse several proxies on its way to a UAS.  Each will make routing
+   decisions, modifying the request before forwarding it to the next
+   element.  Responses will route through the same set of proxies
+   traversed by the request in the reverse order.
+
+   Being a proxy is a logical role for a SIP element.  When a request
+   arrives, an element that can play the role of a proxy first decides
+   if it needs to respond to the request on its own.  For instance, the
+   request may be malformed or the element may need credentials from the
+   client before acting as a proxy.  The element MAY respond with any
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 91]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   appropriate error code.  When responding directly to a request, the
+   element is playing the role of a UAS and MUST behave as described in
+   Section 8.2.
+
+   A proxy can operate in either a stateful or stateless mode for each
+   new request.  When stateless, a proxy acts as a simple forwarding
+   element.  It forwards each request downstream to a single element
+   determined by making a targeting and routing decision based on the
+   request.  It simply forwards every response it receives upstream.  A
+   stateless proxy discards information about a message once the message
+   has been forwarded.  A stateful proxy remembers information
+   (specifically, transaction state) about each incoming request and any
+   requests it sends as a result of processing the incoming request.  It
+   uses this information to affect the processing of future messages
+   associated with that request.  A stateful proxy MAY choose to "fork"
+   a request, routing it to multiple destinations.  Any request that is
+   forwarded to more than one location MUST be handled statefully.
+
+   In some circumstances, a proxy MAY forward requests using stateful
+   transports (such as TCP) without being transaction-stateful.  For
+   instance, a proxy MAY forward a request from one TCP connection to
+   another transaction statelessly as long as it places enough
+   information in the message to be able to forward the response down
+   the same connection the request arrived on.  Requests forwarded
+   between different types of transports where the proxy's TU must take
+   an active role in ensuring reliable delivery on one of the transports
+   MUST be forwarded transaction statefully.
+
+   A stateful proxy MAY transition to stateless operation at any time
+   during the processing of a request, so long as it did not do anything
+   that would otherwise prevent it from being stateless initially
+   (forking, for example, or generation of a 100 response).  When
+   performing such a transition, all state is simply discarded.  The
+   proxy SHOULD NOT initiate a CANCEL request.
+
+   Much of the processing involved when acting statelessly or statefully
+   for a request is identical.  The next several subsections are written
+   from the point of view of a stateful proxy.  The last section calls
+   out those places where a stateless proxy behaves differently.
+
+16.2 Stateful Proxy
+
+   When stateful, a proxy is purely a SIP transaction processing engine.
+   Its behavior is modeled here in terms of the server and client
+   transactions defined in Section 17.  A stateful proxy has a server
+   transaction associated with one or more client transactions by a
+   higher layer proxy processing component (see figure 3), known as a
+   proxy core.  An incoming request is processed by a server
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 92]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   transaction.  Requests from the server transaction are passed to a
+   proxy core.  The proxy core determines where to route the request,
+   choosing one or more next-hop locations.  An outgoing request for
+   each next-hop location is processed by its own associated client
+   transaction.  The proxy core collects the responses from the client
+   transactions and uses them to send responses to the server
+   transaction.
+
+   A stateful proxy creates a new server transaction for each new
+   request received.  Any retransmissions of the request will then be
+   handled by that server transaction per Section 17.  The proxy core
+   MUST behave as a UAS with respect to sending an immediate provisional
+   on that server transaction (such as 100 Trying) as described in
+   Section 8.2.6.  Thus, a stateful proxy SHOULD NOT generate 100
+   (Trying) responses to non-INVITE requests.
+
+   This is a model of proxy behavior, not of software.  An
+   implementation is free to take any approach that replicates the
+   external behavior this model defines.
+
+   For all new requests, including any with unknown methods, an element
+   intending to proxy the request MUST:
+
+      1. Validate the request (Section 16.3)
+
+      2. Preprocess routing information (Section 16.4)
+
+      3. Determine target(s) for the request (Section 16.5)
+
+            +--------------------+
+            |                    | +---+
+            |                    | | C |
+            |                    | | T |
+            |                    | +---+
+      +---+ |       Proxy        | +---+   CT = Client Transaction
+      | S | |  "Higher" Layer    | | C |
+      | T | |                    | | T |   ST = Server Transaction
+      +---+ |                    | +---+
+            |                    | +---+
+            |                    | | C |
+            |                    | | T |
+            |                    | +---+
+            +--------------------+
+
+               Figure 3: Stateful Proxy Model
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 93]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      4. Forward the request to each target (Section 16.6)
+
+      5. Process all responses (Section 16.7)
+
+16.3 Request Validation
+
+   Before an element can proxy a request, it MUST verify the message's
+   validity.  A valid message must pass the following checks:
+
+      1. Reasonable Syntax
+
+      2. URI scheme
+
+      3. Max-Forwards
+
+      4. (Optional) Loop Detection
+
+      5. Proxy-Require
+
+      6. Proxy-Authorization
+
+   If any of these checks fail, the element MUST behave as a user agent
+   server (see Section 8.2) and respond with an error code.
+
+   Notice that a proxy is not required to detect merged requests and
+   MUST NOT treat merged requests as an error condition.  The endpoints
+   receiving the requests will resolve the merge as described in Section
+   8.2.2.2.
+
+   1. Reasonable syntax check
+
+      The request MUST be well-formed enough to be handled with a server
+      transaction.  Any components involved in the remainder of these
+      Request Validation steps or the Request Forwarding section MUST be
+      well-formed.  Any other components, well-formed or not, SHOULD be
+      ignored and remain unchanged when the message is forwarded.  For
+      instance, an element would not reject a request because of a
+      malformed Date header field.  Likewise, a proxy would not remove a
+      malformed Date header field before forwarding a request.
+
+      This protocol is designed to be extended.  Future extensions may
+      define new methods and header fields at any time.  An element MUST
+      NOT refuse to proxy a request because it contains a method or
+      header field it does not know about.
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 94]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   2. URI scheme check
+
+      If the Request-URI has a URI whose scheme is not understood by the
+      proxy, the proxy SHOULD reject the request with a 416 (Unsupported
+      URI Scheme) response.
+
+   3. Max-Forwards check
+
+      The Max-Forwards header field (Section 20.22) is used to limit the
+      number of elements a SIP request can traverse.
+
+      If the request does not contain a Max-Forwards header field, this
+      check is passed.
+
+      If the request contains a Max-Forwards header field with a field
+      value greater than zero, the check is passed.
+
+      If the request contains a Max-Forwards header field with a field
+      value of zero (0), the element MUST NOT forward the request.  If
+      the request was for OPTIONS, the element MAY act as the final
+      recipient and respond per Section 11.  Otherwise, the element MUST
+      return a 483 (Too many hops) response.
+
+   4. Optional Loop Detection check
+
+      An element MAY check for forwarding loops before forwarding a
+      request.  If the request contains a Via header field with a sent-
+      by value that equals a value placed into previous requests by the
+      proxy, the request has been forwarded by this element before.  The
+      request has either looped or is legitimately spiraling through the
+      element.  To determine if the request has looped, the element MAY
+      perform the branch parameter calculation described in Step 8 of
+      Section 16.6 on this message and compare it to the parameter
+      received in that Via header field.  If the parameters match, the
+      request has looped.  If they differ, the request is spiraling, and
+      processing continues.  If a loop is detected, the element MAY
+      return a 482 (Loop Detected) response.
+
+   5. Proxy-Require check
+
+      Future extensions to this protocol may introduce features that
+      require special handling by proxies.  Endpoints will include a
+      Proxy-Require header field in requests that use these features,
+      telling the proxy not to process the request unless the feature is
+      understood.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 95]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      If the request contains a Proxy-Require header field (Section
+      20.29) with one or more option-tags this element does not
+      understand, the element MUST return a 420 (Bad Extension)
+      response.  The response MUST include an Unsupported (Section
+      20.40) header field listing those option-tags the element did not
+      understand.
+
+   6. Proxy-Authorization check
+
+      If an element requires credentials before forwarding a request,
+      the request MUST be inspected as described in Section 22.3.  That
+      section also defines what the element must do if the inspection
+      fails.
+
+16.4 Route Information Preprocessing
+
+   The proxy MUST inspect the Request-URI of the request.  If the
+   Request-URI of the request contains a value this proxy previously
+   placed into a Record-Route header field (see Section 16.6 item 4),
+   the proxy MUST replace the Request-URI in the request with the last
+   value from the Route header field, and remove that value from the
+   Route header field.  The proxy MUST then proceed as if it received
+   this modified request.
+
+      This will only happen when the element sending the request to the
+      proxy (which may have been an endpoint) is a strict router.  This
+      rewrite on receive is necessary to enable backwards compatibility
+      with those elements.  It also allows elements following this
+      specification to preserve the Request-URI through strict-routing
+      proxies (see Section 12.2.1.1).
+
+      This requirement does not obligate a proxy to keep state in order
+      to detect URIs it previously placed in Record-Route header fields.
+      Instead, a proxy need only place enough information in those URIs
+      to recognize them as values it provided when they later appear.
+
+   If the Request-URI contains a maddr parameter, the proxy MUST check
+   to see if its value is in the set of addresses or domains the proxy
+   is configured to be responsible for.  If the Request-URI has a maddr
+   parameter with a value the proxy is responsible for, and the request
+   was received using the port and transport indicated (explicitly or by
+   default) in the Request-URI, the proxy MUST strip the maddr and any
+   non-default port or transport parameter and continue processing as if
+   those values had not been present in the request.
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 96]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      A request may arrive with a maddr matching the proxy, but on a
+      port or transport different from that indicated in the URI.  Such
+      a request needs to be forwarded to the proxy using the indicated
+      port and transport.
+
+   If the first value in the Route header field indicates this proxy,
+   the proxy MUST remove that value from the request.
+
+16.5 Determining Request Targets
+
+   Next, the proxy calculates the target(s) of the request.  The set of
+   targets will either be predetermined by the contents of the request
+   or will be obtained from an abstract location service.  Each target
+   in the set is represented as a URI.
+
+   If the Request-URI of the request contains an maddr parameter, the
+   Request-URI MUST be placed into the target set as the only target
+   URI, and the proxy MUST proceed to Section 16.6.
+
+   If the domain of the Request-URI indicates a domain this element is
+   not responsible for, the Request-URI MUST be placed into the target
+   set as the only target, and the element MUST proceed to the task of
+   Request Forwarding (Section 16.6).
+
+      There are many circumstances in which a proxy might receive a
+      request for a domain it is not responsible for.  A firewall proxy
+      handling outgoing calls (the way HTTP proxies handle outgoing
+      requests) is an example of where this is likely to occur.
+
+   If the target set for the request has not been predetermined as
+   described above, this implies that the element is responsible for the
+   domain in the Request-URI, and the element MAY use whatever mechanism
+   it desires to determine where to send the request.  Any of these
+   mechanisms can be modeled as accessing an abstract Location Service.
+   This may consist of obtaining information from a location service
+   created by a SIP Registrar, reading a database, consulting a presence
+   server, utilizing other protocols, or simply performing an
+   algorithmic substitution on the Request-URI.  When accessing the
+   location service constructed by a registrar, the Request-URI MUST
+   first be canonicalized as described in Section 10.3 before being used
+   as an index.  The output of these mechanisms is used to construct the
+   target set.
+
+   If the Request-URI does not provide sufficient information for the
+   proxy to determine the target set, it SHOULD return a 485 (Ambiguous)
+   response.  This response SHOULD contain a Contact header field
+   containing URIs of new addresses to be tried.  For example, an INVITE
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 97]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   to sip:John.Smith@company.com may be ambiguous at a proxy whose
+   location service has multiple John Smiths listed.  See Section
+   21.4.23 for details.
+
+   Any information in or about the request or the current environment of
+   the element MAY be used in the construction of the target set.  For
+   instance, different sets may be constructed depending on contents or
+   the presence of header fields and bodies, the time of day of the
+   request's arrival, the interface on which the request arrived,
+   failure of previous requests, or even the element's current level of
+   utilization.
+
+   As potential targets are located through these services, their URIs
+   are added to the target set.  Targets can only be placed in the
+   target set once.  If a target URI is already present in the set
+   (based on the definition of equality for the URI type), it MUST NOT
+   be added again.
+
+   A proxy MUST NOT add additional targets to the target set if the
+   Request-URI of the original request does not indicate a resource this
+   proxy is responsible for.
+
+      A proxy can only change the Request-URI of a request during
+      forwarding if it is responsible for that URI.  If the proxy is not
+      responsible for that URI, it will not recurse on 3xx or 416
+      responses as described below.
+
+   If the Request-URI of the original request indicates a resource this
+   proxy is responsible for, the proxy MAY continue to add targets to
+   the set after beginning Request Forwarding.  It MAY use any
+   information obtained during that processing to determine new targets.
+   For instance, a proxy may choose to incorporate contacts obtained in
+   a redirect response (3xx) into the target set.  If a proxy uses a
+   dynamic source of information while building the target set (for
+   instance, if it consults a SIP Registrar), it SHOULD monitor that
+   source for the duration of processing the request.  New locations
+   SHOULD be added to the target set as they become available.  As
+   above, any given URI MUST NOT be added to the set more than once.
+
+      Allowing a URI to be added to the set only once reduces
+      unnecessary network traffic, and in the case of incorporating
+      contacts from redirect requests prevents infinite recursion.
+
+   For example, a trivial location service is a "no-op", where the
+   target URI is equal to the incoming request URI.  The request is sent
+   to a specific next hop proxy for further processing.  During request
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 98]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   forwarding of Section 16.6, Item 6, the identity of that next hop,
+   expressed as a SIP or SIPS URI, is inserted as the top-most Route
+   header field value into the request.
+
+   If the Request-URI indicates a resource at this proxy that does not
+   exist, the proxy MUST return a 404 (Not Found) response.
+
+   If the target set remains empty after applying all of the above, the
+   proxy MUST return an error response, which SHOULD be the 480
+   (Temporarily Unavailable) response.
+
+16.6 Request Forwarding
+
+   As soon as the target set is non-empty, a proxy MAY begin forwarding
+   the request.  A stateful proxy MAY process the set in any order.  It
+   MAY process multiple targets serially, allowing each client
+   transaction to complete before starting the next.  It MAY start
+   client transactions with every target in parallel.  It also MAY
+   arbitrarily divide the set into groups, processing the groups
+   serially and processing the targets in each group in parallel.
+
+   A common ordering mechanism is to use the qvalue parameter of targets
+   obtained from Contact header fields (see Section 20.10).  Targets are
+   processed from highest qvalue to lowest.  Targets with equal qvalues
+   may be processed in parallel.
+
+   A stateful proxy must have a mechanism to maintain the target set as
+   responses are received and associate the responses to each forwarded
+   request with the original request.  For the purposes of this model,
+   this mechanism is a "response context" created by the proxy layer
+   before forwarding the first request.
+
+   For each target, the proxy forwards the request following these
+   steps:
+
+      1.  Make a copy of the received request
+
+      2.  Update the Request-URI
+
+      3.  Update the Max-Forwards header field
+
+      4.  Optionally add a Record-route header field value
+
+      5.  Optionally add additional header fields
+
+      6.  Postprocess routing information
+
+      7.  Determine the next-hop address, port, and transport
+
+
+
+Rosenberg, et. al.          Standards Track                    [Page 99]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      8.  Add a Via header field value
+
+      9.  Add a Content-Length header field if necessary
+
+      10. Forward the new request
+
+      11. Set timer C
+
+   Each of these steps is detailed below:
+
+      1. Copy request
+
+         The proxy starts with a copy of the received request.  The copy
+         MUST initially contain all of the header fields from the
+         received request.  Fields not detailed in the processing
+         described below MUST NOT be removed.  The copy SHOULD maintain
+         the ordering of the header fields as in the received request.
+         The proxy MUST NOT reorder field values with a common field
+         name (See Section 7.3.1).  The proxy MUST NOT add to, modify,
+         or remove the message body.
+
+         An actual implementation need not perform a copy; the primary
+         requirement is that the processing for each next hop begin with
+         the same request.
+
+      2. Request-URI
+
+         The Request-URI in the copy's start line MUST be replaced with
+         the URI for this target.  If the URI contains any parameters
+         not allowed in a Request-URI, they MUST be removed.
+
+         This is the essence of a proxy's role.  This is the mechanism
+         through which a proxy routes a request toward its destination.
+
+         In some circumstances, the received Request-URI is placed into
+         the target set without being modified.  For that target, the
+         replacement above is effectively a no-op.
+
+      3. Max-Forwards
+
+         If the copy contains a Max-Forwards header field, the proxy
+         MUST decrement its value by one (1).
+
+         If the copy does not contain a Max-Forwards header field, the
+         proxy MUST add one with a field value, which SHOULD be 70.
+
+         Some existing UAs will not provide a Max-Forwards header field
+         in a request.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 100]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      4. Record-Route
+
+         If this proxy wishes to remain on the path of future requests
+         in a dialog created by this request (assuming the request
+         creates a dialog), it MUST insert a Record-Route header field
+         value into the copy before any existing Record-Route header
+         field values, even if a Route header field is already present.
+
+         Requests establishing a dialog may contain a preloaded Route
+         header field.
+
+         If this request is already part of a dialog, the proxy SHOULD
+         insert a Record-Route header field value if it wishes to remain
+         on the path of future requests in the dialog.  In normal
+         endpoint operation as described in Section 12, these Record-
+         Route header field values will not have any effect on the route
+         sets used by the endpoints.
+
+         The proxy will remain on the path if it chooses to not insert a
+         Record-Route header field value into requests that are already
+         part of a dialog.  However, it would be removed from the path
+         when an endpoint that has failed reconstitutes the dialog.
+
+         A proxy MAY insert a Record-Route header field value into any
+         request.  If the request does not initiate a dialog, the
+         endpoints will ignore the value.  See Section 12 for details on
+         how endpoints use the Record-Route header field values to
+         construct Route header fields.
+
+         Each proxy in the path of a request chooses whether to add a
+         Record-Route header field value independently - the presence of
+         a Record-Route header field in a request does not obligate this
+         proxy to add a value.
+
+         The URI placed in the Record-Route header field value MUST be a
+         SIP or SIPS URI.  This URI MUST contain an lr parameter (see
+         Section 19.1.1).  This URI MAY be different for each
+         destination the request is forwarded to.  The URI SHOULD NOT
+         contain the transport parameter unless the proxy has knowledge
+         (such as in a private network) that the next downstream element
+         that will be in the path of subsequent requests supports that
+         transport.
+
+         The URI this proxy provides will be used by some other element
+         to make a routing decision.  This proxy, in general, has no way
+         of knowing the capabilities of that element, so it must
+         restrict itself to the mandatory elements of a SIP
+         implementation: SIP URIs and either the TCP or UDP transports.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 101]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         The URI placed in the Record-Route header field MUST resolve to
+         the element inserting it (or a suitable stand-in) when the
+         server location procedures of [4] are applied to it, so that
+         subsequent requests reach the same SIP element.  If the
+         Request-URI contains a SIPS URI, or the topmost Route header
+         field value (after the post processing of bullet 6) contains a
+         SIPS URI, the URI placed into the Record-Route header field
+         MUST be a SIPS URI.  Furthermore, if the request was not
+         received over TLS, the proxy MUST insert a Record-Route header
+         field.  In a similar fashion, a proxy that receives a request
+         over TLS, but generates a request without a SIPS URI in the
+         Request-URI or topmost Route header field value (after the post
+         processing of bullet 6), MUST insert a Record-Route header
+         field that is not a SIPS URI.
+
+         A proxy at a security perimeter must remain on the perimeter
+         throughout the dialog.
+
+         If the URI placed in the Record-Route header field needs to be
+         rewritten when it passes back through in a response, the URI
+         MUST be distinct enough to locate at that time.  (The request
+         may spiral through this proxy, resulting in more than one
+         Record-Route header field value being added).  Item 8 of
+         Section 16.7 recommends a mechanism to make the URI
+         sufficiently distinct.
+
+         The proxy MAY include parameters in the Record-Route header
+         field value.  These will be echoed in some responses to the
+         request such as the 200 (OK) responses to INVITE.  Such
+         parameters may be useful for keeping state in the message
+         rather than the proxy.
+
+         If a proxy needs to be in the path of any type of dialog (such
+         as one straddling a firewall), it SHOULD add a Record-Route
+         header field value to every request with a method it does not
+         understand since that method may have dialog semantics.
+
+         The URI a proxy places into a Record-Route header field is only
+         valid for the lifetime of any dialog created by the transaction
+         in which it occurs.  A dialog-stateful proxy, for example, MAY
+         refuse to accept future requests with that value in the
+         Request-URI after the dialog has terminated.  Non-dialog-
+         stateful proxies, of course, have no concept of when the dialog
+         has terminated, but they MAY encode enough information in the
+         value to compare it against the dialog identifier of future
+         requests and MAY reject requests not matching that information.
+         Endpoints MUST NOT use a URI obtained from a Record-Route
+         header field outside the dialog in which it was provided.  See
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 102]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         Section 12 for more information on an endpoint's use of
+         Record-Route header fields.
+
+         Record-routing may be required by certain services where the
+         proxy needs to observe all messages in a dialog.  However, it
+         slows down processing and impairs scalability and thus proxies
+         should only record-route if required for a particular service.
+
+         The Record-Route process is designed to work for any SIP
+         request that initiates a dialog.  INVITE is the only such
+         request in this specification, but extensions to the protocol
+         MAY define others.
+
+      5. Add Additional Header Fields
+
+         The proxy MAY add any other appropriate header fields to the
+         copy at this point.
+
+      6. Postprocess routing information
+
+         A proxy MAY have a local policy that mandates that a request
+         visit a specific set of proxies before being delivered to the
+         destination.  A proxy MUST ensure that all such proxies are
+         loose routers.  Generally, this can only be known with
+         certainty if the proxies are within the same administrative
+         domain.  This set of proxies is represented by a set of URIs
+         (each of which contains the lr parameter).  This set MUST be
+         pushed into the Route header field of the copy ahead of any
+         existing values, if present.  If the Route header field is
+         absent, it MUST be added, containing that list of URIs.
+
+         If the proxy has a local policy that mandates that the request
+         visit one specific proxy, an alternative to pushing a Route
+         value into the Route header field is to bypass the forwarding
+         logic of item 10 below, and instead just send the request to
+         the address, port, and transport for that specific proxy.  If
+         the request has a Route header field, this alternative MUST NOT
+         be used unless it is known that next hop proxy is a loose
+         router.  Otherwise, this approach MAY be used, but the Route
+         insertion mechanism above is preferred for its robustness,
+         flexibility, generality and consistency of operation.
+         Furthermore, if the Request-URI contains a SIPS URI, TLS MUST
+         be used to communicate with that proxy.
+
+         If the copy contains a Route header field, the proxy MUST
+         inspect the URI in its first value.  If that URI does not
+         contain an lr parameter, the proxy MUST modify the copy as
+         follows:
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 103]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         -  The proxy MUST place the Request-URI into the Route header
+            field as the last value.
+
+         -  The proxy MUST then place the first Route header field value
+            into the Request-URI and remove that value from the Route
+            header field.
+
+         Appending the Request-URI to the Route header field is part of
+         a mechanism used to pass the information in that Request-URI
+         through strict-routing elements.  "Popping" the first Route
+         header field value into the Request-URI formats the message the
+         way a strict-routing element expects to receive it (with its
+         own URI in the Request-URI and the next location to visit in
+         the first Route header field value).
+
+      7. Determine Next-Hop Address, Port, and Transport
+
+         The proxy MAY have a local policy to send the request to a
+         specific IP address, port, and transport, independent of the
+         values of the Route and Request-URI.  Such a policy MUST NOT be
+         used if the proxy is not certain that the IP address, port, and
+         transport correspond to a server that is a loose router.
+         However, this mechanism for sending the request through a
+         specific next hop is NOT RECOMMENDED; instead a Route header
+         field should be used for that purpose as described above.
+
+         In the absence of such an overriding mechanism, the proxy
+         applies the procedures listed in [4] as follows to determine
+         where to send the request.  If the proxy has reformatted the
+         request to send to a strict-routing element as described in
+         step 6 above, the proxy MUST apply those procedures to the
+         Request-URI of the request.  Otherwise, the proxy MUST apply
+         the procedures to the first value in the Route header field, if
+         present, else the Request-URI.  The procedures will produce an
+         ordered set of (address, port, transport) tuples.
+         Independently of which URI is being used as input to the
+         procedures of [4], if the Request-URI specifies a SIPS
+         resource, the proxy MUST follow the procedures of [4] as if the
+         input URI were a SIPS URI.
+
+         As described in [4], the proxy MUST attempt to deliver the
+         message to the first tuple in that set, and proceed through the
+         set in order until the delivery attempt succeeds.
+
+         For each tuple attempted, the proxy MUST format the message as
+         appropriate for the tuple and send the request using a new
+         client transaction as detailed in steps 8 through 10.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 104]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         Since each attempt uses a new client transaction, it represents
+         a new branch.  Thus, the branch parameter provided with the Via
+         header field inserted in step 8 MUST be different for each
+         attempt.
+
+         If the client transaction reports failure to send the request
+         or a timeout from its state machine, the proxy continues to the
+         next address in that ordered set.  If the ordered set is
+         exhausted, the request cannot be forwarded to this element in
+         the target set.  The proxy does not need to place anything in
+         the response context, but otherwise acts as if this element of
+         the target set returned a 408 (Request Timeout) final response.
+
+      8. Add a Via header field value
+
+         The proxy MUST insert a Via header field value into the copy
+         before the existing Via header field values.  The construction
+         of this value follows the same guidelines of Section 8.1.1.7.
+         This implies that the proxy will compute its own branch
+         parameter, which will be globally unique for that branch, and
+         contain the requisite magic cookie. Note that this implies that
+         the branch parameter will be different for different instances
+         of a spiraled or looped request through a proxy.
+
+         Proxies choosing to detect loops have an additional constraint
+         in the value they use for construction of the branch parameter.
+         A proxy choosing to detect loops SHOULD create a branch
+         parameter separable into two parts by the implementation.  The
+         first part MUST satisfy the constraints of Section 8.1.1.7 as
+         described above.  The second is used to perform loop detection
+         and distinguish loops from spirals.
+
+         Loop detection is performed by verifying that, when a request
+         returns to a proxy, those fields having an impact on the
+         processing of the request have not changed.  The value placed
+         in this part of the branch parameter SHOULD reflect all of
+         those fields (including any Route, Proxy-Require and Proxy-
+         Authorization header fields).  This is to ensure that if the
+         request is routed back to the proxy and one of those fields
+         changes, it is treated as a spiral and not a loop (see Section
+         16.3).  A common way to create this value is to compute a
+         cryptographic hash of the To tag, From tag, Call-ID header
+         field, the Request-URI of the request received (before
+         translation), the topmost Via header, and the sequence number
+         from the CSeq header field, in addition to any Proxy-Require
+         and Proxy-Authorization header fields that may be present.  The
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 105]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         algorithm used to compute the hash is implementation-dependent,
+         but MD5 (RFC 1321 [35]), expressed in hexadecimal, is a
+         reasonable choice.  (Base64 is not permissible for a token.)
+
+         If a proxy wishes to detect loops, the "branch" parameter it
+         supplies MUST depend on all information affecting processing of
+         a request, including the incoming Request-URI and any header
+         fields affecting the request's admission or routing.  This is
+         necessary to distinguish looped requests from requests whose
+         routing parameters have changed before returning to this
+         server.
+
+         The request method MUST NOT be included in the calculation of
+         the branch parameter.  In particular, CANCEL and ACK requests
+         (for non-2xx responses) MUST have the same branch value as the
+         corresponding request they cancel or acknowledge.  The branch
+         parameter is used in correlating those requests at the server
+         handling them (see Sections 17.2.3 and 9.2).
+
+      9. Add a Content-Length header field if necessary
+
+         If the request will be sent to the next hop using a stream-
+         based transport and the copy contains no Content-Length header
+         field, the proxy MUST insert one with the correct value for the
+         body of the request (see Section 20.14).
+
+      10. Forward Request
+
+         A stateful proxy MUST create a new client transaction for this
+         request as described in Section 17.1 and instructs the
+         transaction to send the request using the address, port and
+         transport determined in step 7.
+
+      11. Set timer C
+
+         In order to handle the case where an INVITE request never
+         generates a final response, the TU uses a timer which is called
+         timer C.  Timer C MUST be set for each client transaction when
+         an INVITE request is proxied.  The timer MUST be larger than 3
+         minutes.  Section 16.7 bullet 2 discusses how this timer is
+         updated with provisional responses, and Section 16.8 discusses
+         processing when it fires.
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 106]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+16.7 Response Processing
+
+   When a response is received by an element, it first tries to locate a
+   client transaction (Section 17.1.3) matching the response.  If none
+   is found, the element MUST process the response (even if it is an
+   informational response) as a stateless proxy (described below).  If a
+   match is found, the response is handed to the client transaction.
+
+      Forwarding responses for which a client transaction (or more
+      generally any knowledge of having sent an associated request) is
+      not found improves robustness.  In particular, it ensures that
+      "late" 2xx responses to INVITE requests are forwarded properly.
+
+   As client transactions pass responses to the proxy layer, the
+   following processing MUST take place:
+
+      1.  Find the appropriate response context
+
+      2.  Update timer C for provisional responses
+
+      3.  Remove the topmost Via
+
+      4.  Add the response to the response context
+
+      5.  Check to see if this response should be forwarded immediately
+
+      6.  When necessary, choose the best final response from the
+          response context
+
+   If no final response has been forwarded after every client
+   transaction associated with the response context has been terminated,
+   the proxy must choose and forward the "best" response from those it
+   has seen so far.
+
+   The following processing MUST be performed on each response that is
+   forwarded.  It is likely that more than one response to each request
+   will be forwarded: at least each provisional and one final response.
+
+      7.  Aggregate authorization header field values if necessary
+
+      8.  Optionally rewrite Record-Route header field values
+
+      9.  Forward the response
+
+      10. Generate any necessary CANCEL requests
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 107]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Each of the above steps are detailed below:
+
+      1.  Find Context
+
+         The proxy locates the "response context" it created before
+         forwarding the original request using the key described in
+         Section 16.6.  The remaining processing steps take place in
+         this context.
+
+      2.  Update timer C for provisional responses
+
+         For an INVITE transaction, if the response is a provisional
+         response with status codes 101 to 199 inclusive (i.e., anything
+         but 100), the proxy MUST reset timer C for that client
+         transaction.  The timer MAY be reset to a different value, but
+         this value MUST be greater than 3 minutes.
+
+      3.  Via
+
+         The proxy removes the topmost Via header field value from the
+         response.
+
+         If no Via header field values remain in the response, the
+         response was meant for this element and MUST NOT be forwarded.
+         The remainder of the processing described in this section is
+         not performed on this message, the UAC processing rules
+         described in Section 8.1.3 are followed instead (transport
+         layer processing has already occurred).
+
+         This will happen, for instance, when the element generates
+         CANCEL requests as described in Section 10.
+
+      4.  Add response to context
+
+         Final responses received are stored in the response context
+         until a final response is generated on the server transaction
+         associated with this context.  The response may be a candidate
+         for the best final response to be returned on that server
+         transaction.  Information from this response may be needed in
+         forming the best response, even if this response is not chosen.
+
+         If the proxy chooses to recurse on any contacts in a 3xx
+         response by adding them to the target set, it MUST remove them
+         from the response before adding the response to the response
+         context.  However, a proxy SHOULD NOT recurse to a non-SIPS URI
+         if the Request-URI of the original request was a SIPS URI.  If
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 108]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         the proxy recurses on all of the contacts in a 3xx response,
+         the proxy SHOULD NOT add the resulting contactless response to
+         the response context.
+
+         Removing the contact before adding the response to the response
+         context prevents the next element upstream from retrying a
+         location this proxy has already attempted.
+
+         3xx responses may contain a mixture of SIP, SIPS, and non-SIP
+         URIs.  A proxy may choose to recurse on the SIP and SIPS URIs
+         and place the remainder into the response context to be
+         returned, potentially in the final response.
+
+         If a proxy receives a 416 (Unsupported URI Scheme) response to
+         a request whose Request-URI scheme was not SIP, but the scheme
+         in the original received request was SIP or SIPS (that is, the
+         proxy changed the scheme from SIP or SIPS to something else
+         when it proxied a request), the proxy SHOULD add a new URI to
+         the target set.  This URI SHOULD be a SIP URI version of the
+         non-SIP URI that was just tried.  In the case of the tel URL,
+         this is accomplished by placing the telephone-subscriber part
+         of the tel URL into the user part of the SIP URI, and setting
+         the hostpart to the domain where the prior request was sent.
+         See Section 19.1.6 for more detail on forming SIP URIs from tel
+         URLs.
+
+         As with a 3xx response, if a proxy "recurses" on the 416 by
+         trying a SIP or SIPS URI instead, the 416 response SHOULD NOT
+         be added to the response context.
+
+      5.  Check response for forwarding
+
+         Until a final response has been sent on the server transaction,
+         the following responses MUST be forwarded immediately:
+
+         -  Any provisional response other than 100 (Trying)
+
+         -  Any 2xx response
+
+         If a 6xx response is received, it is not immediately forwarded,
+         but the stateful proxy SHOULD cancel all client pending
+         transactions as described in Section 10, and it MUST NOT create
+         any new branches in this context.
+
+         This is a change from RFC 2543, which mandated that the proxy
+         was to forward the 6xx response immediately.  For an INVITE
+         transaction, this approach had the problem that a 2xx response
+         could arrive on another branch, in which case the proxy would
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 109]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         have to forward the 2xx.  The result was that the UAC could
+         receive a 6xx response followed by a 2xx response, which should
+         never be allowed to happen.  Under the new rules, upon
+         receiving a 6xx, a proxy will issue a CANCEL request, which
+         will generally result in 487 responses from all outstanding
+         client transactions, and then at that point the 6xx is
+         forwarded upstream.
+
+         After a final response has been sent on the server transaction,
+         the following responses MUST be forwarded immediately:
+
+         -  Any 2xx response to an INVITE request
+
+         A stateful proxy MUST NOT immediately forward any other
+         responses.  In particular, a stateful proxy MUST NOT forward
+         any 100 (Trying) response.  Those responses that are candidates
+         for forwarding later as the "best" response have been gathered
+         as described in step "Add Response to Context".
+
+         Any response chosen for immediate forwarding MUST be processed
+         as described in steps "Aggregate Authorization Header Field
+         Values" through "Record-Route".
+
+         This step, combined with the next, ensures that a stateful
+         proxy will forward exactly one final response to a non-INVITE
+         request, and either exactly one non-2xx response or one or more
+         2xx responses to an INVITE request.
+
+      6.  Choosing the best response
+
+         A stateful proxy MUST send a final response to a response
+         context's server transaction if no final responses have been
+         immediately forwarded by the above rules and all client
+         transactions in this response context have been terminated.
+
+         The stateful proxy MUST choose the "best" final response among
+         those received and stored in the response context.
+
+         If there are no final responses in the context, the proxy MUST
+         send a 408 (Request Timeout) response to the server
+         transaction.
+
+         Otherwise, the proxy MUST forward a response from the responses
+         stored in the response context.  It MUST choose from the 6xx
+         class responses if any exist in the context.  If no 6xx class
+         responses are present, the proxy SHOULD choose from the lowest
+         response class stored in the response context.  The proxy MAY
+         select any response within that chosen class.  The proxy SHOULD
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 110]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         give preference to responses that provide information affecting
+         resubmission of this request, such as 401, 407, 415, 420, and
+         484 if the 4xx class is chosen.
+
+         A proxy which receives a 503 (Service Unavailable) response
+         SHOULD NOT forward it upstream unless it can determine that any
+         subsequent requests it might proxy will also generate a 503.
+         In other words, forwarding a 503 means that the proxy knows it
+         cannot service any requests, not just the one for the Request-
+         URI in the request which generated the 503.  If the only
+         response that was received is a 503, the proxy SHOULD generate
+         a 500 response and forward that upstream.
+
+         The forwarded response MUST be processed as described in steps
+         "Aggregate Authorization Header Field Values" through "Record-
+         Route".
+
+         For example, if a proxy forwarded a request to 4 locations, and
+         received 503, 407, 501, and 404 responses, it may choose to
+         forward the 407 (Proxy Authentication Required) response.
+
+         1xx and 2xx responses may be involved in the establishment of
+         dialogs.  When a request does not contain a To tag, the To tag
+         in the response is used by the UAC to distinguish multiple
+         responses to a dialog creating request.  A proxy MUST NOT
+         insert a tag into the To header field of a 1xx or 2xx response
+         if the request did not contain one.  A proxy MUST NOT modify
+         the tag in the To header field of a 1xx or 2xx response.
+
+         Since a proxy may not insert a tag into the To header field of
+         a 1xx response to a request that did not contain one, it cannot
+         issue non-100 provisional responses on its own.  However, it
+         can branch the request to a UAS sharing the same element as the
+         proxy.  This UAS can return its own provisional responses,
+         entering into an early dialog with the initiator of the
+         request.  The UAS does not have to be a discreet process from
+         the proxy.  It could be a virtual UAS implemented in the same
+         code space as the proxy.
+
+         3-6xx responses are delivered hop-by-hop.  When issuing a 3-6xx
+         response, the element is effectively acting as a UAS, issuing
+         its own response, usually based on the responses received from
+         downstream elements.  An element SHOULD preserve the To tag
+         when simply forwarding a 3-6xx response to a request that did
+         not contain a To tag.
+
+         A proxy MUST NOT modify the To tag in any forwarded response to
+         a request that contains a To tag.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 111]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         While it makes no difference to the upstream elements if the
+         proxy replaced the To tag in a forwarded 3-6xx response,
+         preserving the original tag may assist with debugging.
+
+         When the proxy is aggregating information from several
+         responses, choosing a To tag from among them is arbitrary, and
+         generating a new To tag may make debugging easier.  This
+         happens, for instance, when combining 401 (Unauthorized) and
+         407 (Proxy Authentication Required) challenges, or combining
+         Contact values from unencrypted and unauthenticated 3xx
+         responses.
+
+      7.  Aggregate Authorization Header Field Values
+
+         If the selected response is a 401 (Unauthorized) or 407 (Proxy
+         Authentication Required), the proxy MUST collect any WWW-
+         Authenticate and Proxy-Authenticate header field values from
+         all other 401 (Unauthorized) and 407 (Proxy Authentication
+         Required) responses received so far in this response context
+         and add them to this response without modification before
+         forwarding.  The resulting 401 (Unauthorized) or 407 (Proxy
+         Authentication Required) response could have several WWW-
+         Authenticate AND Proxy-Authenticate header field values.
+
+         This is necessary because any or all of the destinations the
+         request was forwarded to may have requested credentials.  The
+         client needs to receive all of those challenges and supply
+         credentials for each of them when it retries the request.
+         Motivation for this behavior is provided in Section 26.
+
+      8.  Record-Route
+
+         If the selected response contains a Record-Route header field
+         value originally provided by this proxy, the proxy MAY choose
+         to rewrite the value before forwarding the response.  This
+         allows the proxy to provide different URIs for itself to the
+         next upstream and downstream elements.  A proxy may choose to
+         use this mechanism for any reason.  For instance, it is useful
+         for multi-homed hosts.
+
+         If the proxy received the request over TLS, and sent it out
+         over a non-TLS connection, the proxy MUST rewrite the URI in
+         the Record-Route header field to be a SIPS URI.  If the proxy
+         received the request over a non-TLS connection, and sent it out
+         over TLS, the proxy MUST rewrite the URI in the Record-Route
+         header field to be a SIP URI.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 112]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         The new URI provided by the proxy MUST satisfy the same
+         constraints on URIs placed in Record-Route header fields in
+         requests (see Step 4 of Section 16.6) with the following
+         modifications:
+
+         The URI SHOULD NOT contain the transport parameter unless the
+         proxy has knowledge that the next upstream (as opposed to
+         downstream) element that will be in the path of subsequent
+         requests supports that transport.
+
+         When a proxy does decide to modify the Record-Route header
+         field in the response, one of the operations it performs is
+         locating the Record-Route value that it had inserted.  If the
+         request spiraled, and the proxy inserted a Record-Route value
+         in each iteration of the spiral, locating the correct value in
+         the response (which must be the proper iteration in the reverse
+         direction) is tricky.  The rules above recommend that a proxy
+         wishing to rewrite Record-Route header field values insert
+         sufficiently distinct URIs into the Record-Route header field
+         so that the right one may be selected for rewriting.  A
+         RECOMMENDED mechanism to achieve this is for the proxy to
+         append a unique identifier for the proxy instance to the user
+         portion of the URI.
+
+         When the response arrives, the proxy modifies the first
+         Record-Route whose identifier matches the proxy instance.  The
+         modification results in a URI without this piece of data
+         appended to the user portion of the URI.  Upon the next
+         iteration, the same algorithm (find the topmost Record-Route
+         header field value with the parameter) will correctly extract
+         the next Record-Route header field value inserted by that
+         proxy.
+
+         Not every response to a request to which a proxy adds a
+         Record-Route header field value will contain a Record-Route
+         header field.  If the response does contain a Record-Route
+         header field, it will contain the value the proxy added.
+
+      9.  Forward response
+
+         After performing the processing described in steps "Aggregate
+         Authorization Header Field Values" through "Record-Route", the
+         proxy MAY perform any feature specific manipulations on the
+         selected response.  The proxy MUST NOT add to, modify, or
+         remove the message body.  Unless otherwise specified, the proxy
+         MUST NOT remove any header field values other than the Via
+         header field value discussed in Section 16.7 Item 3.  In
+         particular, the proxy MUST NOT remove any "received" parameter
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 113]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         it may have added to the next Via header field value while
+         processing the request associated with this response.  The
+         proxy MUST pass the response to the server transaction
+         associated with the response context.  This will result in the
+         response being sent to the location now indicated in the
+         topmost Via header field value.  If the server transaction is
+         no longer available to handle the transmission, the element
+         MUST forward the response statelessly by sending it to the
+         server transport.  The server transaction might indicate
+         failure to send the response or signal a timeout in its state
+         machine.  These errors would be logged for diagnostic purposes
+         as appropriate, but the protocol requires no remedial action
+         from the proxy.
+
+         The proxy MUST maintain the response context until all of its
+         associated transactions have been terminated, even after
+         forwarding a final response.
+
+      10. Generate CANCELs
+
+         If the forwarded response was a final response, the proxy MUST
+         generate a CANCEL request for all pending client transactions
+         associated with this response context.  A proxy SHOULD also
+         generate a CANCEL request for all pending client transactions
+         associated with this response context when it receives a 6xx
+         response.  A pending client transaction is one that has
+         received a provisional response, but no final response (it is
+         in the proceeding state) and has not had an associated CANCEL
+         generated for it.  Generating CANCEL requests is described in
+         Section 9.1.
+
+         The requirement to CANCEL pending client transactions upon
+         forwarding a final response does not guarantee that an endpoint
+         will not receive multiple 200 (OK) responses to an INVITE.  200
+         (OK) responses on more than one branch may be generated before
+         the CANCEL requests can be sent and processed.  Further, it is
+         reasonable to expect that a future extension may override this
+         requirement to issue CANCEL requests.
+
+16.8 Processing Timer C
+
+   If timer C should fire, the proxy MUST either reset the timer with
+   any value it chooses, or terminate the client transaction.  If the
+   client transaction has received a provisional response, the proxy
+   MUST generate a CANCEL request matching that transaction.  If the
+   client transaction has not received a provisional response, the proxy
+   MUST behave as if the transaction received a 408 (Request Timeout)
+   response.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 114]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Allowing the proxy to reset the timer allows the proxy to dynamically
+   extend the transaction's lifetime based on current conditions (such
+   as utilization) when the timer fires.
+
+16.9 Handling Transport Errors
+
+   If the transport layer notifies a proxy of an error when it tries to
+   forward a request (see Section 18.4), the proxy MUST behave as if the
+   forwarded request received a 503 (Service Unavailable) response.
+
+   If the proxy is notified of an error when forwarding a response, it
+   drops the response.  The proxy SHOULD NOT cancel any outstanding
+   client transactions associated with this response context due to this
+   notification.
+
+      If a proxy cancels its outstanding client transactions, a single
+      malicious or misbehaving client can cause all transactions to fail
+      through its Via header field.
+
+16.10 CANCEL Processing
+
+   A stateful proxy MAY generate a CANCEL to any other request it has
+   generated at any time (subject to receiving a provisional response to
+   that request as described in section 9.1).  A proxy MUST cancel any
+   pending client transactions associated with a response context when
+   it receives a matching CANCEL request.
+
+   A stateful proxy MAY generate CANCEL requests for pending INVITE
+   client transactions based on the period specified in the INVITE's
+   Expires header field elapsing.  However, this is generally
+   unnecessary since the endpoints involved will take care of signaling
+   the end of the transaction.
+
+   While a CANCEL request is handled in a stateful proxy by its own
+   server transaction, a new response context is not created for it.
+   Instead, the proxy layer searches its existing response contexts for
+   the server transaction handling the request associated with this
+   CANCEL.  If a matching response context is found, the element MUST
+   immediately return a 200 (OK) response to the CANCEL request.  In
+   this case, the element is acting as a user agent server as defined in
+   Section 8.2.  Furthermore, the element MUST generate CANCEL requests
+   for all pending client transactions in the context as described in
+   Section 16.7 step 10.
+
+   If a response context is not found, the element does not have any
+   knowledge of the request to apply the CANCEL to.  It MUST statelessly
+   forward the CANCEL request (it may have statelessly forwarded the
+   associated request previously).
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 115]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+16.11 Stateless Proxy
+
+   When acting statelessly, a proxy is a simple message forwarder.  Much
+   of the processing performed when acting statelessly is the same as
+   when behaving statefully.  The differences are detailed here.
+
+   A stateless proxy does not have any notion of a transaction, or of
+   the response context used to describe stateful proxy behavior.
+   Instead, the stateless proxy takes messages, both requests and
+   responses, directly from the transport layer (See section 18).  As a
+   result, stateless proxies do not retransmit messages on their own.
+   They do, however, forward all retransmissions they receive (they do
+   not have the ability to distinguish a retransmission from the
+   original message).  Furthermore, when handling a request statelessly,
+   an element MUST NOT generate its own 100 (Trying) or any other
+   provisional response.
+
+   A stateless proxy MUST validate a request as described in Section
+   16.3
+
+   A stateless proxy MUST follow the request processing steps described
+   in Sections 16.4 through 16.5 with the following exception:
+
+      o  A stateless proxy MUST choose one and only one target from the
+         target set.  This choice MUST only rely on fields in the
+         message and time-invariant properties of the server.  In
+         particular, a retransmitted request MUST be forwarded to the
+         same destination each time it is processed.  Furthermore,
+         CANCEL and non-Routed ACK requests MUST generate the same
+         choice as their associated INVITE.
+
+   A stateless proxy MUST follow the request processing steps described
+   in Section 16.6 with the following exceptions:
+
+      o  The requirement for unique branch IDs across space and time
+         applies to stateless proxies as well.  However, a stateless
+         proxy cannot simply use a random number generator to compute
+         the first component of the branch ID, as described in Section
+         16.6 bullet 8.  This is because retransmissions of a request
+         need to have the same value, and a stateless proxy cannot tell
+         a retransmission from the original request.  Therefore, the
+         component of the branch parameter that makes it unique MUST be
+         the same each time a retransmitted request is forwarded.  Thus
+         for a stateless proxy, the branch parameter MUST be computed as
+         a combinatoric function of message parameters which are
+         invariant on retransmission.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 116]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         The stateless proxy MAY use any technique it likes to guarantee
+         uniqueness of its branch IDs across transactions.  However, the
+         following procedure is RECOMMENDED.  The proxy examines the
+         branch ID in the topmost Via header field of the received
+         request.  If it begins with the magic cookie, the first
+         component of the branch ID of the outgoing request is computed
+         as a hash of the received branch ID.  Otherwise, the first
+         component of the branch ID is computed as a hash of the topmost
+         Via, the tag in the To header field, the tag in the From header
+         field, the Call-ID header field, the CSeq number (but not
+         method), and the Request-URI from the received request.  One of
+         these fields will always vary across two different
+         transactions.
+
+      o  All other message transformations specified in Section 16.6
+         MUST result in the same transformation of a retransmitted
+         request.  In particular, if the proxy inserts a Record-Route
+         value or pushes URIs into the Route header field, it MUST place
+         the same values in retransmissions of the request.  As for the
+         Via branch parameter, this implies that the transformations
+         MUST be based on time-invariant configuration or
+         retransmission-invariant properties of the request.
+
+      o  A stateless proxy determines where to forward the request as
+         described for stateful proxies in Section 16.6 Item 10.  The
+         request is sent directly to the transport layer instead of
+         through a client transaction.
+
+         Since a stateless proxy must forward retransmitted requests to
+         the same destination and add identical branch parameters to
+         each of them, it can only use information from the message
+         itself and time-invariant configuration data for those
+         calculations.  If the configuration state is not time-invariant
+         (for example, if a routing table is updated) any requests that
+         could be affected by the change may not be forwarded
+         statelessly during an interval equal to the transaction timeout
+         window before or after the change.  The method of processing
+         the affected requests in that interval is an implementation
+         decision.  A common solution is to forward them transaction
+         statefully.
+
+   Stateless proxies MUST NOT perform special processing for CANCEL
+   requests.  They are processed by the above rules as any other
+   requests.  In particular, a stateless proxy applies the same Route
+   header field processing to CANCEL requests that it applies to any
+   other request.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 117]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Response processing as described in Section 16.7 does not apply to a
+   proxy behaving statelessly.  When a response arrives at a stateless
+   proxy, the proxy MUST inspect the sent-by value in the first
+   (topmost) Via header field value.  If that address matches the proxy,
+   (it equals a value this proxy has inserted into previous requests)
+   the proxy MUST remove that header field value from the response and
+   forward the result to the location indicated in the next Via header
+   field value.  The proxy MUST NOT add to, modify, or remove the
+   message body.  Unless specified otherwise, the proxy MUST NOT remove
+   any other header field values.  If the address does not match the
+   proxy, the message MUST be silently discarded.
+
+16.12 Summary of Proxy Route Processing
+
+   In the absence of local policy to the contrary, the processing a
+   proxy performs on a request containing a Route header field can be
+   summarized in the following steps.
+
+      1.  The proxy will inspect the Request-URI.  If it indicates a
+          resource owned by this proxy, the proxy will replace it with
+          the results of running a location service.  Otherwise, the
+          proxy will not change the Request-URI.
+
+      2.  The proxy will inspect the URI in the topmost Route header
+          field value.  If it indicates this proxy, the proxy removes it
+          from the Route header field (this route node has been
+          reached).
+
+      3.  The proxy will forward the request to the resource indicated
+          by the URI in the topmost Route header field value or in the
+          Request-URI if no Route header field is present.  The proxy
+          determines the address, port and transport to use when
+          forwarding the request by applying the procedures in [4] to
+          that URI.
+
+   If no strict-routing elements are encountered on the path of the
+   request, the Request-URI will always indicate the target of the
+   request.
+
+16.12.1 Examples
+
+16.12.1.1 Basic SIP Trapezoid
+
+   This scenario is the basic SIP trapezoid, U1 -> P1 -> P2 -> U2, with
+   both proxies record-routing.  Here is the flow.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 118]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   U1 sends:
+
+      INVITE sip:callee@domain.com SIP/2.0
+      Contact: sip:caller@u1.example.com
+
+   to P1.  P1 is an outbound proxy.  P1 is not responsible for
+   domain.com, so it looks it up in DNS and sends it there.  It also
+   adds a Record-Route header field value:
+
+      INVITE sip:callee@domain.com SIP/2.0
+      Contact: sip:caller@u1.example.com
+      Record-Route: <sip:p1.example.com;lr>
+
+   P2 gets this.  It is responsible for domain.com so it runs a location
+   service and rewrites the Request-URI.  It also adds a Record-Route
+   header field value.  There is no Route header field, so it resolves
+   the new Request-URI to determine where to send the request:
+
+      INVITE sip:callee@u2.domain.com SIP/2.0
+      Contact: sip:caller@u1.example.com
+      Record-Route: <sip:p2.domain.com;lr>
+      Record-Route: <sip:p1.example.com;lr>
+
+   The callee at u2.domain.com gets this and responds with a 200 OK:
+
+      SIP/2.0 200 OK
+      Contact: sip:callee@u2.domain.com
+      Record-Route: <sip:p2.domain.com;lr>
+      Record-Route: <sip:p1.example.com;lr>
+
+   The callee at u2 also sets its dialog state's remote target URI to
+   sip:caller@u1.example.com and its route set to:
+
+      (<sip:p2.domain.com;lr>,<sip:p1.example.com;lr>)
+
+   This is forwarded by P2 to P1 to U1 as normal.  Now, U1 sets its
+   dialog state's remote target URI to sip:callee@u2.domain.com and its
+   route set to:
+
+      (<sip:p1.example.com;lr>,<sip:p2.domain.com;lr>)
+
+   Since all the route set elements contain the lr parameter, U1
+   constructs the following BYE request:
+
+      BYE sip:callee@u2.domain.com SIP/2.0
+      Route: <sip:p1.example.com;lr>,<sip:p2.domain.com;lr>
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 119]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   As any other element (including proxies) would do, it resolves the
+   URI in the topmost Route header field value using DNS to determine
+   where to send the request.  This goes to P1.  P1 notices that it is
+   not responsible for the resource indicated in the Request-URI so it
+   doesn't change it.  It does see that it is the first value in the
+   Route header field, so it removes that value, and forwards the
+   request to P2:
+
+      BYE sip:callee@u2.domain.com SIP/2.0
+      Route: <sip:p2.domain.com;lr>
+
+   P2 also notices it is not responsible for the resource indicated by
+   the Request-URI (it is responsible for domain.com, not
+   u2.domain.com), so it doesn't change it.  It does see itself in the
+   first Route header field value, so it removes it and forwards the
+   following to u2.domain.com based on a DNS lookup against the
+   Request-URI:
+
+      BYE sip:callee@u2.domain.com SIP/2.0
+
+16.12.1.2 Traversing a Strict-Routing Proxy
+
+   In this scenario, a dialog is established across four proxies, each
+   of which adds Record-Route header field values.  The third proxy
+   implements the strict-routing procedures specified in RFC 2543 and
+   many works in progress.
+
+      U1->P1->P2->P3->P4->U2
+
+   The INVITE arriving at U2 contains:
+
+      INVITE sip:callee@u2.domain.com SIP/2.0
+      Contact: sip:caller@u1.example.com
+      Record-Route: <sip:p4.domain.com;lr>
+      Record-Route: <sip:p3.middle.com>
+      Record-Route: <sip:p2.example.com;lr>
+      Record-Route: <sip:p1.example.com;lr>
+
+   Which U2 responds to with a 200 OK.  Later, U2 sends the following
+   BYE request to P4 based on the first Route header field value.
+
+      BYE sip:caller@u1.example.com SIP/2.0
+      Route: <sip:p4.domain.com;lr>
+      Route: <sip:p3.middle.com>
+      Route: <sip:p2.example.com;lr>
+      Route: <sip:p1.example.com;lr>
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 120]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   P4 is not responsible for the resource indicated in the Request-URI
+   so it will leave it alone.  It notices that it is the element in the
+   first Route header field value so it removes it.  It then prepares to
+   send the request based on the now first Route header field value of
+   sip:p3.middle.com, but it notices that this URI does not contain the
+   lr parameter, so before sending, it reformats the request to be:
+
+      BYE sip:p3.middle.com SIP/2.0
+      Route: <sip:p2.example.com;lr>
+      Route: <sip:p1.example.com;lr>
+      Route: <sip:caller@u1.example.com>
+
+   P3 is a strict router, so it forwards the following to P2:
+
+      BYE sip:p2.example.com;lr SIP/2.0
+      Route: <sip:p1.example.com;lr>
+      Route: <sip:caller@u1.example.com>
+
+   P2 sees the request-URI is a value it placed into a Record-Route
+   header field, so before further processing, it rewrites the request
+   to be:
+
+      BYE sip:caller@u1.example.com SIP/2.0
+      Route: <sip:p1.example.com;lr>
+
+   P2 is not responsible for u1.example.com, so it sends the request to
+   P1 based on the resolution of the Route header field value.
+
+   P1 notices itself in the topmost Route header field value, so it
+   removes it, resulting in:
+
+      BYE sip:caller@u1.example.com SIP/2.0
+
+   Since P1 is not responsible for u1.example.com and there is no Route
+   header field, P1 will forward the request to u1.example.com based on
+   the Request-URI.
+
+16.12.1.3 Rewriting Record-Route Header Field Values
+
+   In this scenario, U1 and U2 are in different private namespaces and
+   they enter a dialog through a proxy P1, which acts as a gateway
+   between the namespaces.
+
+      U1->P1->U2
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 121]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   U1 sends:
+
+      INVITE sip:callee@gateway.leftprivatespace.com SIP/2.0
+      Contact: <sip:caller@u1.leftprivatespace.com>
+
+   P1 uses its location service and sends the following to U2:
+
+      INVITE sip:callee@rightprivatespace.com SIP/2.0
+      Contact: <sip:caller@u1.leftprivatespace.com>
+      Record-Route: <sip:gateway.rightprivatespace.com;lr>
+
+   U2 sends this 200 (OK) back to P1:
+
+      SIP/2.0 200 OK
+      Contact: <sip:callee@u2.rightprivatespace.com>
+      Record-Route: <sip:gateway.rightprivatespace.com;lr>
+
+   P1 rewrites its Record-Route header parameter to provide a value that
+   U1 will find useful, and sends the following to U1:
+
+      SIP/2.0 200 OK
+      Contact: <sip:callee@u2.rightprivatespace.com>
+      Record-Route: <sip:gateway.leftprivatespace.com;lr>
+
+   Later, U1 sends the following BYE request to P1:
+
+      BYE sip:callee@u2.rightprivatespace.com SIP/2.0
+      Route: <sip:gateway.leftprivatespace.com;lr>
+
+   which P1 forwards to U2 as:
+
+      BYE sip:callee@u2.rightprivatespace.com SIP/2.0
+
+17 Transactions
+
+   SIP is a transactional protocol: interactions between components take
+   place in a series of independent message exchanges.  Specifically, a
+   SIP transaction consists of a single request and any responses to
+   that request, which include zero or more provisional responses and
+   one or more final responses.  In the case of a transaction where the
+   request was an INVITE (known as an INVITE transaction), the
+   transaction also includes the ACK only if the final response was not
+   a 2xx response.  If the response was a 2xx, the ACK is not considered
+   part of the transaction.
+
+      The reason for this separation is rooted in the importance of
+      delivering all 200 (OK) responses to an INVITE to the UAC.  To
+      deliver them all to the UAC, the UAS alone takes responsibility
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 122]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      for retransmitting them (see Section 13.3.1.4), and the UAC alone
+      takes responsibility for acknowledging them with ACK (see Section
+      13.2.2.4).  Since this ACK is retransmitted only by the UAC, it is
+      effectively considered its own transaction.
+
+   Transactions have a client side and a server side.  The client side
+   is known as a client transaction and the server side as a server
+   transaction.  The client transaction sends the request, and the
+   server transaction sends the response.  The client and server
+   transactions are logical functions that are embedded in any number of
+   elements.  Specifically, they exist within user agents and stateful
+   proxy servers.  Consider the example in Section 4.  In this example,
+   the UAC executes the client transaction, and its outbound proxy
+   executes the server transaction.  The outbound proxy also executes a
+   client transaction, which sends the request to a server transaction
+   in the inbound proxy.  That proxy also executes a client transaction,
+   which in turn sends the request to a server transaction in the UAS.
+   This is shown in Figure 4.
+
+   +---------+        +---------+        +---------+        +---------+
+   |      +-+|Request |+-+   +-+|Request |+-+   +-+|Request |+-+      |
+   |      |C||------->||S|   |C||------->||S|   |C||------->||S|      |
+   |      |l||        ||e|   |l||        ||e|   |l||        ||e|      |
+   |      |i||        ||r|   |i||        ||r|   |i||        ||r|      |
+   |      |e||        ||v|   |e||        ||v|   |e||        ||v|      |
+   |      |n||        ||e|   |n||        ||e|   |n||        ||e|      |
+   |      |t||        ||r|   |t||        ||r|   |t||        ||r|      |
+   |      | ||        || |   | ||        || |   | ||        || |      |
+   |      |T||        ||T|   |T||        ||T|   |T||        ||T|      |
+   |      |r||        ||r|   |r||        ||r|   |r||        ||r|      |
+   |      |a||        ||a|   |a||        ||a|   |a||        ||a|      |
+   |      |n||        ||n|   |n||        ||n|   |n||        ||n|      |
+   |      |s||Response||s|   |s||Response||s|   |s||Response||s|      |
+   |      +-+|<-------|+-+   +-+|<-------|+-+   +-+|<-------|+-+      |
+   +---------+        +---------+        +---------+        +---------+
+      UAC               Outbound           Inbound              UAS
+                        Proxy               Proxy
+
+                  Figure 4: Transaction relationships
+
+   A stateless proxy does not contain a client or server transaction.
+   The transaction exists between the UA or stateful proxy on one side,
+   and the UA or stateful proxy on the other side.  As far as SIP
+   transactions are concerned, stateless proxies are effectively
+   transparent.  The purpose of the client transaction is to receive a
+   request from the element in which the client is embedded (call this
+   element the "Transaction User" or TU; it can be a UA or a stateful
+   proxy), and reliably deliver the request to a server transaction.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 123]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The client transaction is also responsible for receiving responses
+   and delivering them to the TU, filtering out any response
+   retransmissions or disallowed responses (such as a response to ACK).
+   Additionally, in the case of an INVITE request, the client
+   transaction is responsible for generating the ACK request for any
+   final response accepting a 2xx response.
+
+   Similarly, the purpose of the server transaction is to receive
+   requests from the transport layer and deliver them to the TU.  The
+   server transaction filters any request retransmissions from the
+   network.  The server transaction accepts responses from the TU and
+   delivers them to the transport layer for transmission over the
+   network.  In the case of an INVITE transaction, it absorbs the ACK
+   request for any final response excepting a 2xx response.
+
+   The 2xx response and its ACK receive special treatment.  This
+   response is retransmitted only by a UAS, and its ACK generated only
+   by the UAC.  This end-to-end treatment is needed so that a caller
+   knows the entire set of users that have accepted the call.  Because
+   of this special handling, retransmissions of the 2xx response are
+   handled by the UA core, not the transaction layer.  Similarly,
+   generation of the ACK for the 2xx is handled by the UA core.  Each
+   proxy along the path merely forwards each 2xx response to INVITE and
+   its corresponding ACK.
+
+17.1 Client Transaction
+
+   The client transaction provides its functionality through the
+   maintenance of a state machine.
+
+   The TU communicates with the client transaction through a simple
+   interface.  When the TU wishes to initiate a new transaction, it
+   creates a client transaction and passes it the SIP request to send
+   and an IP address, port, and transport to which to send it.  The
+   client transaction begins execution of its state machine.  Valid
+   responses are passed up to the TU from the client transaction.
+
+   There are two types of client transaction state machines, depending
+   on the method of the request passed by the TU.  One handles client
+   transactions for INVITE requests.  This type of machine is referred
+   to as an INVITE client transaction.  Another type handles client
+   transactions for all requests except INVITE and ACK.  This is
+   referred to as a non-INVITE client transaction.  There is no client
+   transaction for ACK.  If the TU wishes to send an ACK, it passes one
+   directly to the transport layer for transmission.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 124]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The INVITE transaction is different from those of other methods
+   because of its extended duration.  Normally, human input is required
+   in order to respond to an INVITE.  The long delays expected for
+   sending a response argue for a three-way handshake.  On the other
+   hand, requests of other methods are expected to complete rapidly.
+   Because of the non-INVITE transaction's reliance on a two-way
+   handshake, TUs SHOULD respond immediately to non-INVITE requests.
+
+17.1.1 INVITE Client Transaction
+
+17.1.1.1 Overview of INVITE Transaction
+
+   The INVITE transaction consists of a three-way handshake.  The client
+   transaction sends an INVITE, the server transaction sends responses,
+   and the client transaction sends an ACK.  For unreliable transports
+   (such as UDP), the client transaction retransmits requests at an
+   interval that starts at T1 seconds and doubles after every
+   retransmission.  T1 is an estimate of the round-trip time (RTT), and
+   it defaults to 500 ms.  Nearly all of the transaction timers
+   described here scale with T1, and changing T1 adjusts their values.
+   The request is not retransmitted over reliable transports.  After
+   receiving a 1xx response, any retransmissions cease altogether, and
+   the client waits for further responses.  The server transaction can
+   send additional 1xx responses, which are not transmitted reliably by
+   the server transaction.  Eventually, the server transaction decides
+   to send a final response.  For unreliable transports, that response
+   is retransmitted periodically, and for reliable transports, it is
+   sent once.  For each final response that is received at the client
+   transaction, the client transaction sends an ACK, the purpose of
+   which is to quench retransmissions of the response.
+
+17.1.1.2 Formal Description
+
+   The state machine for the INVITE client transaction is shown in
+   Figure 5.  The initial state, "calling", MUST be entered when the TU
+   initiates a new client transaction with an INVITE request.  The
+   client transaction MUST pass the request to the transport layer for
+   transmission (see Section 18).  If an unreliable transport is being
+   used, the client transaction MUST start timer A with a value of T1.
+   If a reliable transport is being used, the client transaction SHOULD
+   NOT start timer A (Timer A controls request retransmissions).  For
+   any transport, the client transaction MUST start timer B with a value
+   of 64*T1 seconds (Timer B controls transaction timeouts).
+
+   When timer A fires, the client transaction MUST retransmit the
+   request by passing it to the transport layer, and MUST reset the
+   timer with a value of 2*T1.  The formal definition of retransmit
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 125]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   within the context of the transaction layer is to take the message
+   previously sent to the transport layer and pass it to the transport
+   layer once more.
+
+   When timer A fires 2*T1 seconds later, the request MUST be
+   retransmitted again (assuming the client transaction is still in this
+   state).  This process MUST continue so that the request is
+   retransmitted with intervals that double after each transmission.
+   These retransmissions SHOULD only be done while the client
+   transaction is in the "calling" state.
+
+   The default value for T1 is 500 ms.  T1 is an estimate of the RTT
+   between the client and server transactions.  Elements MAY (though it
+   is NOT RECOMMENDED) use smaller values of T1 within closed, private
+   networks that do not permit general Internet connection.  T1 MAY be
+   chosen larger, and this is RECOMMENDED if it is known in advance
+   (such as on high latency access links) that the RTT is larger.
+   Whatever the value of T1, the exponential backoffs on retransmissions
+   described in this section MUST be used.
+
+   If the client transaction is still in the "Calling" state when timer
+   B fires, the client transaction SHOULD inform the TU that a timeout
+   has occurred.  The client transaction MUST NOT generate an ACK.  The
+   value of 64*T1 is equal to the amount of time required to send seven
+   requests in the case of an unreliable transport.
+
+   If the client transaction receives a provisional response while in
+   the "Calling" state, it transitions to the "Proceeding" state. In the
+   "Proceeding" state, the client transaction SHOULD NOT retransmit the
+   request any longer. Furthermore, the provisional response MUST be
+   passed to the TU.  Any further provisional responses MUST be passed
+   up to the TU while in the "Proceeding" state.
+
+   When in either the "Calling" or "Proceeding" states, reception of a
+   response with status code from 300-699 MUST cause the client
+   transaction to transition to "Completed".  The client transaction
+   MUST pass the received response up to the TU, and the client
+   transaction MUST generate an ACK request, even if the transport is
+   reliable (guidelines for constructing the ACK from the response are
+   given in Section 17.1.1.3) and then pass the ACK to the transport
+   layer for transmission.  The ACK MUST be sent to the same address,
+   port, and transport to which the original request was sent.  The
+   client transaction SHOULD start timer D when it enters the
+   "Completed" state, with a value of at least 32 seconds for unreliable
+   transports, and a value of zero seconds for reliable transports.
+   Timer D reflects the amount of time that the server transaction can
+   remain in the "Completed" state when unreliable transports are used.
+   This is equal to Timer H in the INVITE server transaction, whose
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 126]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   default is 64*T1.  However, the client transaction does not know the
+   value of T1 in use by the server transaction, so an absolute minimum
+   of 32s is used instead of basing Timer D on T1.
+
+   Any retransmissions of the final response that are received while in
+   the "Completed" state MUST cause the ACK to be re-passed to the
+   transport layer for retransmission, but the newly received response
+   MUST NOT be passed up to the TU.  A retransmission of the response is
+   defined as any response which would match the same client transaction
+   based on the rules of Section 17.1.3.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 127]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                               |INVITE from TU
+             Timer A fires     |INVITE sent
+             Reset A,          V                      Timer B fires
+             INVITE sent +-----------+                or Transport Err.
+               +---------|           |---------------+inform TU
+               |         |  Calling  |               |
+               +-------->|           |-------------->|
+                         +-----------+ 2xx           |
+                            |  |       2xx to TU     |
+                            |  |1xx                  |
+    300-699 +---------------+  |1xx to TU            |
+   ACK sent |                  |                     |
+resp. to TU |  1xx             V                     |
+            |  1xx to TU  -----------+               |
+            |  +---------|           |               |
+            |  |         |Proceeding |-------------->|
+            |  +-------->|           | 2xx           |
+            |            +-----------+ 2xx to TU     |
+            |       300-699    |                     |
+            |       ACK sent,  |                     |
+            |       resp. to TU|                     |
+            |                  |                     |      NOTE:
+            |  300-699         V                     |
+            |  ACK sent  +-----------+Transport Err. |  transitions
+            |  +---------|           |Inform TU      |  labeled with
+            |  |         | Completed |-------------->|  the event
+            |  +-------->|           |               |  over the action
+            |            +-----------+               |  to take
+            |              ^   |                     |
+            |              |   | Timer D fires       |
+            +--------------+   | -                   |
+                               |                     |
+                               V                     |
+                         +-----------+               |
+                         |           |               |
+                         | Terminated|<--------------+
+                         |           |
+                         +-----------+
+
+                 Figure 5: INVITE client transaction
+
+   If timer D fires while the client transaction is in the "Completed"
+   state, the client transaction MUST move to the terminated state.
+
+   When in either the "Calling" or "Proceeding" states, reception of a
+   2xx response MUST cause the client transaction to enter the
+   "Terminated" state, and the response MUST be passed up to the TU.
+   The handling of this response depends on whether the TU is a proxy
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 128]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   core or a UAC core.  A UAC core will handle generation of the ACK for
+   this response, while a proxy core will always forward the 200 (OK)
+   upstream.  The differing treatment of 200 (OK) between proxy and UAC
+   is the reason that handling of it does not take place in the
+   transaction layer.
+
+   The client transaction MUST be destroyed the instant it enters the
+   "Terminated" state.  This is actually necessary to guarantee correct
+   operation.  The reason is that 2xx responses to an INVITE are treated
+   differently; each one is forwarded by proxies, and the ACK handling
+   in a UAC is different.  Thus, each 2xx needs to be passed to a proxy
+   core (so that it can be forwarded) and to a UAC core (so it can be
+   acknowledged).  No transaction layer processing takes place.
+   Whenever a response is received by the transport, if the transport
+   layer finds no matching client transaction (using the rules of
+   Section 17.1.3), the response is passed directly to the core.  Since
+   the matching client transaction is destroyed by the first 2xx,
+   subsequent 2xx will find no match and therefore be passed to the
+   core.
+
+17.1.1.3 Construction of the ACK Request
+
+   This section specifies the construction of ACK requests sent within
+   the client transaction.  A UAC core that generates an ACK for 2xx
+   MUST instead follow the rules described in Section 13.
+
+   The ACK request constructed by the client transaction MUST contain
+   values for the Call-ID, From, and Request-URI that are equal to the
+   values of those header fields in the request passed to the transport
+   by the client transaction (call this the "original request").  The To
+   header field in the ACK MUST equal the To header field in the
+   response being acknowledged, and therefore will usually differ from
+   the To header field in the original request by the addition of the
+   tag parameter.  The ACK MUST contain a single Via header field, and
+   this MUST be equal to the top Via header field of the original
+   request.  The CSeq header field in the ACK MUST contain the same
+   value for the sequence number as was present in the original request,
+   but the method parameter MUST be equal to "ACK".
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 129]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   If the INVITE request whose response is being acknowledged had Route
+   header fields, those header fields MUST appear in the ACK.  This is
+   to ensure that the ACK can be routed properly through any downstream
+   stateless proxies.
+
+   Although any request MAY contain a body, a body in an ACK is special
+   since the request cannot be rejected if the body is not understood.
+   Therefore, placement of bodies in ACK for non-2xx is NOT RECOMMENDED,
+   but if done, the body types are restricted to any that appeared in
+   the INVITE, assuming that the response to the INVITE was not 415.  If
+   it was, the body in the ACK MAY be any type listed in the Accept
+   header field in the 415.
+
+   For example, consider the following request:
+
+   INVITE sip:bob@biloxi.com SIP/2.0
+   Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKkjshdyff
+   To: Bob <sip:bob@biloxi.com>
+   From: Alice <sip:alice@atlanta.com>;tag=88sja8x
+   Max-Forwards: 70
+   Call-ID: 987asjd97y7atg
+   CSeq: 986759 INVITE
+
+   The ACK request for a non-2xx final response to this request would
+   look like this:
+
+   ACK sip:bob@biloxi.com SIP/2.0
+   Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKkjshdyff
+   To: Bob <sip:bob@biloxi.com>;tag=99sa0xk
+   From: Alice <sip:alice@atlanta.com>;tag=88sja8x
+   Max-Forwards: 70
+   Call-ID: 987asjd97y7atg
+   CSeq: 986759 ACK
+
+17.1.2 Non-INVITE Client Transaction
+
+17.1.2.1 Overview of the non-INVITE Transaction
+
+   Non-INVITE transactions do not make use of ACK.  They are simple
+   request-response interactions.  For unreliable transports, requests
+   are retransmitted at an interval which starts at T1 and doubles until
+   it hits T2.  If a provisional response is received, retransmissions
+   continue for unreliable transports, but at an interval of T2.  The
+   server transaction retransmits the last response it sent, which can
+   be a provisional or final response, only when a retransmission of the
+   request is received.  This is why request retransmissions need to
+   continue even after a provisional response; they are to ensure
+   reliable delivery of the final response.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 130]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Unlike an INVITE transaction, a non-INVITE transaction has no special
+   handling for the 2xx response.  The result is that only a single 2xx
+   response to a non-INVITE is ever delivered to a UAC.
+
+17.1.2.2 Formal Description
+
+   The state machine for the non-INVITE client transaction is shown in
+   Figure 6.  It is very similar to the state machine for INVITE.
+
+   The "Trying" state is entered when the TU initiates a new client
+   transaction with a request.  When entering this state, the client
+   transaction SHOULD set timer F to fire in 64*T1 seconds.  The request
+   MUST be passed to the transport layer for transmission.  If an
+   unreliable transport is in use, the client transaction MUST set timer
+   E to fire in T1 seconds.  If timer E fires while still in this state,
+   the timer is reset, but this time with a value of MIN(2*T1, T2).
+   When the timer fires again, it is reset to a MIN(4*T1, T2).  This
+   process continues so that retransmissions occur with an exponentially
+   increasing interval that caps at T2.  The default value of T2 is 4s,
+   and it represents the amount of time a non-INVITE server transaction
+   will take to respond to a request, if it does not respond
+   immediately.  For the default values of T1 and T2, this results in
+   intervals of 500 ms, 1 s, 2 s, 4 s, 4 s, 4 s, etc.
+
+   If Timer F fires while the client transaction is still in the
+   "Trying" state, the client transaction SHOULD inform the TU about the
+   timeout, and then it SHOULD enter the "Terminated" state.  If a
+   provisional response is received while in the "Trying" state, the
+   response MUST be passed to the TU, and then the client transaction
+   SHOULD move to the "Proceeding" state.  If a final response (status
+   codes 200-699) is received while in the "Trying" state, the response
+   MUST be passed to the TU, and the client transaction MUST transition
+   to the "Completed" state.
+
+   If Timer E fires while in the "Proceeding" state, the request MUST be
+   passed to the transport layer for retransmission, and Timer E MUST be
+   reset with a value of T2 seconds.  If timer F fires while in the
+   "Proceeding" state, the TU MUST be informed of a timeout, and the
+   client transaction MUST transition to the terminated state.  If a
+   final response (status codes 200-699) is received while in the
+   "Proceeding" state, the response MUST be passed to the TU, and the
+   client transaction MUST transition to the "Completed" state.
+
+   Once the client transaction enters the "Completed" state, it MUST set
+   Timer K to fire in T4 seconds for unreliable transports, and zero
+   seconds for reliable transports.  The "Completed" state exists to
+   buffer any additional response retransmissions that may be received
+   (which is why the client transaction remains there only for
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 131]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   unreliable transports).  T4 represents the amount of time the network
+   will take to clear messages between client and server transactions.
+   The default value of T4 is 5s.  A response is a retransmission when
+   it matches the same transaction, using the rules specified in Section
+   17.1.3.  If Timer K fires while in this state, the client transaction
+   MUST transition to the "Terminated" state.
+
+   Once the transaction is in the terminated state, it MUST be destroyed
+   immediately.
+
+17.1.3 Matching Responses to Client Transactions
+
+   When the transport layer in the client receives a response, it has to
+   determine which client transaction will handle the response, so that
+   the processing of Sections 17.1.1 and 17.1.2 can take place.  The
+   branch parameter in the top Via header field is used for this
+   purpose.  A response matches a client transaction under two
+   conditions:
+
+      1.  If the response has the same value of the branch parameter in
+          the top Via header field as the branch parameter in the top
+          Via header field of the request that created the transaction.
+
+      2.  If the method parameter in the CSeq header field matches the
+          method of the request that created the transaction.  The
+          method is needed since a CANCEL request constitutes a
+          different transaction, but shares the same value of the branch
+          parameter.
+
+   If a request is sent via multicast, it is possible that it will
+   generate multiple responses from different servers.  These responses
+   will all have the same branch parameter in the topmost Via, but vary
+   in the To tag.  The first response received, based on the rules
+   above, will be used, and others will be viewed as retransmissions.
+   That is not an error; multicast SIP provides only a rudimentary
+   "single-hop-discovery-like" service that is limited to processing a
+   single response.  See Section 18.1.1 for details.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 132]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+17.1.4 Handling Transport Errors
+
+                                   |Request from TU
+                                   |send request
+               Timer E             V
+               send request  +-----------+
+                   +---------|           |-------------------+
+                   |         |  Trying   |  Timer F          |
+                   +-------->|           |  or Transport Err.|
+                             +-----------+  inform TU        |
+                200-699         |  |                         |
+                resp. to TU     |  |1xx                      |
+                +---------------+  |resp. to TU              |
+                |                  |                         |
+                |   Timer E        V       Timer F           |
+                |   send req +-----------+ or Transport Err. |
+                |  +---------|           | inform TU         |
+                |  |         |Proceeding |------------------>|
+                |  +-------->|           |-----+             |
+                |            +-----------+     |1xx          |
+                |              |      ^        |resp to TU   |
+                | 200-699      |      +--------+             |
+                | resp. to TU  |                             |
+                |              |                             |
+                |              V                             |
+                |            +-----------+                   |
+                |            |           |                   |
+                |            | Completed |                   |
+                |            |           |                   |
+                |            +-----------+                   |
+                |              ^   |                         |
+                |              |   | Timer K                 |
+                +--------------+   | -                       |
+                                   |                         |
+                                   V                         |
+             NOTE:           +-----------+                   |
+                             |           |                   |
+         transitions         | Terminated|<------------------+
+         labeled with        |           |
+         the event           +-----------+
+         over the action
+         to take
+
+                 Figure 6: non-INVITE client transaction
+
+   When the client transaction sends a request to the transport layer to
+   be sent, the following procedures are followed if the transport layer
+   indicates a failure.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 133]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The client transaction SHOULD inform the TU that a transport failure
+   has occurred, and the client transaction SHOULD transition directly
+   to the "Terminated" state.  The TU will handle the failover
+   mechanisms described in [4].
+
+17.2 Server Transaction
+
+   The server transaction is responsible for the delivery of requests to
+   the TU and the reliable transmission of responses.  It accomplishes
+   this through a state machine.  Server transactions are created by the
+   core when a request is received, and transaction handling is desired
+   for that request (this is not always the case).
+
+   As with the client transactions, the state machine depends on whether
+   the received request is an INVITE request.
+
+17.2.1 INVITE Server Transaction
+
+   The state diagram for the INVITE server transaction is shown in
+   Figure 7.
+
+   When a server transaction is constructed for a request, it enters the
+   "Proceeding" state.  The server transaction MUST generate a 100
+   (Trying) response unless it knows that the TU will generate a
+   provisional or final response within 200 ms, in which case it MAY
+   generate a 100 (Trying) response.  This provisional response is
+   needed to quench request retransmissions rapidly in order to avoid
+   network congestion.  The 100 (Trying) response is constructed
+   according to the procedures in Section 8.2.6, except that the
+   insertion of tags in the To header field of the response (when none
+   was present in the request) is downgraded from MAY to SHOULD NOT.
+   The request MUST be passed to the TU.
+
+   The TU passes any number of provisional responses to the server
+   transaction.  So long as the server transaction is in the
+   "Proceeding" state, each of these MUST be passed to the transport
+   layer for transmission.  They are not sent reliably by the
+   transaction layer (they are not retransmitted by it) and do not cause
+   a change in the state of the server transaction.  If a request
+   retransmission is received while in the "Proceeding" state, the most
+   recent provisional response that was received from the TU MUST be
+   passed to the transport layer for retransmission.  A request is a
+   retransmission if it matches the same server transaction based on the
+   rules of Section 17.2.3.
+
+   If, while in the "Proceeding" state, the TU passes a 2xx response to
+   the server transaction, the server transaction MUST pass this
+   response to the transport layer for transmission.  It is not
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 134]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   retransmitted by the server transaction; retransmissions of 2xx
+   responses are handled by the TU.  The server transaction MUST then
+   transition to the "Terminated" state.
+
+   While in the "Proceeding" state, if the TU passes a response with
+   status code from 300 to 699 to the server transaction, the response
+   MUST be passed to the transport layer for transmission, and the state
+   machine MUST enter the "Completed" state.  For unreliable transports,
+   timer G is set to fire in T1 seconds, and is not set to fire for
+   reliable transports.
+
+      This is a change from RFC 2543, where responses were always
+      retransmitted, even over reliable transports.
+
+   When the "Completed" state is entered, timer H MUST be set to fire in
+   64*T1 seconds for all transports.  Timer H determines when the server
+   transaction abandons retransmitting the response.  Its value is
+   chosen to equal Timer B, the amount of time a client transaction will
+   continue to retry sending a request.  If timer G fires, the response
+   is passed to the transport layer once more for retransmission, and
+   timer G is set to fire in MIN(2*T1, T2) seconds.  From then on, when
+   timer G fires, the response is passed to the transport again for
+   transmission, and timer G is reset with a value that doubles, unless
+   that value exceeds T2, in which case it is reset with the value of
+   T2.  This is identical to the retransmit behavior for requests in the
+   "Trying" state of the non-INVITE client transaction.  Furthermore,
+   while in the "Completed" state, if a request retransmission is
+   received, the server SHOULD pass the response to the transport for
+   retransmission.
+
+   If an ACK is received while the server transaction is in the
+   "Completed" state, the server transaction MUST transition to the
+   "Confirmed" state.  As Timer G is ignored in this state, any
+   retransmissions of the response will cease.
+
+   If timer H fires while in the "Completed" state, it implies that the
+   ACK was never received.  In this case, the server transaction MUST
+   transition to the "Terminated" state, and MUST indicate to the TU
+   that a transaction failure has occurred.
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 135]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                               |INVITE
+                               |pass INV to TU
+            INVITE             V send 100 if TU won't in 200ms
+            send response+-----------+
+                +--------|           |--------+101-199 from TU
+                |        | Proceeding|        |send response
+                +------->|           |<-------+
+                         |           |          Transport Err.
+                         |           |          Inform TU
+                         |           |--------------->+
+                         +-----------+                |
+            300-699 from TU |     |2xx from TU        |
+            send response   |     |send response      |
+                            |     +------------------>+
+                            |                         |
+            INVITE          V          Timer G fires  |
+            send response+-----------+ send response  |
+                +--------|           |--------+       |
+                |        | Completed |        |       |
+                +------->|           |<-------+       |
+                         +-----------+                |
+                            |     |                   |
+                        ACK |     |                   |
+                        -   |     +------------------>+
+                            |        Timer H fires    |
+                            V        or Transport Err.|
+                         +-----------+  Inform TU     |
+                         |           |                |
+                         | Confirmed |                |
+                         |           |                |
+                         +-----------+                |
+                               |                      |
+                               |Timer I fires         |
+                               |-                     |
+                               |                      |
+                               V                      |
+                         +-----------+                |
+                         |           |                |
+                         | Terminated|<---------------+
+                         |           |
+                         +-----------+
+
+              Figure 7: INVITE server transaction
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 136]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The purpose of the "Confirmed" state is to absorb any additional ACK
+   messages that arrive, triggered from retransmissions of the final
+   response.  When this state is entered, timer I is set to fire in T4
+   seconds for unreliable transports, and zero seconds for reliable
+   transports.  Once timer I fires, the server MUST transition to the
+   "Terminated" state.
+
+   Once the transaction is in the "Terminated" state, it MUST be
+   destroyed immediately.  As with client transactions, this is needed
+   to ensure reliability of the 2xx responses to INVITE.
+
+17.2.2 Non-INVITE Server Transaction
+
+   The state machine for the non-INVITE server transaction is shown in
+   Figure 8.
+
+   The state machine is initialized in the "Trying" state and is passed
+   a request other than INVITE or ACK when initialized.  This request is
+   passed up to the TU.  Once in the "Trying" state, any further request
+   retransmissions are discarded.  A request is a retransmission if it
+   matches the same server transaction, using the rules specified in
+   Section 17.2.3.
+
+   While in the "Trying" state, if the TU passes a provisional response
+   to the server transaction, the server transaction MUST enter the
+   "Proceeding" state.  The response MUST be passed to the transport
+   layer for transmission.  Any further provisional responses that are
+   received from the TU while in the "Proceeding" state MUST be passed
+   to the transport layer for transmission.  If a retransmission of the
+   request is received while in the "Proceeding" state, the most
+   recently sent provisional response MUST be passed to the transport
+   layer for retransmission.  If the TU passes a final response (status
+   codes 200-699) to the server while in the "Proceeding" state, the
+   transaction MUST enter the "Completed" state, and the response MUST
+   be passed to the transport layer for transmission.
+
+   When the server transaction enters the "Completed" state, it MUST set
+   Timer J to fire in 64*T1 seconds for unreliable transports, and zero
+   seconds for reliable transports.  While in the "Completed" state, the
+   server transaction MUST pass the final response to the transport
+   layer for retransmission whenever a retransmission of the request is
+   received.  Any other final responses passed by the TU to the server
+   transaction MUST be discarded while in the "Completed" state.  The
+   server transaction remains in this state until Timer J fires, at
+   which point it MUST transition to the "Terminated" state.
+
+   The server transaction MUST be destroyed the instant it enters the
+   "Terminated" state.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 137]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+17.2.3 Matching Requests to Server Transactions
+
+   When a request is received from the network by the server, it has to
+   be matched to an existing transaction.  This is accomplished in the
+   following manner.
+
+   The branch parameter in the topmost Via header field of the request
+   is examined.  If it is present and begins with the magic cookie
+   "z9hG4bK", the request was generated by a client transaction
+   compliant to this specification.  Therefore, the branch parameter
+   will be unique across all transactions sent by that client.  The
+   request matches a transaction if:
+
+      1. the branch parameter in the request is equal to the one in the
+         top Via header field of the request that created the
+         transaction, and
+
+      2. the sent-by value in the top Via of the request is equal to the
+         one in the request that created the transaction, and
+
+      3. the method of the request matches the one that created the
+         transaction, except for ACK, where the method of the request
+         that created the transaction is INVITE.
+
+   This matching rule applies to both INVITE and non-INVITE transactions
+   alike.
+
+      The sent-by value is used as part of the matching process because
+      there could be accidental or malicious duplication of branch
+      parameters from different clients.
+
+   If the branch parameter in the top Via header field is not present,
+   or does not contain the magic cookie, the following procedures are
+   used.  These exist to handle backwards compatibility with RFC 2543
+   compliant implementations.
+
+   The INVITE request matches a transaction if the Request-URI, To tag,
+   From tag, Call-ID, CSeq, and top Via header field match those of the
+   INVITE request which created the transaction.  In this case, the
+   INVITE is a retransmission of the original one that created the
+   transaction.  The ACK request matches a transaction if the Request-
+   URI, From tag, Call-ID, CSeq number (not the method), and top Via
+   header field match those of the INVITE request which created the
+   transaction, and the To tag of the ACK matches the To tag of the
+   response sent by the server transaction.  Matching is done based on
+   the matching rules defined for each of those header fields.
+   Inclusion of the tag in the To header field in the ACK matching
+   process helps disambiguate ACK for 2xx from ACK for other responses
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 138]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   at a proxy, which may have forwarded both responses (This can occur
+   in unusual conditions.  Specifically, when a proxy forked a request,
+   and then crashes, the responses may be delivered to another proxy,
+   which might end up forwarding multiple responses upstream).  An ACK
+   request that matches an INVITE transaction matched by a previous ACK
+   is considered a retransmission of that previous ACK.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 139]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                                  |Request received
+                                  |pass to TU
+                                  V
+                            +-----------+
+                            |           |
+                            | Trying    |-------------+
+                            |           |             |
+                            +-----------+             |200-699 from TU
+                                  |                   |send response
+                                  |1xx from TU        |
+                                  |send response      |
+                                  |                   |
+               Request            V      1xx from TU  |
+               send response+-----------+send response|
+                   +--------|           |--------+    |
+                   |        | Proceeding|        |    |
+                   +------->|           |<-------+    |
+            +<--------------|           |             |
+            |Trnsprt Err    +-----------+             |
+            |Inform TU            |                   |
+            |                     |                   |
+            |                     |200-699 from TU    |
+            |                     |send response      |
+            |  Request            V                   |
+            |  send response+-----------+             |
+            |      +--------|           |             |
+            |      |        | Completed |<------------+
+            |      +------->|           |
+            +<--------------|           |
+            |Trnsprt Err    +-----------+
+            |Inform TU            |
+            |                     |Timer J fires
+            |                     |-
+            |                     |
+            |                     V
+            |               +-----------+
+            |               |           |
+            +-------------->| Terminated|
+                            |           |
+                            +-----------+
+
+                Figure 8: non-INVITE server transaction
+
+   For all other request methods, a request is matched to a transaction
+   if the Request-URI, To tag, From tag, Call-ID, CSeq (including the
+   method), and top Via header field match those of the request that
+   created the transaction.  Matching is done based on the matching
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 140]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   rules defined for each of those header fields.  When a non-INVITE
+   request matches an existing transaction, it is a retransmission of
+   the request that created that transaction.
+
+   Because the matching rules include the Request-URI, the server cannot
+   match a response to a transaction.  When the TU passes a response to
+   the server transaction, it must pass it to the specific server
+   transaction for which the response is targeted.
+
+17.2.4 Handling Transport Errors
+
+   When the server transaction sends a response to the transport layer
+   to be sent, the following procedures are followed if the transport
+   layer indicates a failure.
+
+   First, the procedures in [4] are followed, which attempt to deliver
+   the response to a backup.  If those should all fail, based on the
+   definition of failure in [4], the server transaction SHOULD inform
+   the TU that a failure has occurred, and SHOULD transition to the
+   terminated state.
+
+18 Transport
+
+   The transport layer is responsible for the actual transmission of
+   requests and responses over network transports.  This includes
+   determination of the connection to use for a request or response in
+   the case of connection-oriented transports.
+
+   The transport layer is responsible for managing persistent
+   connections for transport protocols like TCP and SCTP, or TLS over
+   those, including ones opened to the transport layer.  This includes
+   connections opened by the client or server transports, so that
+   connections are shared between client and server transport functions.
+   These connections are indexed by the tuple formed from the address,
+   port, and transport protocol at the far end of the connection.  When
+   a connection is opened by the transport layer, this index is set to
+   the destination IP, port and transport.  When the connection is
+   accepted by the transport layer, this index is set to the source IP
+   address, port number, and transport.  Note that, because the source
+   port is often ephemeral, but it cannot be known whether it is
+   ephemeral or selected through procedures in [4], connections accepted
+   by the transport layer will frequently not be reused.  The result is
+   that two proxies in a "peering" relationship using a connection-
+   oriented transport frequently will have two connections in use, one
+   for transactions initiated in each direction.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 141]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   It is RECOMMENDED that connections be kept open for some
+   implementation-defined duration after the last message was sent or
+   received over that connection.  This duration SHOULD at least equal
+   the longest amount of time the element would need in order to bring a
+   transaction from instantiation to the terminated state.  This is to
+   make it likely that transactions are completed over the same
+   connection on which they are initiated (for example, request,
+   response, and in the case of INVITE, ACK for non-2xx responses).
+   This usually means at least 64*T1 (see Section 17.1.1.1 for a
+   definition of T1).  However, it could be larger in an element that
+   has a TU using a large value for timer C (bullet 11 of Section 16.6),
+   for example.
+
+   All SIP elements MUST implement UDP and TCP.  SIP elements MAY
+   implement other protocols.
+
+      Making TCP mandatory for the UA is a substantial change from RFC
+      2543.  It has arisen out of the need to handle larger messages,
+      which MUST use TCP, as discussed below.  Thus, even if an element
+      never sends large messages, it may receive one and needs to be
+      able to handle them.
+
+18.1 Clients
+
+18.1.1 Sending Requests
+
+   The client side of the transport layer is responsible for sending the
+   request and receiving responses.  The user of the transport layer
+   passes the client transport the request, an IP address, port,
+   transport, and possibly TTL for multicast destinations.
+
+   If a request is within 200 bytes of the path MTU, or if it is larger
+   than 1300 bytes and the path MTU is unknown, the request MUST be sent
+   using an RFC 2914 [43] congestion controlled transport protocol, such
+   as TCP. If this causes a change in the transport protocol from the
+   one indicated in the top Via, the value in the top Via MUST be
+   changed.  This prevents fragmentation of messages over UDP and
+   provides congestion control for larger messages.  However,
+   implementations MUST be able to handle messages up to the maximum
+   datagram packet size.  For UDP, this size is 65,535 bytes, including
+   IP and UDP headers.
+
+      The 200 byte "buffer" between the message size and the MTU
+      accommodates the fact that the response in SIP can be larger than
+      the request.  This happens due to the addition of Record-Route
+      header field values to the responses to INVITE, for example.  With
+      the extra buffer, the response can be about 170 bytes larger than
+      the request, and still not be fragmented on IPv4 (about 30 bytes
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 142]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      is consumed by IP/UDP, assuming no IPSec).  1300 is chosen when
+      path MTU is not known, based on the assumption of a 1500 byte
+      Ethernet MTU.
+
+   If an element sends a request over TCP because of these message size
+   constraints, and that request would have otherwise been sent over
+   UDP, if the attempt to establish the connection generates either an
+   ICMP Protocol Not Supported, or results in a TCP reset, the element
+   SHOULD retry the request, using UDP.  This is only to provide
+   backwards compatibility with RFC 2543 compliant implementations that
+   do not support TCP.  It is anticipated that this behavior will be
+   deprecated in a future revision of this specification.
+
+   A client that sends a request to a multicast address MUST add the
+   "maddr" parameter to its Via header field value containing the
+   destination multicast address, and for IPv4, SHOULD add the "ttl"
+   parameter with a value of 1.  Usage of IPv6 multicast is not defined
+   in this specification, and will be a subject of future
+   standardization when the need arises.
+
+   These rules result in a purposeful limitation of multicast in SIP.
+   Its primary function is to provide a "single-hop-discovery-like"
+   service, delivering a request to a group of homogeneous servers,
+   where it is only required to process the response from any one of
+   them.  This functionality is most useful for registrations.  In fact,
+   based on the transaction processing rules in Section 17.1.3, the
+   client transaction will accept the first response, and view any
+   others as retransmissions because they all contain the same Via
+   branch identifier.
+
+   Before a request is sent, the client transport MUST insert a value of
+   the "sent-by" field into the Via header field.  This field contains
+   an IP address or host name, and port.  The usage of an FQDN is
+   RECOMMENDED.  This field is used for sending responses under certain
+   conditions, described below.  If the port is absent, the default
+   value depends on the transport.  It is 5060 for UDP, TCP and SCTP,
+   5061 for TLS.
+
+   For reliable transports, the response is normally sent on the
+   connection on which the request was received.  Therefore, the client
+   transport MUST be prepared to receive the response on the same
+   connection used to send the request.  Under error conditions, the
+   server may attempt to open a new connection to send the response.  To
+   handle this case, the transport layer MUST also be prepared to
+   receive an incoming connection on the source IP address from which
+   the request was sent and port number in the "sent-by" field.  It also
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 143]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   MUST be prepared to receive incoming connections on any address and
+   port that would be selected by a server based on the procedures
+   described in Section 5 of [4].
+
+   For unreliable unicast transports, the client transport MUST be
+   prepared to receive responses on the source IP address from which the
+   request is sent (as responses are sent back to the source address)
+   and the port number in the "sent-by" field.  Furthermore, as with
+   reliable transports, in certain cases the response will be sent
+   elsewhere.  The client MUST be prepared to receive responses on any
+   address and port that would be selected by a server based on the
+   procedures described in Section 5 of [4].
+
+   For multicast, the client transport MUST be prepared to receive
+   responses on the same multicast group and port to which the request
+   is sent (that is, it needs to be a member of the multicast group it
+   sent the request to.)
+
+   If a request is destined to an IP address, port, and transport to
+   which an existing connection is open, it is RECOMMENDED that this
+   connection be used to send the request, but another connection MAY be
+   opened and used.
+
+   If a request is sent using multicast, it is sent to the group
+   address, port, and TTL provided by the transport user.  If a request
+   is sent using unicast unreliable transports, it is sent to the IP
+   address and port provided by the transport user.
+
+18.1.2 Receiving Responses
+
+   When a response is received, the client transport examines the top
+   Via header field value.  If the value of the "sent-by" parameter in
+   that header field value does not correspond to a value that the
+   client transport is configured to insert into requests, the response
+   MUST be silently discarded.
+
+   If there are any client transactions in existence, the client
+   transport uses the matching procedures of Section 17.1.3 to attempt
+   to match the response to an existing transaction.  If there is a
+   match, the response MUST be passed to that transaction.  Otherwise,
+   the response MUST be passed to the core (whether it be stateless
+   proxy, stateful proxy, or UA) for further processing.  Handling of
+   these "stray" responses is dependent on the core (a proxy will
+   forward them, while a UA will discard, for example).
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 144]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+18.2 Servers
+
+18.2.1 Receiving Requests
+
+   A server SHOULD be prepared to receive requests on any IP address,
+   port and transport combination that can be the result of a DNS lookup
+   on a SIP or SIPS URI [4] that is handed out for the purposes of
+   communicating with that server.  In this context, "handing out"
+   includes placing a URI in a Contact header field in a REGISTER
+   request or a redirect response, or in a Record-Route header field in
+   a request or response.  A URI can also be "handed out" by placing it
+   on a web page or business card.  It is also RECOMMENDED that a server
+   listen for requests on the default SIP ports (5060 for TCP and UDP,
+   5061 for TLS over TCP) on all public interfaces.  The typical
+   exception would be private networks, or when multiple server
+   instances are running on the same host.  For any port and interface
+   that a server listens on for UDP, it MUST listen on that same port
+   and interface for TCP.  This is because a message may need to be sent
+   using TCP, rather than UDP, if it is too large.  As a result, the
+   converse is not true.  A server need not listen for UDP on a
+   particular address and port just because it is listening on that same
+   address and port for TCP.  There may, of course, be other reasons why
+   a server needs to listen for UDP on a particular address and port.
+
+   When the server transport receives a request over any transport, it
+   MUST examine the value of the "sent-by" parameter in the top Via
+   header field value.  If the host portion of the "sent-by" parameter
+   contains a domain name, or if it contains an IP address that differs
+   from the packet source address, the server MUST add a "received"
+   parameter to that Via header field value.  This parameter MUST
+   contain the source address from which the packet was received.  This
+   is to assist the server transport layer in sending the response,
+   since it must be sent to the source IP address from which the request
+   came.
+
+   Consider a request received by the server transport which looks like,
+   in part:
+
+      INVITE sip:bob@Biloxi.com SIP/2.0
+      Via: SIP/2.0/UDP bobspc.biloxi.com:5060
+
+   The request is received with a source IP address of 192.0.2.4.
+   Before passing the request up, the transport adds a "received"
+   parameter, so that the request would look like, in part:
+
+      INVITE sip:bob@Biloxi.com SIP/2.0
+      Via: SIP/2.0/UDP bobspc.biloxi.com:5060;received=192.0.2.4
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 145]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Next, the server transport attempts to match the request to a server
+   transaction.  It does so using the matching rules described in
+   Section 17.2.3.  If a matching server transaction is found, the
+   request is passed to that transaction for processing.  If no match is
+   found, the request is passed to the core, which may decide to
+   construct a new server transaction for that request.  Note that when
+   a UAS core sends a 2xx response to INVITE, the server transaction is
+   destroyed.  This means that when the ACK arrives, there will be no
+   matching server transaction, and based on this rule, the ACK is
+   passed to the UAS core, where it is processed.
+
+18.2.2 Sending Responses
+
+   The server transport uses the value of the top Via header field in
+   order to determine where to send a response.  It MUST follow the
+   following process:
+
+      o  If the "sent-protocol" is a reliable transport protocol such as
+         TCP or SCTP, or TLS over those, the response MUST be sent using
+         the existing connection to the source of the original request
+         that created the transaction, if that connection is still open.
+         This requires the server transport to maintain an association
+         between server transactions and transport connections.  If that
+         connection is no longer open, the server SHOULD open a
+         connection to the IP address in the "received" parameter, if
+         present, using the port in the "sent-by" value, or the default
+         port for that transport, if no port is specified.  If that
+         connection attempt fails, the server SHOULD use the procedures
+         in [4] for servers in order to determine the IP address and
+         port to open the connection and send the response to.
+
+      o  Otherwise, if the Via header field value contains a "maddr"
+         parameter, the response MUST be forwarded to the address listed
+         there, using the port indicated in "sent-by", or port 5060 if
+         none is present.  If the address is a multicast address, the
+         response SHOULD be sent using the TTL indicated in the "ttl"
+         parameter, or with a TTL of 1 if that parameter is not present.
+
+      o  Otherwise (for unreliable unicast transports), if the top Via
+         has a "received" parameter, the response MUST be sent to the
+         address in the "received" parameter, using the port indicated
+         in the "sent-by" value, or using port 5060 if none is specified
+         explicitly.  If this fails, for example, elicits an ICMP "port
+         unreachable" response, the procedures of Section 5 of [4]
+         SHOULD be used to determine where to send the response.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 146]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      o  Otherwise, if it is not receiver-tagged, the response MUST be
+         sent to the address indicated by the "sent-by" value, using the
+         procedures in Section 5 of [4].
+
+18.3 Framing
+
+   In the case of message-oriented transports (such as UDP), if the
+   message has a Content-Length header field, the message body is
+   assumed to contain that many bytes.  If there are additional bytes in
+   the transport packet beyond the end of the body, they MUST be
+   discarded.  If the transport packet ends before the end of the
+   message body, this is considered an error.  If the message is a
+   response, it MUST be discarded.  If the message is a request, the
+   element SHOULD generate a 400 (Bad Request) response.  If the message
+   has no Content-Length header field, the message body is assumed to
+   end at the end of the transport packet.
+
+   In the case of stream-oriented transports such as TCP, the Content-
+   Length header field indicates the size of the body.  The Content-
+   Length header field MUST be used with stream oriented transports.
+
+18.4 Error Handling
+
+   Error handling is independent of whether the message was a request or
+   response.
+
+   If the transport user asks for a message to be sent over an
+   unreliable transport, and the result is an ICMP error, the behavior
+   depends on the type of ICMP error.  Host, network, port or protocol
+   unreachable errors, or parameter problem errors SHOULD cause the
+   transport layer to inform the transport user of a failure in sending.
+   Source quench and TTL exceeded ICMP errors SHOULD be ignored.
+
+   If the transport user asks for a request to be sent over a reliable
+   transport, and the result is a connection failure, the transport
+   layer SHOULD inform the transport user of a failure in sending.
+
+19 Common Message Components
+
+   There are certain components of SIP messages that appear in various
+   places within SIP messages (and sometimes, outside of them) that
+   merit separate discussion.
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 147]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+19.1 SIP and SIPS Uniform Resource Indicators
+
+   A SIP or SIPS URI identifies a communications resource.  Like all
+   URIs, SIP and SIPS URIs may be placed in web pages, email messages,
+   or printed literature.  They contain sufficient information to
+   initiate and maintain a communication session with the resource.
+
+   Examples of communications resources include the following:
+
+      o  a user of an online service
+
+      o  an appearance on a multi-line phone
+
+      o  a mailbox on a messaging system
+
+      o  a PSTN number at a gateway service
+
+      o  a group (such as "sales" or "helpdesk") in an organization
+
+   A SIPS URI specifies that the resource be contacted securely.  This
+   means, in particular, that TLS is to be used between the UAC and the
+   domain that owns the URI.  From there, secure communications are used
+   to reach the user, where the specific security mechanism depends on
+   the policy of the domain.  Any resource described by a SIP URI can be
+   "upgraded" to a SIPS URI by just changing the scheme, if it is
+   desired to communicate with that resource securely.
+
+19.1.1 SIP and SIPS URI Components
+
+   The "sip:" and "sips:" schemes follow the guidelines in RFC 2396 [5].
+   They use a form similar to the mailto URL, allowing the specification
+   of SIP request-header fields and the SIP message-body.  This makes it
+   possible to specify the subject, media type, or urgency of sessions
+   initiated by using a URI on a web page or in an email message.  The
+   formal syntax for a SIP or SIPS URI is presented in Section 25.  Its
+   general form, in the case of a SIP URI, is:
+
+      sip:user:password@host:port;uri-parameters?headers
+
+   The format for a SIPS URI is the same, except that the scheme is
+   "sips" instead of sip.  These tokens, and some of the tokens in their
+   expansions, have the following meanings:
+
+      user: The identifier of a particular resource at the host being
+         addressed.  The term "host" in this context frequently refers
+         to a domain.  The "userinfo" of a URI consists of this user
+         field, the password field, and the @ sign following them.  The
+         userinfo part of a URI is optional and MAY be absent when the
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 148]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         destination host does not have a notion of users or when the
+         host itself is the resource being identified.  If the @ sign is
+         present in a SIP or SIPS URI, the user field MUST NOT be empty.
+
+         If the host being addressed can process telephone numbers, for
+         instance, an Internet telephony gateway, a telephone-
+         subscriber field defined in RFC 2806 [9] MAY be used to
+         populate the user field.  There are special escaping rules for
+         encoding telephone-subscriber fields in SIP and SIPS URIs
+         described in Section 19.1.2.
+
+      password: A password associated with the user.  While the SIP and
+         SIPS URI syntax allows this field to be present, its use is NOT
+         RECOMMENDED, because the passing of authentication information
+         in clear text (such as URIs) has proven to be a security risk
+         in almost every case where it has been used.  For instance,
+         transporting a PIN number in this field exposes the PIN.
+
+         Note that the password field is just an extension of the user
+         portion.  Implementations not wishing to give special
+         significance to the password portion of the field MAY simply
+         treat "user:password" as a single string.
+
+      host: The host providing the SIP resource.  The host part contains
+         either a fully-qualified domain name or numeric IPv4 or IPv6
+         address.  Using the fully-qualified domain name form is
+         RECOMMENDED whenever possible.
+
+      port: The port number where the request is to be sent.
+
+      URI parameters: Parameters affecting a request constructed from
+         the URI.
+
+         URI parameters are added after the hostport component and are
+         separated by semi-colons.
+
+         URI parameters take the form:
+
+            parameter-name "=" parameter-value
+
+         Even though an arbitrary number of URI parameters may be
+         included in a URI, any given parameter-name MUST NOT appear
+         more than once.
+
+         This extensible mechanism includes the transport, maddr, ttl,
+         user, method and lr parameters.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 149]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         The transport parameter determines the transport mechanism to
+         be used for sending SIP messages, as specified in [4].  SIP can
+         use any network transport protocol.  Parameter names are
+         defined for UDP (RFC 768 [14]), TCP (RFC 761 [15]), and SCTP
+         (RFC 2960 [16]).  For a SIPS URI, the transport parameter MUST
+         indicate a reliable transport.
+
+         The maddr parameter indicates the server address to be
+         contacted for this user, overriding any address derived from
+         the host field.  When an maddr parameter is present, the port
+         and transport components of the URI apply to the address
+         indicated in the maddr parameter value.  [4] describes the
+         proper interpretation of the transport, maddr, and hostport in
+         order to obtain the destination address, port, and transport
+         for sending a request.
+
+         The maddr field has been used as a simple form of loose source
+         routing.  It allows a URI to specify a proxy that must be
+         traversed en-route to the destination.  Continuing to use the
+         maddr parameter this way is strongly discouraged (the
+         mechanisms that enable it are deprecated).  Implementations
+         should instead use the Route mechanism described in this
+         document, establishing a pre-existing route set if necessary
+         (see Section 8.1.1.1).  This provides a full URI to describe
+         the node to be traversed.
+
+         The ttl parameter determines the time-to-live value of the UDP
+         multicast packet and MUST only be used if maddr is a multicast
+         address and the transport protocol is UDP.  For example, to
+         specify a call to alice@atlanta.com using multicast to
+         239.255.255.1 with a ttl of 15, the following URI would be
+         used:
+
+            sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15
+
+         The set of valid telephone-subscriber strings is a subset of
+         valid user strings.  The user URI parameter exists to
+         distinguish telephone numbers from user names that happen to
+         look like telephone numbers.  If the user string contains a
+         telephone number formatted as a telephone-subscriber, the user
+         parameter value "phone" SHOULD be present.  Even without this
+         parameter, recipients of SIP and SIPS URIs MAY interpret the
+         pre-@ part as a telephone number if local restrictions on the
+         name space for user name allow it.
+
+         The method of the SIP request constructed from the URI can be
+         specified with the method parameter.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 150]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         The lr parameter, when present, indicates that the element
+         responsible for this resource implements the routing mechanisms
+         specified in this document.  This parameter will be used in the
+         URIs proxies place into Record-Route header field values, and
+         may appear in the URIs in a pre-existing route set.
+
+         This parameter is used to achieve backwards compatibility with
+         systems implementing the strict-routing mechanisms of RFC 2543
+         and the rfc2543bis drafts up to bis-05.  An element preparing
+         to send a request based on a URI not containing this parameter
+         can assume the receiving element implements strict-routing and
+         reformat the message to preserve the information in the
+         Request-URI.
+
+         Since the uri-parameter mechanism is extensible, SIP elements
+         MUST silently ignore any uri-parameters that they do not
+         understand.
+
+      Headers: Header fields to be included in a request constructed
+         from the URI.
+
+         Headers fields in the SIP request can be specified with the "?"
+         mechanism within a URI.  The header names and values are
+         encoded in ampersand separated hname = hvalue pairs.  The
+         special hname "body" indicates that the associated hvalue is
+         the message-body of the SIP request.
+
+   Table 1 summarizes the use of SIP and SIPS URI components based on
+   the context in which the URI appears.  The external column describes
+   URIs appearing anywhere outside of a SIP message, for instance on a
+   web page or business card.  Entries marked "m" are mandatory, those
+   marked "o" are optional, and those marked "-" are not allowed.
+   Elements processing URIs SHOULD ignore any disallowed components if
+   they are present.  The second column indicates the default value of
+   an optional element if it is not present.  "--" indicates that the
+   element is either not optional, or has no default value.
+
+   URIs in Contact header fields have different restrictions depending
+   on the context in which the header field appears.  One set applies to
+   messages that establish and maintain dialogs (INVITE and its 200 (OK)
+   response).  The other applies to registration and redirection
+   messages (REGISTER, its 200 (OK) response, and 3xx class responses to
+   any method).
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 151]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+19.1.2 Character Escaping Requirements
+
+                                                       dialog
+                                          reg./redir. Contact/
+              default  Req.-URI  To  From  Contact   R-R/Route  external
+user          --          o      o    o       o          o         o
+password      --          o      o    o       o          o         o
+host          --          m      m    m       m          m         m
+port          (1)         o      -    -       o          o         o
+user-param    ip          o      o    o       o          o         o
+method        INVITE      -      -    -       -          -         o
+maddr-param   --          o      -    -       o          o         o
+ttl-param     1           o      -    -       o          -         o
+transp.-param (2)         o      -    -       o          o         o
+lr-param      --          o      -    -       -          o         o
+other-param   --          o      o    o       o          o         o
+headers       --          -      -    -       o          -         o
+
+   (1): The default port value is transport and scheme dependent.  The
+   default  is  5060  for  sip: using UDP, TCP, or SCTP.  The default is
+   5061 for sip: using TLS over TCP and sips: over TCP.
+
+   (2): The default transport is scheme dependent.  For sip:, it is UDP.
+   For sips:, it is TCP.
+
+   Table 1: Use and default values of URI components for SIP header
+   field values, Request-URI and references
+
+   SIP follows the requirements and guidelines of RFC 2396 [5] when
+   defining the set of characters that must be escaped in a SIP URI, and
+   uses its ""%" HEX HEX" mechanism for escaping.  From RFC 2396 [5]:
+
+      The set of characters actually reserved within any given URI
+      component is defined by that component.  In general, a character
+      is reserved if the semantics of the URI changes if the character
+      is replaced with its escaped US-ASCII encoding [5].  Excluded US-
+      ASCII characters (RFC 2396 [5]), such as space and control
+      characters and characters used as URI delimiters, also MUST be
+      escaped.  URIs MUST NOT contain unescaped space and control
+      characters.
+
+   For each component, the set of valid BNF expansions defines exactly
+   which characters may appear unescaped.  All other characters MUST be
+   escaped.
+
+   For example, "@" is not in the set of characters in the user
+   component, so the user "j@s0n" must have at least the @ sign encoded,
+   as in "j%40s0n".
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 152]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Expanding the hname and hvalue tokens in Section 25 show that all URI
+   reserved characters in header field names and values MUST be escaped.
+
+   The telephone-subscriber subset of the user component has special
+   escaping considerations.  The set of characters not reserved in the
+   RFC 2806 [9] description of telephone-subscriber contains a number of
+   characters in various syntax elements that need to be escaped when
+   used in SIP URIs.  Any characters occurring in a telephone-subscriber
+   that do not appear in an expansion of the BNF for the user rule MUST
+   be escaped.
+
+   Note that character escaping is not allowed in the host component of
+   a SIP or SIPS URI (the % character is not valid in its expansion).
+   This is likely to change in the future as requirements for
+   Internationalized Domain Names are finalized.  Current
+   implementations MUST NOT attempt to improve robustness by treating
+   received escaped characters in the host component as literally
+   equivalent to their unescaped counterpart.  The behavior required to
+   meet the requirements of IDN may be significantly different.
+
+19.1.3 Example SIP and SIPS URIs
+
+   sip:alice@atlanta.com
+   sip:alice:secretword@atlanta.com;transport=tcp
+   sips:alice@atlanta.com?subject=project%20x&priority=urgent
+   sip:+1-212-555-1212:1234@gateway.com;user=phone
+   sips:1212@gateway.com
+   sip:alice@192.0.2.4
+   sip:atlanta.com;method=REGISTER?to=alice%40atlanta.com
+   sip:alice;day=tuesday@atlanta.com
+
+   The last sample URI above has a user field value of
+   "alice;day=tuesday".  The escaping rules defined above allow a
+   semicolon to appear unescaped in this field.  For the purposes of
+   this protocol, the field is opaque.  The structure of that value is
+   only useful to the SIP element responsible for the resource.
+
+19.1.4 URI Comparison
+
+   Some operations in this specification require determining whether two
+   SIP or SIPS URIs are equivalent.  In this specification, registrars
+   need to compare bindings in Contact URIs in REGISTER requests (see
+   Section 10.3.).  SIP and SIPS URIs are compared for equality
+   according to the following rules:
+
+      o  A SIP and SIPS URI are never equivalent.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 153]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      o  Comparison of the userinfo of SIP and SIPS URIs is case-
+         sensitive.  This includes userinfo containing passwords or
+         formatted as telephone-subscribers.  Comparison of all other
+         components of the URI is case-insensitive unless explicitly
+         defined otherwise.
+
+      o  The ordering of parameters and header fields is not significant
+         in comparing SIP and SIPS URIs.
+
+      o  Characters other than those in the "reserved" set (see RFC 2396
+         [5]) are equivalent to their ""%" HEX HEX" encoding.
+
+      o  An IP address that is the result of a DNS lookup of a host name
+         does not match that host name.
+
+      o  For two URIs to be equal, the user, password, host, and port
+         components must match.
+
+         A URI omitting the user component will not match a URI that
+         includes one.  A URI omitting the password component will not
+         match a URI that includes one.
+
+         A URI omitting any component with a default value will not
+         match a URI explicitly containing that component with its
+         default value.  For instance, a URI omitting the optional port
+         component will not match a URI explicitly declaring port 5060.
+         The same is true for the transport-parameter, ttl-parameter,
+         user-parameter, and method components.
+
+            Defining sip:user@host to not be equivalent to
+            sip:user@host:5060 is a change from RFC 2543.  When deriving
+            addresses from URIs, equivalent addresses are expected from
+            equivalent URIs.  The URI sip:user@host:5060 will always
+            resolve to port 5060.  The URI sip:user@host may resolve to
+            other ports through the DNS SRV mechanisms detailed in [4].
+
+      o  URI uri-parameter components are compared as follows:
+
+         -  Any uri-parameter appearing in both URIs must match.
+
+         -  A user, ttl, or method uri-parameter appearing in only one
+            URI never matches, even if it contains the default value.
+
+         -  A URI that includes an maddr parameter will not match a URI
+            that contains no maddr parameter.
+
+         -  All other uri-parameters appearing in only one URI are
+            ignored when comparing the URIs.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 154]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      o  URI header components are never ignored.  Any present header
+         component MUST be present in both URIs and match for the URIs
+         to match.  The matching rules are defined for each header field
+         in Section 20.
+
+   The URIs within each of the following sets are equivalent:
+
+   sip:%61lice@atlanta.com;transport=TCP
+   sip:alice@AtLanTa.CoM;Transport=tcp
+
+   sip:carol@chicago.com
+   sip:carol@chicago.com;newparam=5
+   sip:carol@chicago.com;security=on
+
+   sip:biloxi.com;transport=tcp;method=REGISTER?to=sip:bob%40biloxi.com
+   sip:biloxi.com;method=REGISTER;transport=tcp?to=sip:bob%40biloxi.com
+
+   sip:alice@atlanta.com?subject=project%20x&priority=urgent
+   sip:alice@atlanta.com?priority=urgent&subject=project%20x
+
+   The URIs within each of the following sets are not equivalent:
+
+   SIP:ALICE@AtLanTa.CoM;Transport=udp             (different usernames)
+   sip:alice@AtLanTa.CoM;Transport=UDP
+
+   sip:bob@biloxi.com                   (can resolve to different ports)
+   sip:bob@biloxi.com:5060
+
+   sip:bob@biloxi.com              (can resolve to different transports)
+   sip:bob@biloxi.com;transport=udp
+
+   sip:bob@biloxi.com     (can resolve to different port and transports)
+   sip:bob@biloxi.com:6000;transport=tcp
+
+   sip:carol@chicago.com                    (different header component)
+   sip:carol@chicago.com?Subject=next%20meeting
+
+   sip:bob@phone21.boxesbybob.com   (even though that's what
+   sip:bob@192.0.2.4                 phone21.boxesbybob.com resolves to)
+
+   Note that equality is not transitive:
+
+      o  sip:carol@chicago.com and sip:carol@chicago.com;security=on are
+         equivalent
+
+      o  sip:carol@chicago.com and sip:carol@chicago.com;security=off
+         are equivalent
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 155]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      o  sip:carol@chicago.com;security=on and
+         sip:carol@chicago.com;security=off are not equivalent
+
+19.1.5 Forming Requests from a URI
+
+   An implementation needs to take care when forming requests directly
+   from a URI.  URIs from business cards, web pages, and even from
+   sources inside the protocol such as registered contacts may contain
+   inappropriate header fields or body parts.
+
+   An implementation MUST include any provided transport, maddr, ttl, or
+   user parameter in the Request-URI of the formed request.  If the URI
+   contains a method parameter, its value MUST be used as the method of
+   the request.  The method parameter MUST NOT be placed in the
+   Request-URI.  Unknown URI parameters MUST be placed in the message's
+   Request-URI.
+
+   An implementation SHOULD treat the presence of any headers or body
+   parts in the URI as a desire to include them in the message, and
+   choose to honor the request on a per-component basis.
+
+   An implementation SHOULD NOT honor these obviously dangerous header
+   fields: From, Call-ID, CSeq, Via, and Record-Route.
+
+   An implementation SHOULD NOT honor any requested Route header field
+   values in order to not be used as an unwitting agent in malicious
+   attacks.
+
+   An implementation SHOULD NOT honor requests to include header fields
+   that may cause it to falsely advertise its location or capabilities.
+   These include: Accept, Accept-Encoding, Accept-Language, Allow,
+   Contact (in its dialog usage), Organization, Supported, and User-
+   Agent.
+
+   An implementation SHOULD verify the accuracy of any requested
+   descriptive header fields, including: Content-Disposition, Content-
+   Encoding, Content-Language, Content-Length, Content-Type, Date,
+   Mime-Version, and Timestamp.
+
+   If the request formed from constructing a message from a given URI is
+   not a valid SIP request, the URI is invalid.  An implementation MUST
+   NOT proceed with transmitting the request.  It should instead pursue
+   the course of action due an invalid URI in the context it occurs.
+
+      The constructed request can be invalid in many ways.  These
+      include, but are not limited to, syntax error in header fields,
+      invalid combinations of URI parameters, or an incorrect
+      description of the message body.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 156]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Sending a request formed from a given URI may require capabilities
+   unavailable to the implementation.  The URI might indicate use of an
+   unimplemented transport or extension, for example.  An implementation
+   SHOULD refuse to send these requests rather than modifying them to
+   match their capabilities.  An implementation MUST NOT send a request
+   requiring an extension that it does not support.
+
+      For example, such a request can be formed through the presence of
+      a Require header parameter or a method URI parameter with an
+      unknown or explicitly unsupported value.
+
+19.1.6 Relating SIP URIs and tel URLs
+
+   When a tel URL (RFC 2806 [9]) is converted to a SIP or SIPS URI, the
+   entire telephone-subscriber portion of the tel URL, including any
+   parameters, is placed into the userinfo part of the SIP or SIPS URI.
+
+   Thus, tel:+358-555-1234567;postd=pp22 becomes
+
+      sip:+358-555-1234567;postd=pp22@foo.com;user=phone
+
+   or
+      sips:+358-555-1234567;postd=pp22@foo.com;user=phone
+
+   not
+      sip:+358-555-1234567@foo.com;postd=pp22;user=phone
+
+   or
+
+      sips:+358-555-1234567@foo.com;postd=pp22;user=phone
+
+   In general, equivalent "tel" URLs converted to SIP or SIPS URIs in
+   this fashion may not produce equivalent SIP or SIPS URIs.  The
+   userinfo of SIP and SIPS URIs are compared as a case-sensitive
+   string.  Variance in case-insensitive portions of tel URLs and
+   reordering of tel URL parameters does not affect tel URL equivalence,
+   but does affect the equivalence of SIP URIs formed from them.
+
+   For example,
+
+      tel:+358-555-1234567;postd=pp22
+      tel:+358-555-1234567;POSTD=PP22
+
+   are equivalent, while
+
+      sip:+358-555-1234567;postd=pp22@foo.com;user=phone
+      sip:+358-555-1234567;POSTD=PP22@foo.com;user=phone
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 157]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   are not.
+
+   Likewise,
+
+      tel:+358-555-1234567;postd=pp22;isub=1411
+      tel:+358-555-1234567;isub=1411;postd=pp22
+
+   are equivalent, while
+
+      sip:+358-555-1234567;postd=pp22;isub=1411@foo.com;user=phone
+      sip:+358-555-1234567;isub=1411;postd=pp22@foo.com;user=phone
+
+   are not.
+
+   To mitigate this problem, elements constructing telephone-subscriber
+   fields to place in the userinfo part of a SIP or SIPS URI SHOULD fold
+   any case-insensitive portion of telephone-subscriber to lower case,
+   and order the telephone-subscriber parameters lexically by parameter
+   name, excepting isdn-subaddress and post-dial, which occur first and
+   in that order.  (All components of a tel URL except for future-
+   extension parameters are defined to be compared case-insensitive.)
+
+   Following this suggestion, both
+
+      tel:+358-555-1234567;postd=pp22
+      tel:+358-555-1234567;POSTD=PP22
+
+      become
+
+        sip:+358-555-1234567;postd=pp22@foo.com;user=phone
+
+   and both
+
+        tel:+358-555-1234567;tsp=a.b;phone-context=5
+        tel:+358-555-1234567;phone-context=5;tsp=a.b
+
+      become
+
+        sip:+358-555-1234567;phone-context=5;tsp=a.b@foo.com;user=phone
+
+19.2 Option Tags
+
+   Option tags are unique identifiers used to designate new options
+   (extensions) in SIP.  These tags are used in Require (Section 20.32),
+   Proxy-Require (Section 20.29), Supported (Section 20.37) and
+   Unsupported (Section 20.40) header fields.  Note that these options
+   appear as parameters in those header fields in an option-tag = token
+   form (see Section 25 for the definition of token).
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 158]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Option tags are defined in standards track RFCs.  This is a change
+   from past practice, and is instituted to ensure continuing multi-
+   vendor interoperability (see discussion in Section 20.32 and Section
+   20.37).  An IANA registry of option tags is used to ensure easy
+   reference.
+
+19.3 Tags
+
+   The "tag" parameter is used in the To and From header fields of SIP
+   messages.  It serves as a general mechanism to identify a dialog,
+   which is the combination of the Call-ID along with two tags, one from
+   each participant in the dialog.  When a UA sends a request outside of
+   a dialog, it contains a From tag only, providing "half" of the dialog
+   ID.  The dialog is completed from the response(s), each of which
+   contributes the second half in the To header field.  The forking of
+   SIP requests means that multiple dialogs can be established from a
+   single request.  This also explains the need for the two-sided dialog
+   identifier; without a contribution from the recipients, the
+   originator could not disambiguate the multiple dialogs established
+   from a single request.
+
+   When a tag is generated by a UA for insertion into a request or
+   response, it MUST be globally unique and cryptographically random
+   with at least 32 bits of randomness.  A property of this selection
+   requirement is that a UA will place a different tag into the From
+   header of an INVITE than it would place into the To header of the
+   response to the same INVITE.  This is needed in order for a UA to
+   invite itself to a session, a common case for "hairpinning" of calls
+   in PSTN gateways.  Similarly, two INVITEs for different calls will
+   have different From tags, and two responses for different calls will
+   have different To tags.
+
+   Besides the requirement for global uniqueness, the algorithm for
+   generating a tag is implementation-specific.  Tags are helpful in
+   fault tolerant systems, where a dialog is to be recovered on an
+   alternate server after a failure.  A UAS can select the tag in such a
+   way that a backup can recognize a request as part of a dialog on the
+   failed server, and therefore determine that it should attempt to
+   recover the dialog and any other state associated with it.
+
+20 Header Fields
+
+   The general syntax for header fields is covered in Section 7.3.  This
+   section lists the full set of header fields along with notes on
+   syntax, meaning, and usage.  Throughout this section, we use [HX.Y]
+   to refer to Section X.Y of the current HTTP/1.1 specification RFC
+   2616 [8].  Examples of each header field are given.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 159]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Information about header fields in relation to methods and proxy
+   processing is summarized in Tables 2 and 3.
+
+   The "where" column describes the request and response types in which
+   the header field can be used.  Values in this column are:
+
+      R: header field may only appear in requests;
+
+      r: header field may only appear in responses;
+
+      2xx, 4xx, etc.: A numerical value or range indicates response
+           codes with which the header field can be used;
+
+      c: header field is copied from the request to the response.
+
+      An empty entry in the "where" column indicates that the header
+           field may be present in all requests and responses.
+
+   The "proxy" column describes the operations a proxy may perform on a
+   header field:
+
+      a: A proxy can add or concatenate the header field if not present.
+
+      m: A proxy can modify an existing header field value.
+
+      d: A proxy can delete a header field value.
+
+      r: A proxy must be able to read the header field, and thus this
+           header field cannot be encrypted.
+
+   The next six columns relate to the presence of a header field in a
+   method:
+
+      c: Conditional; requirements on the header field depend on the
+           context of the message.
+
+      m: The header field is mandatory.
+
+      m*: The header field SHOULD be sent, but clients/servers need to
+           be prepared to receive messages without that header field.
+
+      o: The header field is optional.
+
+      t: The header field SHOULD be sent, but clients/servers need to be
+           prepared to receive messages without that header field.
+
+           If a stream-based protocol (such as TCP) is used as a
+           transport, then the header field MUST be sent.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 160]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      *: The header field is required if the message body is not empty.
+           See Sections 20.14, 20.15 and 7.4 for details.
+
+      -: The header field is not applicable.
+
+   "Optional" means that an element MAY include the header field in a
+   request or response, and a UA MAY ignore the header field if present
+   in the request or response (The exception to this rule is the Require
+   header field discussed in 20.32).  A "mandatory" header field MUST be
+   present in a request, and MUST be understood by the UAS receiving the
+   request.  A mandatory response header field MUST be present in the
+   response, and the header field MUST be understood by the UAC
+   processing the response.  "Not applicable" means that the header
+   field MUST NOT be present in a request.  If one is placed in a
+   request by mistake, it MUST be ignored by the UAS receiving the
+   request.  Similarly, a header field labeled "not applicable" for a
+   response means that the UAS MUST NOT place the header field in the
+   response, and the UAC MUST ignore the header field in the response.
+
+   A UA SHOULD ignore extension header parameters that are not
+   understood.
+
+   A compact form of some common header field names is also defined for
+   use when overall message size is an issue.
+
+   The Contact, From, and To header fields contain a URI.  If the URI
+   contains a comma, question mark or semicolon, the URI MUST be
+   enclosed in angle brackets (< and >).  Any URI parameters are
+   contained within these brackets.  If the URI is not enclosed in angle
+   brackets, any semicolon-delimited parameters are header-parameters,
+   not URI parameters.
+
+20.1 Accept
+
+   The Accept header field follows the syntax defined in [H14.1].  The
+   semantics are also identical, with the exception that if no Accept
+   header field is present, the server SHOULD assume a default value of
+   application/sdp.
+
+   An empty Accept header field means that no formats are acceptable.
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 161]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      Header field          where   proxy ACK BYE CAN INV OPT REG
+      ___________________________________________________________
+      Accept                  R            -   o   -   o   m*  o
+      Accept                 2xx           -   -   -   o   m*  o
+      Accept                 415           -   c   -   c   c   c
+      Accept-Encoding         R            -   o   -   o   o   o
+      Accept-Encoding        2xx           -   -   -   o   m*  o
+      Accept-Encoding        415           -   c   -   c   c   c
+      Accept-Language         R            -   o   -   o   o   o
+      Accept-Language        2xx           -   -   -   o   m*  o
+      Accept-Language        415           -   c   -   c   c   c
+      Alert-Info              R      ar    -   -   -   o   -   -
+      Alert-Info             180     ar    -   -   -   o   -   -
+      Allow                   R            -   o   -   o   o   o
+      Allow                  2xx           -   o   -   m*  m*  o
+      Allow                   r            -   o   -   o   o   o
+      Allow                  405           -   m   -   m   m   m
+      Authentication-Info    2xx           -   o   -   o   o   o
+      Authorization           R            o   o   o   o   o   o
+      Call-ID                 c       r    m   m   m   m   m   m
+      Call-Info                      ar    -   -   -   o   o   o
+      Contact                 R            o   -   -   m   o   o
+      Contact                1xx           -   -   -   o   -   -
+      Contact                2xx           -   -   -   m   o   o
+      Contact                3xx      d    -   o   -   o   o   o
+      Contact                485           -   o   -   o   o   o
+      Content-Disposition                  o   o   -   o   o   o
+      Content-Encoding                     o   o   -   o   o   o
+      Content-Language                     o   o   -   o   o   o
+      Content-Length                 ar    t   t   t   t   t   t
+      Content-Type                         *   *   -   *   *   *
+      CSeq                    c       r    m   m   m   m   m   m
+      Date                            a    o   o   o   o   o   o
+      Error-Info           300-699    a    -   o   o   o   o   o
+      Expires                              -   -   -   o   -   o
+      From                    c       r    m   m   m   m   m   m
+      In-Reply-To             R            -   -   -   o   -   -
+      Max-Forwards            R      amr   m   m   m   m   m   m
+      Min-Expires            423           -   -   -   -   -   m
+      MIME-Version                         o   o   -   o   o   o
+      Organization                   ar    -   -   -   o   o   o
+
+             Table 2: Summary of header fields, A--O
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 162]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Header field              where       proxy ACK BYE CAN INV OPT REG
+   ___________________________________________________________________
+   Priority                    R          ar    -   -   -   o   -   -
+   Proxy-Authenticate         407         ar    -   m   -   m   m   m
+   Proxy-Authenticate         401         ar    -   o   o   o   o   o
+   Proxy-Authorization         R          dr    o   o   -   o   o   o
+   Proxy-Require               R          ar    -   o   -   o   o   o
+   Record-Route                R          ar    o   o   o   o   o   -
+   Record-Route             2xx,18x       mr    -   o   o   o   o   -
+   Reply-To                                     -   -   -   o   -   -
+   Require                                ar    -   c   -   c   c   c
+   Retry-After          404,413,480,486         -   o   o   o   o   o
+                            500,503             -   o   o   o   o   o
+                            600,603             -   o   o   o   o   o
+   Route                       R          adr   c   c   c   c   c   c
+   Server                      r                -   o   o   o   o   o
+   Subject                     R                -   -   -   o   -   -
+   Supported                   R                -   o   o   m*  o   o
+   Supported                  2xx               -   o   o   m*  m*  o
+   Timestamp                                    o   o   o   o   o   o
+   To                        c(1)          r    m   m   m   m   m   m
+   Unsupported                420               -   m   -   m   m   m
+   User-Agent                                   o   o   o   o   o   o
+   Via                         R          amr   m   m   m   m   m   m
+   Via                        rc          dr    m   m   m   m   m   m
+   Warning                     r                -   o   o   o   o   o
+   WWW-Authenticate           401         ar    -   m   -   m   m   m
+   WWW-Authenticate           407         ar    -   o   -   o   o   o
+
+   Table 3: Summary of header fields, P--Z; (1): copied with possible
+   addition of tag
+
+      Accept: application/sdp;level=1, application/x-private, text/html
+
+20.2 Accept-Encoding
+
+   The Accept-Encoding header field is similar to Accept, but restricts
+   the content-codings [H3.5] that are acceptable in the response.  See
+   [H14.3].  The semantics in SIP are identical to those defined in
+   [H14.3].
+
+   An empty Accept-Encoding header field is permissible.  It is
+   equivalent to Accept-Encoding: identity, that is, only the identity
+   encoding, meaning no encoding, is permissible.
+
+   If no Accept-Encoding header field is present, the server SHOULD
+   assume a default value of identity.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 163]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   This differs slightly from the HTTP definition, which indicates that
+   when not present, any encoding can be used, but the identity encoding
+   is preferred.
+
+   Example:
+
+      Accept-Encoding: gzip
+
+20.3 Accept-Language
+
+   The Accept-Language header field is used in requests to indicate the
+   preferred languages for reason phrases, session descriptions, or
+   status responses carried as message bodies in the response.  If no
+   Accept-Language header field is present, the server SHOULD assume all
+   languages are acceptable to the client.
+
+   The Accept-Language header field follows the syntax defined in
+   [H14.4].  The rules for ordering the languages based on the "q"
+   parameter apply to SIP as well.
+
+   Example:
+
+      Accept-Language: da, en-gb;q=0.8, en;q=0.7
+
+20.4 Alert-Info
+
+   When present in an INVITE request, the Alert-Info header field
+   specifies an alternative ring tone to the UAS.  When present in a 180
+   (Ringing) response, the Alert-Info header field specifies an
+   alternative ringback tone to the UAC.  A typical usage is for a proxy
+   to insert this header field to provide a distinctive ring feature.
+
+   The Alert-Info header field can introduce security risks.  These
+   risks and the ways to handle them are discussed in Section 20.9,
+   which discusses the Call-Info header field since the risks are
+   identical.
+
+   In addition, a user SHOULD be able to disable this feature
+   selectively.
+
+      This helps prevent disruptions that could result from the use of
+      this header field by untrusted elements.
+
+   Example:
+
+      Alert-Info: <http://www.example.com/sounds/moo.wav>
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 164]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+20.5 Allow
+
+   The Allow header field lists the set of methods supported by the UA
+   generating the message.
+
+   All methods, including ACK and CANCEL, understood by the UA MUST be
+   included in the list of methods in the Allow header field, when
+   present.  The absence of an Allow header field MUST NOT be
+   interpreted to mean that the UA sending the message supports no
+   methods.   Rather, it implies that the UA is not providing any
+   information on what methods it supports.
+
+   Supplying an Allow header field in responses to methods other than
+   OPTIONS reduces the number of messages needed.
+
+   Example:
+
+      Allow: INVITE, ACK, OPTIONS, CANCEL, BYE
+
+20.6 Authentication-Info
+
+   The Authentication-Info header field provides for mutual
+   authentication with HTTP Digest.  A UAS MAY include this header field
+   in a 2xx response to a request that was successfully authenticated
+   using digest based on the Authorization header field.
+
+   Syntax and semantics follow those specified in RFC 2617 [17].
+
+   Example:
+
+      Authentication-Info: nextnonce="47364c23432d2e131a5fb210812c"
+
+20.7 Authorization
+
+   The Authorization header field contains authentication credentials of
+   a UA.  Section 22.2 overviews the use of the Authorization header
+   field, and Section 22.4 describes the syntax and semantics when used
+   with HTTP authentication.
+
+   This header field, along with Proxy-Authorization, breaks the general
+   rules about multiple header field values.  Although not a comma-
+   separated list, this header field name may be present multiple times,
+   and MUST NOT be combined into a single header line using the usual
+   rules described in Section 7.3.
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 165]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   In the example below, there are no quotes around the Digest
+   parameter:
+
+      Authorization: Digest username="Alice", realm="atlanta.com",
+       nonce="84a4cc6f3082121f32b42a2187831a9e",
+       response="7587245234b3434cc3412213e5f113a5432"
+
+20.8 Call-ID
+
+   The Call-ID header field uniquely identifies a particular invitation
+   or all registrations of a particular client.  A single multimedia
+   conference can give rise to several calls with different Call-IDs,
+   for example, if a user invites a single individual several times to
+   the same (long-running) conference.  Call-IDs are case-sensitive and
+   are simply compared byte-by-byte.
+
+   The compact form of the Call-ID header field is i.
+
+   Examples:
+
+      Call-ID: f81d4fae-7dec-11d0-a765-00a0c91e6bf6@biloxi.com
+      i:f81d4fae-7dec-11d0-a765-00a0c91e6bf6@192.0.2.4
+
+20.9 Call-Info
+
+   The Call-Info header field provides additional information about the
+   caller or callee, depending on whether it is found in a request or
+   response.  The purpose of the URI is described by the "purpose"
+   parameter.  The "icon" parameter designates an image suitable as an
+   iconic representation of the caller or callee.  The "info" parameter
+   describes the caller or callee in general, for example, through a web
+   page.  The "card" parameter provides a business card, for example, in
+   vCard [36] or LDIF [37] formats.  Additional tokens can be registered
+   using IANA and the procedures in Section 27.
+
+   Use of the Call-Info header field can pose a security risk.  If a
+   callee fetches the URIs provided by a malicious caller, the callee
+   may be at risk for displaying inappropriate or offensive content,
+   dangerous or illegal content, and so on.  Therefore, it is
+   RECOMMENDED that a UA only render the information in the Call-Info
+   header field if it can verify the authenticity of the element that
+   originated the header field and trusts that element.  This need not
+   be the peer UA; a proxy can insert this header field into requests.
+
+   Example:
+
+   Call-Info: <http://wwww.example.com/alice/photo.jpg> ;purpose=icon,
+     <http://www.example.com/alice/> ;purpose=info
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 166]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+20.10 Contact
+
+   A Contact header field value provides a URI whose meaning depends on
+   the type of request or response it is in.
+
+   A Contact header field value can contain a display name, a URI with
+   URI parameters, and header parameters.
+
+   This document defines the Contact parameters "q" and "expires".
+   These parameters are only used when the Contact is present in a
+   REGISTER request or response, or in a 3xx response.  Additional
+   parameters may be defined in other specifications.
+
+   When the header field value contains a display name, the URI
+   including all URI parameters is enclosed in "<" and ">".  If no "<"
+   and ">" are present, all parameters after the URI are header
+   parameters, not URI parameters.  The display name can be tokens, or a
+   quoted string, if a larger character set is desired.
+
+   Even if the "display-name" is empty, the "name-addr" form MUST be
+   used if the "addr-spec" contains a comma, semicolon, or question
+   mark.  There may or may not be LWS between the display-name and the
+   "<".
+
+   These rules for parsing a display name, URI and URI parameters, and
+   header parameters also apply for the header fields To and From.
+
+      The Contact header field has a role similar to the Location header
+      field in HTTP.  However, the HTTP header field only allows one
+      address, unquoted.  Since URIs can contain commas and semicolons
+      as reserved characters, they can be mistaken for header or
+      parameter delimiters, respectively.
+
+   The compact form of the Contact header field is m (for "moved").
+
+   Examples:
+
+      Contact: "Mr. Watson" <sip:watson@worcester.bell-telephone.com>
+         ;q=0.7; expires=3600,
+         "Mr. Watson" <mailto:watson@bell-telephone.com> ;q=0.1
+      m: <sips:bob@192.0.2.4>;expires=60
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 167]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+20.11 Content-Disposition
+
+   The Content-Disposition header field describes how the message body
+   or, for multipart messages, a message body part is to be interpreted
+   by the UAC or UAS.  This SIP header field extends the MIME Content-
+   Type (RFC 2183 [18]).
+
+   Several new "disposition-types" of the Content-Disposition header are
+   defined by SIP.  The value "session" indicates that the body part
+   describes a session, for either calls or early (pre-call) media.  The
+   value "render" indicates that the body part should be displayed or
+   otherwise rendered to the user.  Note that the value "render" is used
+   rather than "inline" to avoid the connotation that the MIME body is
+   displayed as a part of the rendering of the entire message (since the
+   MIME bodies of SIP messages oftentimes are not displayed to users).
+   For backward-compatibility, if the Content-Disposition header field
+   is missing, the server SHOULD assume bodies of Content-Type
+   application/sdp are the disposition "session", while other content
+   types are "render".
+
+   The disposition type "icon" indicates that the body part contains an
+   image suitable as an iconic representation of the caller or callee
+   that could be rendered informationally by a user agent when a message
+   has been received, or persistently while a dialog takes place.  The
+   value "alert" indicates that the body part contains information, such
+   as an audio clip, that should be rendered by the user agent in an
+   attempt to alert the user to the receipt of a request, generally a
+   request that initiates a dialog; this alerting body could for example
+   be rendered as a ring tone for a phone call after a 180 Ringing
+   provisional response has been sent.
+
+   Any MIME body with a "disposition-type" that renders content to the
+   user should only be processed when a message has been properly
+   authenticated.
+
+   The handling parameter, handling-param, describes how the UAS should
+   react if it receives a message body whose content type or disposition
+   type it does not understand.  The parameter has defined values of
+   "optional" and "required".  If the handling parameter is missing, the
+   value "required" SHOULD be assumed.  The handling parameter is
+   described in RFC 3204 [19].
+
+   If this header field is missing, the MIME type determines the default
+   content disposition.  If there is none, "render" is assumed.
+
+   Example:
+
+      Content-Disposition: session
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 168]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+20.12 Content-Encoding
+
+   The Content-Encoding header field is used as a modifier to the
+   "media-type".  When present, its value indicates what additional
+   content codings have been applied to the entity-body, and thus what
+   decoding mechanisms MUST be applied in order to obtain the media-type
+   referenced by the Content-Type header field.  Content-Encoding is
+   primarily used to allow a body to be compressed without losing the
+   identity of its underlying media type.
+
+   If multiple encodings have been applied to an entity-body, the
+   content codings MUST be listed in the order in which they were
+   applied.
+
+   All content-coding values are case-insensitive.  IANA acts as a
+   registry for content-coding value tokens.  See [H3.5] for a
+   definition of the syntax for content-coding.
+
+   Clients MAY apply content encodings to the body in requests.  A
+   server MAY apply content encodings to the bodies in responses.  The
+   server MUST only use encodings listed in the Accept-Encoding header
+   field in the request.
+
+   The compact form of the Content-Encoding header field is e.
+   Examples:
+
+      Content-Encoding: gzip
+      e: tar
+
+20.13 Content-Language
+
+   See [H14.12]. Example:
+
+      Content-Language: fr
+
+20.14 Content-Length
+
+   The Content-Length header field indicates the size of the message-
+   body, in decimal number of octets, sent to the recipient.
+   Applications SHOULD use this field to indicate the size of the
+   message-body to be transferred, regardless of the media type of the
+   entity.  If a stream-based protocol (such as TCP) is used as
+   transport, the header field MUST be used.
+
+   The size of the message-body does not include the CRLF separating
+   header fields and body.  Any Content-Length greater than or equal to
+   zero is a valid value.  If no body is present in a message, then the
+   Content-Length header field value MUST be set to zero.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 169]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      The ability to omit Content-Length simplifies the creation of
+      cgi-like scripts that dynamically generate responses.
+
+   The compact form of the header field is l.
+
+   Examples:
+
+      Content-Length: 349
+      l: 173
+
+20.15 Content-Type
+
+   The Content-Type header field indicates the media type of the
+   message-body sent to the recipient.  The "media-type" element is
+   defined in [H3.7].  The Content-Type header field MUST be present if
+   the body is not empty.  If the body is empty, and a Content-Type
+   header field is present, it indicates that the body of the specific
+   type has zero length (for example, an empty audio file).
+
+   The compact form of the header field is c.
+
+   Examples:
+
+      Content-Type: application/sdp
+      c: text/html; charset=ISO-8859-4
+
+20.16 CSeq
+
+   A CSeq header field in a request contains a single decimal sequence
+   number and the request method.  The sequence number MUST be
+   expressible as a 32-bit unsigned integer.  The method part of CSeq is
+   case-sensitive.  The CSeq header field serves to order transactions
+   within a dialog, to provide a means to uniquely identify
+   transactions, and to differentiate between new requests and request
+   retransmissions.  Two CSeq header fields are considered equal if the
+   sequence number and the request method are identical.  Example:
+
+      CSeq: 4711 INVITE
+
+20.17 Date
+
+   The Date header field contains the date and time.  Unlike HTTP/1.1,
+   SIP only supports the most recent RFC 1123 [20] format for dates.  As
+   in [H3.3], SIP restricts the time zone in SIP-date to "GMT", while
+   RFC 1123 allows any time zone.  An RFC 1123 date is case-sensitive.
+
+   The Date header field reflects the time when the request or response
+   is first sent.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 170]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      The Date header field can be used by simple end systems without a
+      battery-backed clock to acquire a notion of current time.
+      However, in its GMT form, it requires clients to know their offset
+      from GMT.
+
+   Example:
+
+      Date: Sat, 13 Nov 2010 23:29:00 GMT
+
+20.18 Error-Info
+
+   The Error-Info header field provides a pointer to additional
+   information about the error status response.
+
+      SIP UACs have user interface capabilities ranging from pop-up
+      windows and audio on PC softclients to audio-only on "black"
+      phones or endpoints connected via gateways.  Rather than forcing a
+      server generating an error to choose between sending an error
+      status code with a detailed reason phrase and playing an audio
+      recording, the Error-Info header field allows both to be sent.
+      The UAC then has the choice of which error indicator to render to
+      the caller.
+
+   A UAC MAY treat a SIP or SIPS URI in an Error-Info header field as if
+   it were a Contact in a redirect and generate a new INVITE, resulting
+   in a recorded announcement session being established.  A non-SIP URI
+   MAY be rendered to the user.
+
+   Examples:
+
+      SIP/2.0 404 The number you have dialed is not in service
+      Error-Info: <sip:not-in-service-recording@atlanta.com>
+
+20.19 Expires
+
+   The Expires header field gives the relative time after which the
+   message (or content) expires.
+
+   The precise meaning of this is method dependent.
+
+   The expiration time in an INVITE does not affect the duration of the
+   actual session that may result from the invitation.  Session
+   description protocols may offer the ability to express time limits on
+   the session duration, however.
+
+   The value of this field is an integral number of seconds (in decimal)
+   between 0 and (2**32)-1, measured from the receipt of the request.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 171]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      Expires: 5
+
+20.20 From
+
+   The From header field indicates the initiator of the request.  This
+   may be different from the initiator of the dialog.  Requests sent by
+   the callee to the caller use the callee's address in the From header
+   field.
+
+   The optional "display-name" is meant to be rendered by a human user
+   interface.  A system SHOULD use the display name "Anonymous" if the
+   identity of the client is to remain hidden.  Even if the "display-
+   name" is empty, the "name-addr" form MUST be used if the "addr-spec"
+   contains a comma, question mark, or semicolon.  Syntax issues are
+   discussed in Section 7.3.1.
+
+   Two From header fields are equivalent if their URIs match, and their
+   parameters match. Extension parameters in one header field, not
+   present in the other are ignored for the purposes of comparison. This
+   means that the display name and presence or absence of angle brackets
+   do not affect matching.
+
+   See Section 20.10 for the rules for parsing a display name, URI and
+   URI parameters, and header field parameters.
+
+   The compact form of the From header field is f.
+
+   Examples:
+
+      From: "A. G. Bell" <sip:agb@bell-telephone.com> ;tag=a48s
+      From: sip:+12125551212@server.phone2net.com;tag=887s
+      f: Anonymous <sip:c8oqz84zk7z@privacy.org>;tag=hyh8
+
+20.21 In-Reply-To
+
+   The In-Reply-To header field enumerates the Call-IDs that this call
+   references or returns.  These Call-IDs may have been cached by the
+   client then included in this header field in a return call.
+
+      This allows automatic call distribution systems to route return
+      calls to the originator of the first call.  This also allows
+      callees to filter calls, so that only return calls for calls they
+      originated will be accepted.  This field is not a substitute for
+      request authentication.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 172]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      In-Reply-To: 70710@saturn.bell-tel.com, 17320@saturn.bell-tel.com
+
+20.22 Max-Forwards
+
+   The Max-Forwards header field must be used with any SIP method to
+   limit the number of proxies or gateways that can forward the request
+   to the next downstream server.  This can also be useful when the
+   client is attempting to trace a request chain that appears to be
+   failing or looping in mid-chain.
+
+   The Max-Forwards value is an integer in the range 0-255 indicating
+   the remaining number of times this request message is allowed to be
+   forwarded.  This count is decremented by each server that forwards
+   the request.  The recommended initial value is 70.
+
+   This header field should be inserted by elements that can not
+   otherwise guarantee loop detection.  For example, a B2BUA should
+   insert a Max-Forwards header field.
+
+   Example:
+
+      Max-Forwards: 6
+
+20.23 Min-Expires
+
+   The Min-Expires header field conveys the minimum refresh interval
+   supported for soft-state elements managed by that server.  This
+   includes Contact header fields that are stored by a registrar.  The
+   header field contains a decimal integer number of seconds from 0 to
+   (2**32)-1.  The use of the header field in a 423 (Interval Too Brief)
+   response is described in Sections 10.2.8, 10.3, and 21.4.17.
+
+   Example:
+
+      Min-Expires: 60
+
+20.24 MIME-Version
+
+   See [H19.4.1].
+
+   Example:
+
+      MIME-Version: 1.0
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 173]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+20.25 Organization
+
+   The Organization header field conveys the name of the organization to
+   which the SIP element issuing the request or response belongs.
+
+      The field MAY be used by client software to filter calls.
+
+   Example:
+
+      Organization: Boxes by Bob
+
+20.26 Priority
+
+   The Priority header field indicates the urgency of the request as
+   perceived by the client.  The Priority header field describes the
+   priority that the SIP request should have to the receiving human or
+   its agent.  For example, it may be factored into decisions about call
+   routing and acceptance.  For these decisions, a message containing no
+   Priority header field SHOULD be treated as if it specified a Priority
+   of "normal".  The Priority header field does not influence the use of
+   communications resources such as packet forwarding priority in
+   routers or access to circuits in PSTN gateways.  The header field can
+   have the values "non-urgent", "normal", "urgent", and "emergency",
+   but additional values can be defined elsewhere.  It is RECOMMENDED
+   that the value of "emergency" only be used when life, limb, or
+   property are in imminent danger.  Otherwise, there are no semantics
+   defined for this header field.
+
+      These are the values of RFC 2076 [38], with the addition of
+      "emergency".
+
+   Examples:
+
+      Subject: A tornado is heading our way!
+      Priority: emergency
+
+   or
+
+      Subject: Weekend plans
+      Priority: non-urgent
+
+20.27 Proxy-Authenticate
+
+   A Proxy-Authenticate header field value contains an authentication
+   challenge.
+
+   The use of this header field is defined in [H14.33].  See Section
+   22.3 for further details on its usage.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 174]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      Proxy-Authenticate: Digest realm="atlanta.com",
+       domain="sip:ss1.carrier.com", qop="auth",
+       nonce="f84f1cec41e6cbe5aea9c8e88d359",
+       opaque="", stale=FALSE, algorithm=MD5
+
+20.28 Proxy-Authorization
+
+   The Proxy-Authorization header field allows the client to identify
+   itself (or its user) to a proxy that requires authentication.  A
+   Proxy-Authorization field value consists of credentials containing
+   the authentication information of the user agent for the proxy and/or
+   realm of the resource being requested.
+
+   See Section 22.3 for a definition of the usage of this header field.
+
+   This header field, along with Authorization, breaks the general rules
+   about multiple header field names.  Although not a comma-separated
+   list, this header field name may be present multiple times, and MUST
+   NOT be combined into a single header line using the usual rules
+   described in Section 7.3.1.
+
+   Example:
+
+   Proxy-Authorization: Digest username="Alice", realm="atlanta.com",
+      nonce="c60f3082ee1212b402a21831ae",
+      response="245f23415f11432b3434341c022"
+
+20.29 Proxy-Require
+
+   The Proxy-Require header field is used to indicate proxy-sensitive
+   features that must be supported by the proxy.  See Section 20.32 for
+   more details on the mechanics of this message and a usage example.
+
+   Example:
+
+      Proxy-Require: foo
+
+20.30 Record-Route
+
+   The Record-Route header field is inserted by proxies in a request to
+   force future requests in the dialog to be routed through the proxy.
+
+   Examples of its use with the Route header field are described in
+   Sections 16.12.1.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 175]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      Record-Route: <sip:server10.biloxi.com;lr>,
+                    <sip:bigbox3.site3.atlanta.com;lr>
+
+20.31 Reply-To
+
+   The Reply-To header field contains a logical return URI that may be
+   different from the From header field.  For example, the URI MAY be
+   used to return missed calls or unestablished sessions.  If the user
+   wished to remain anonymous, the header field SHOULD either be omitted
+   from the request or populated in such a way that does not reveal any
+   private information.
+
+   Even if the "display-name" is empty, the "name-addr" form MUST be
+   used if the "addr-spec" contains a comma, question mark, or
+   semicolon.  Syntax issues are discussed in Section 7.3.1.
+
+   Example:
+
+      Reply-To: Bob <sip:bob@biloxi.com>
+
+20.32 Require
+
+   The Require header field is used by UACs to tell UASs about options
+   that the UAC expects the UAS to support in order to process the
+   request.  Although an optional header field, the Require MUST NOT be
+   ignored if it is present.
+
+   The Require header field contains a list of option tags, described in
+   Section 19.2.  Each option tag defines a SIP extension that MUST be
+   understood to process the request.  Frequently, this is used to
+   indicate that a specific set of extension header fields need to be
+   understood.  A UAC compliant to this specification MUST only include
+   option tags corresponding to standards-track RFCs.
+
+   Example:
+
+      Require: 100rel
+
+20.33 Retry-After
+
+   The Retry-After header field can be used with a 500 (Server Internal
+   Error) or 503 (Service Unavailable) response to indicate how long the
+   service is expected to be unavailable to the requesting client and
+   with a 404 (Not Found), 413 (Request Entity Too Large), 480
+   (Temporarily Unavailable), 486 (Busy Here), 600 (Busy), or 603
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 176]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   (Decline) response to indicate when the called party anticipates
+   being available again.  The value of this field is a positive integer
+   number of seconds (in decimal) after the time of the response.
+
+   An optional comment can be used to indicate additional information
+   about the time of callback.  An optional "duration" parameter
+   indicates how long the called party will be reachable starting at the
+   initial time of availability.  If no duration parameter is given, the
+   service is assumed to be available indefinitely.
+
+   Examples:
+
+      Retry-After: 18000;duration=3600
+      Retry-After: 120 (I'm in a meeting)
+
+20.34 Route
+
+   The Route header field is used to force routing for a request through
+   the listed set of proxies.  Examples of the use of the Route header
+   field are in Section 16.12.1.
+
+   Example:
+
+      Route: <sip:bigbox3.site3.atlanta.com;lr>,
+             <sip:server10.biloxi.com;lr>
+
+20.35 Server
+
+   The Server header field contains information about the software used
+   by the UAS to handle the request.
+
+   Revealing the specific software version of the server might allow the
+   server to become more vulnerable to attacks against software that is
+   known to contain security holes.  Implementers SHOULD make the Server
+   header field a configurable option.
+
+   Example:
+
+      Server: HomeServer v2
+
+20.36 Subject
+
+   The Subject header field provides a summary or indicates the nature
+   of the call, allowing call filtering without having to parse the
+   session description.  The session description does not have to use
+   the same subject indication as the invitation.
+
+   The compact form of the Subject header field is s.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 177]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Example:
+
+      Subject: Need more boxes
+      s: Tech Support
+
+20.37 Supported
+
+   The Supported header field enumerates all the extensions supported by
+   the UAC or UAS.
+
+   The Supported header field contains a list of option tags, described
+   in Section 19.2, that are understood by the UAC or UAS.  A UA
+   compliant to this specification MUST only include option tags
+   corresponding to standards-track RFCs.  If empty, it means that no
+   extensions are supported.
+
+   The compact form of the Supported header field is k.
+
+   Example:
+
+      Supported: 100rel
+
+20.38 Timestamp
+
+   The Timestamp header field describes when the UAC sent the request to
+   the UAS.
+
+   See Section 8.2.6 for details on how to generate a response to a
+   request that contains the header field.  Although there is no
+   normative behavior defined here that makes use of the header, it
+   allows for extensions or SIP applications to obtain RTT estimates.
+
+   Example:
+
+      Timestamp: 54
+
+20.39 To
+
+   The To header field specifies the logical recipient of the request.
+
+   The optional "display-name" is meant to be rendered by a human-user
+   interface.  The "tag" parameter serves as a general mechanism for
+   dialog identification.
+
+   See Section 19.3 for details of the "tag" parameter.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 178]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Comparison of To header fields for equality is identical to
+   comparison of From header fields.  See Section 20.10 for the rules
+   for parsing a display name, URI and URI parameters, and header field
+   parameters.
+
+   The compact form of the To header field is t.
+
+   The following are examples of valid To header fields:
+
+      To: The Operator <sip:operator@cs.columbia.edu>;tag=287447
+      t: sip:+12125551212@server.phone2net.com
+
+20.40 Unsupported
+
+   The Unsupported header field lists the features not supported by the
+   UAS.  See Section 20.32 for motivation.
+
+   Example:
+
+      Unsupported: foo
+
+20.41 User-Agent
+
+   The User-Agent header field contains information about the UAC
+   originating the request.  The semantics of this header field are
+   defined in [H14.43].
+
+   Revealing the specific software version of the user agent might allow
+   the user agent to become more vulnerable to attacks against software
+   that is known to contain security holes.  Implementers SHOULD make
+   the User-Agent header field a configurable option.
+
+   Example:
+
+      User-Agent: Softphone Beta1.5
+
+20.42 Via
+
+   The Via header field indicates the path taken by the request so far
+   and indicates the path that should be followed in routing responses.
+   The branch ID parameter in the Via header field values serves as a
+   transaction identifier, and is used by proxies to detect loops.
+
+   A Via header field value contains the transport protocol used to send
+   the message, the client's host name or network address, and possibly
+   the port number at which it wishes to receive responses.  A Via
+   header field value can also contain parameters such as "maddr",
+   "ttl", "received", and "branch", whose meaning and use are described
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 179]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   in other sections.  For implementations compliant to this
+   specification, the value of the branch parameter MUST start with the
+   magic cookie "z9hG4bK", as discussed in Section 8.1.1.7.
+
+   Transport protocols defined here are "UDP", "TCP", "TLS", and "SCTP".
+   "TLS" means TLS over TCP.  When a request is sent to a SIPS URI, the
+   protocol still indicates "SIP", and the transport protocol is TLS.
+
+Via: SIP/2.0/UDP erlang.bell-telephone.com:5060;branch=z9hG4bK87asdks7
+Via: SIP/2.0/UDP 192.0.2.1:5060 ;received=192.0.2.207
+     ;branch=z9hG4bK77asjd
+
+   The compact form of the Via header field is v.
+
+   In this example, the message originated from a multi-homed host with
+   two addresses, 192.0.2.1 and 192.0.2.207.  The sender guessed wrong
+   as to which network interface would be used.  Erlang.bell-
+   telephone.com noticed the mismatch and added a parameter to the
+   previous hop's Via header field value, containing the address that
+   the packet actually came from.
+
+   The host or network address and port number are not required to
+   follow the SIP URI syntax.  Specifically, LWS on either side of the
+   ":" or "/" is allowed, as shown here:
+
+      Via: SIP / 2.0 / UDP first.example.com: 4000;ttl=16
+        ;maddr=224.2.0.1 ;branch=z9hG4bKa7c6a8dlze.1
+
+   Even though this specification mandates that the branch parameter be
+   present in all requests, the BNF for the header field indicates that
+   it is optional.  This allows interoperation with RFC 2543 elements,
+   which did not have to insert the branch parameter.
+
+   Two Via header fields are equal if their sent-protocol and sent-by
+   fields are equal, both have the same set of parameters, and the
+   values of all parameters are equal.
+
+20.43 Warning
+
+   The Warning header field is used to carry additional information
+   about the status of a response.  Warning header field values are sent
+   with responses and contain a three-digit warning code, host name, and
+   warning text.
+
+   The "warn-text" should be in a natural language that is most likely
+   to be intelligible to the human user receiving the response.  This
+   decision can be based on any available knowledge, such as the
+   location of the user, the Accept-Language field in a request, or the
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 180]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Content-Language field in a response.  The default language is i-
+   default [21].
+
+   The currently-defined "warn-code"s are listed below, with a
+   recommended warn-text in English and a description of their meaning.
+   These warnings describe failures induced by the session description.
+   The first digit of warning codes beginning with "3" indicates
+   warnings specific to SIP.  Warnings 300 through 329 are reserved for
+   indicating problems with keywords in the session description, 330
+   through 339 are warnings related to basic network services requested
+   in the session description, 370 through 379 are warnings related to
+   quantitative QoS parameters requested in the session description, and
+   390 through 399 are miscellaneous warnings that do not fall into one
+   of the above categories.
+
+      300 Incompatible network protocol: One or more network protocols
+          contained in the session description are not available.
+
+      301 Incompatible network address formats: One or more network
+          address formats contained in the session description are not
+          available.
+
+      302 Incompatible transport protocol: One or more transport
+          protocols described in the session description are not
+          available.
+
+      303 Incompatible bandwidth units: One or more bandwidth
+          measurement units contained in the session description were
+          not understood.
+
+      304 Media type not available: One or more media types contained in
+          the session description are not available.
+
+      305 Incompatible media format: One or more media formats contained
+          in the session description are not available.
+
+      306 Attribute not understood: One or more of the media attributes
+          in the session description are not supported.
+
+      307 Session description parameter not understood: A parameter
+          other than those listed above was not understood.
+
+      330 Multicast not available: The site where the user is located
+          does not support multicast.
+
+      331 Unicast not available: The site where the user is located does
+          not support unicast communication (usually due to the presence
+          of a firewall).
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 181]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      370 Insufficient bandwidth: The bandwidth specified in the session
+          description or defined by the media exceeds that known to be
+          available.
+
+      399 Miscellaneous warning: The warning text can include arbitrary
+          information to be presented to a human user or logged.  A
+          system receiving this warning MUST NOT take any automated
+          action.
+
+             1xx and 2xx have been taken by HTTP/1.1.
+
+   Additional "warn-code"s can be defined through IANA, as defined in
+   Section 27.2.
+
+   Examples:
+
+      Warning: 307 isi.edu "Session parameter 'foo' not understood"
+      Warning: 301 isi.edu "Incompatible network address type 'E.164'"
+
+20.44 WWW-Authenticate
+
+   A WWW-Authenticate header field value contains an authentication
+   challenge.  See Section 22.2 for further details on its usage.
+
+   Example:
+
+      WWW-Authenticate: Digest realm="atlanta.com",
+        domain="sip:boxesbybob.com", qop="auth",
+        nonce="f84f1cec41e6cbe5aea9c8e88d359",
+        opaque="", stale=FALSE, algorithm=MD5
+
+21 Response Codes
+
+   The response codes are consistent with, and extend, HTTP/1.1 response
+   codes.  Not all HTTP/1.1 response codes are appropriate, and only
+   those that are appropriate are given here.  Other HTTP/1.1 response
+   codes SHOULD NOT be used.  Also, SIP defines a new class, 6xx.
+
+21.1 Provisional 1xx
+
+   Provisional responses, also known as informational responses,
+   indicate that the server contacted is performing some further action
+   and does not yet have a definitive response.  A server sends a 1xx
+   response if it expects to take more than 200 ms to obtain a final
+   response.  Note that 1xx responses are not transmitted reliably.
+   They never cause the client to send an ACK.  Provisional (1xx)
+   responses MAY contain message bodies, including session descriptions.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 182]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.1.1 100 Trying
+
+   This response indicates that the request has been received by the
+   next-hop server and that some unspecified action is being taken on
+   behalf of this call (for example, a database is being consulted).
+   This response, like all other provisional responses, stops
+   retransmissions of an INVITE by a UAC.  The 100 (Trying) response is
+   different from other provisional responses, in that it is never
+   forwarded upstream by a stateful proxy.
+
+21.1.2 180 Ringing
+
+   The UA receiving the INVITE is trying to alert the user.  This
+   response MAY be used to initiate local ringback.
+
+21.1.3 181 Call Is Being Forwarded
+
+   A server MAY use this status code to indicate that the call is being
+   forwarded to a different set of destinations.
+
+21.1.4 182 Queued
+
+   The called party is temporarily unavailable, but the server has
+   decided to queue the call rather than reject it.  When the callee
+   becomes available, it will return the appropriate final status
+   response.  The reason phrase MAY give further details about the
+   status of the call, for example, "5 calls queued; expected waiting
+   time is 15 minutes".  The server MAY issue several 182 (Queued)
+   responses to update the caller about the status of the queued call.
+
+21.1.5 183 Session Progress
+
+   The 183 (Session Progress) response is used to convey information
+   about the progress of the call that is not otherwise classified.  The
+   Reason-Phrase, header fields, or message body MAY be used to convey
+   more details about the call progress.
+
+21.2 Successful 2xx
+
+   The request was successful.
+
+21.2.1 200 OK
+
+   The request has succeeded.  The information returned with the
+   response depends on the method used in the request.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 183]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.3 Redirection 3xx
+
+   3xx responses give information about the user's new location, or
+   about alternative services that might be able to satisfy the call.
+
+21.3.1 300 Multiple Choices
+
+   The address in the request resolved to several choices, each with its
+   own specific location, and the user (or UA) can select a preferred
+   communication end point and redirect its request to that location.
+
+   The response MAY include a message body containing a list of resource
+   characteristics and location(s) from which the user or UA can choose
+   the one most appropriate, if allowed by the Accept request header
+   field.  However, no MIME types have been defined for this message
+   body.
+
+   The choices SHOULD also be listed as Contact fields (Section 20.10).
+   Unlike HTTP, the SIP response MAY contain several Contact fields or a
+   list of addresses in a Contact field.  UAs MAY use the Contact header
+   field value for automatic redirection or MAY ask the user to confirm
+   a choice.  However, this specification does not define any standard
+   for such automatic selection.
+
+      This status response is appropriate if the callee can be reached
+      at several different locations and the server cannot or prefers
+      not to proxy the request.
+
+21.3.2 301 Moved Permanently
+
+   The user can no longer be found at the address in the Request-URI,
+   and the requesting client SHOULD retry at the new address given by
+   the Contact header field (Section 20.10).  The requestor SHOULD
+   update any local directories, address books, and user location caches
+   with this new value and redirect future requests to the address(es)
+   listed.
+
+21.3.3 302 Moved Temporarily
+
+   The requesting client SHOULD retry the request at the new address(es)
+   given by the Contact header field (Section 20.10).  The Request-URI
+   of the new request uses the value of the Contact header field in the
+   response.
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 184]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The duration of the validity of the Contact URI can be indicated
+   through an Expires (Section 20.19) header field or an expires
+   parameter in the Contact header field.  Both proxies and UAs MAY
+   cache this URI for the duration of the expiration time.  If there is
+   no explicit expiration time, the address is only valid once for
+   recursing, and MUST NOT be cached for future transactions.
+
+   If the URI cached from the Contact header field fails, the Request-
+   URI from the redirected request MAY be tried again a single time.
+
+      The temporary URI may have become out-of-date sooner than the
+      expiration time, and a new temporary URI may be available.
+
+21.3.4 305 Use Proxy
+
+   The requested resource MUST be accessed through the proxy given by
+   the Contact field.  The Contact field gives the URI of the proxy.
+   The recipient is expected to repeat this single request via the
+   proxy.  305 (Use Proxy) responses MUST only be generated by UASs.
+
+21.3.5 380 Alternative Service
+
+   The call was not successful, but alternative services are possible.
+
+   The alternative services are described in the message body of the
+   response.  Formats for such bodies are not defined here, and may be
+   the subject of future standardization.
+
+21.4 Request Failure 4xx
+
+   4xx responses are definite failure responses from a particular
+   server.  The client SHOULD NOT retry the same request without
+   modification (for example, adding appropriate authorization).
+   However, the same request to a different server might be successful.
+
+21.4.1 400 Bad Request
+
+   The request could not be understood due to malformed syntax.  The
+   Reason-Phrase SHOULD identify the syntax problem in more detail, for
+   example, "Missing Call-ID header field".
+
+21.4.2 401 Unauthorized
+
+   The request requires user authentication.  This response is issued by
+   UASs and registrars, while 407 (Proxy Authentication Required) is
+   used by proxy servers.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 185]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.4.3 402 Payment Required
+
+   Reserved for future use.
+
+21.4.4 403 Forbidden
+
+   The server understood the request, but is refusing to fulfill it.
+   Authorization will not help, and the request SHOULD NOT be repeated.
+
+21.4.5 404 Not Found
+
+   The server has definitive information that the user does not exist at
+   the domain specified in the Request-URI.  This status is also
+   returned if the domain in the Request-URI does not match any of the
+   domains handled by the recipient of the request.
+
+21.4.6 405 Method Not Allowed
+
+   The method specified in the Request-Line is understood, but not
+   allowed for the address identified by the Request-URI.
+
+   The response MUST include an Allow header field containing a list of
+   valid methods for the indicated address.
+
+21.4.7 406 Not Acceptable
+
+   The resource identified by the request is only capable of generating
+   response entities that have content characteristics not acceptable
+   according to the Accept header field sent in the request.
+
+21.4.8 407 Proxy Authentication Required
+
+   This code is similar to 401 (Unauthorized), but indicates that the
+   client MUST first authenticate itself with the proxy.  SIP access
+   authentication is explained in Sections 26 and 22.3.
+
+   This status code can be used for applications where access to the
+   communication channel (for example, a telephony gateway) rather than
+   the callee requires authentication.
+
+21.4.9 408 Request Timeout
+
+   The server could not produce a response within a suitable amount of
+   time, for example, if it could not determine the location of the user
+   in time.  The client MAY repeat the request without modifications at
+   any later time.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 186]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.4.10 410 Gone
+
+   The requested resource is no longer available at the server and no
+   forwarding address is known.  This condition is expected to be
+   considered permanent.  If the server does not know, or has no
+   facility to determine, whether or not the condition is permanent, the
+   status code 404 (Not Found) SHOULD be used instead.
+
+21.4.11 413 Request Entity Too Large
+
+   The server is refusing to process a request because the request
+   entity-body is larger than the server is willing or able to process.
+   The server MAY close the connection to prevent the client from
+   continuing the request.
+
+   If the condition is temporary, the server SHOULD include a Retry-
+   After header field to indicate that it is temporary and after what
+   time the client MAY try again.
+
+21.4.12 414 Request-URI Too Long
+
+   The server is refusing to service the request because the Request-URI
+   is longer than the server is willing to interpret.
+
+21.4.13 415 Unsupported Media Type
+
+   The server is refusing to service the request because the message
+   body of the request is in a format not supported by the server for
+   the requested method.  The server MUST return a list of acceptable
+   formats using the Accept, Accept-Encoding, or Accept-Language header
+   field, depending on the specific problem with the content.  UAC
+   processing of this response is described in Section 8.1.3.5.
+
+21.4.14 416 Unsupported URI Scheme
+
+   The server cannot process the request because the scheme of the URI
+   in the Request-URI is unknown to the server.  Client processing of
+   this response is described in Section 8.1.3.5.
+
+21.4.15 420 Bad Extension
+
+   The server did not understand the protocol extension specified in a
+   Proxy-Require (Section 20.29) or Require (Section 20.32) header
+   field.  The server MUST include a list of the unsupported extensions
+   in an Unsupported header field in the response.  UAC processing of
+   this response is described in Section 8.1.3.5.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 187]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.4.16 421 Extension Required
+
+   The UAS needs a particular extension to process the request, but this
+   extension is not listed in a Supported header field in the request.
+   Responses with this status code MUST contain a Require header field
+   listing the required extensions.
+
+   A UAS SHOULD NOT use this response unless it truly cannot provide any
+   useful service to the client.  Instead, if a desirable extension is
+   not listed in the Supported header field, servers SHOULD process the
+   request using baseline SIP capabilities and any extensions supported
+   by the client.
+
+21.4.17 423 Interval Too Brief
+
+   The server is rejecting the request because the expiration time of
+   the resource refreshed by the request is too short.  This response
+   can be used by a registrar to reject a registration whose Contact
+   header field expiration time was too small.  The use of this response
+   and the related Min-Expires header field are described in Sections
+   10.2.8, 10.3, and 20.23.
+
+21.4.18 480 Temporarily Unavailable
+
+   The callee's end system was contacted successfully but the callee is
+   currently unavailable (for example, is not logged in, logged in but
+   in a state that precludes communication with the callee, or has
+   activated the "do not disturb" feature).  The response MAY indicate a
+   better time to call in the Retry-After header field.  The user could
+   also be available elsewhere (unbeknownst to this server).  The reason
+   phrase SHOULD indicate a more precise cause as to why the callee is
+   unavailable.  This value SHOULD be settable by the UA.  Status 486
+   (Busy Here) MAY be used to more precisely indicate a particular
+   reason for the call failure.
+
+   This status is also returned by a redirect or proxy server that
+   recognizes the user identified by the Request-URI, but does not
+   currently have a valid forwarding location for that user.
+
+21.4.19 481 Call/Transaction Does Not Exist
+
+   This status indicates that the UAS received a request that does not
+   match any existing dialog or transaction.
+
+21.4.20 482 Loop Detected
+
+   The server has detected a loop (Section 16.3 Item 4).
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 188]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.4.21 483 Too Many Hops
+
+   The server received a request that contains a Max-Forwards (Section
+   20.22) header field with the value zero.
+
+21.4.22 484 Address Incomplete
+
+   The server received a request with a Request-URI that was incomplete.
+   Additional information SHOULD be provided in the reason phrase.
+
+      This status code allows overlapped dialing.  With overlapped
+      dialing, the client does not know the length of the dialing
+      string.  It sends strings of increasing lengths, prompting the
+      user for more input, until it no longer receives a 484 (Address
+      Incomplete) status response.
+
+21.4.23 485 Ambiguous
+
+   The Request-URI was ambiguous.  The response MAY contain a listing of
+   possible unambiguous addresses in Contact header fields.  Revealing
+   alternatives can infringe on privacy of the user or the organization.
+   It MUST be possible to configure a server to respond with status 404
+   (Not Found) or to suppress the listing of possible choices for
+   ambiguous Request-URIs.
+
+   Example response to a request with the Request-URI
+   sip:lee@example.com:
+
+      SIP/2.0 485 Ambiguous
+      Contact: Carol Lee <sip:carol.lee@example.com>
+      Contact: Ping Lee <sip:p.lee@example.com>
+      Contact: Lee M. Foote <sips:lee.foote@example.com>
+
+      Some email and voice mail systems provide this functionality.  A
+      status code separate from 3xx is used since the semantics are
+      different: for 300, it is assumed that the same person or service
+      will be reached by the choices provided.  While an automated
+      choice or sequential search makes sense for a 3xx response, user
+      intervention is required for a 485 (Ambiguous) response.
+
+21.4.24 486 Busy Here
+
+   The callee's end system was contacted successfully, but the callee is
+   currently not willing or able to take additional calls at this end
+   system.  The response MAY indicate a better time to call in the
+   Retry-After header field.  The user could also be available
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 189]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   elsewhere, such as through a voice mail service.  Status 600 (Busy
+   Everywhere) SHOULD be used if the client knows that no other end
+   system will be able to accept this call.
+
+21.4.25 487 Request Terminated
+
+   The request was terminated by a BYE or CANCEL request.  This response
+   is never returned for a CANCEL request itself.
+
+21.4.26 488 Not Acceptable Here
+
+   The response has the same meaning as 606 (Not Acceptable), but only
+   applies to the specific resource addressed by the Request-URI and the
+   request may succeed elsewhere.
+
+   A message body containing a description of media capabilities MAY be
+   present in the response, which is formatted according to the Accept
+   header field in the INVITE (or application/sdp if not present), the
+   same as a message body in a 200 (OK) response to an OPTIONS request.
+
+21.4.27 491 Request Pending
+
+   The request was received by a UAS that had a pending request within
+   the same dialog.  Section 14.2 describes how such "glare" situations
+   are resolved.
+
+21.4.28 493 Undecipherable
+
+   The request was received by a UAS that contained an encrypted MIME
+   body for which the recipient does not possess or will not provide an
+   appropriate decryption key.  This response MAY have a single body
+   containing an appropriate public key that should be used to encrypt
+   MIME bodies sent to this UA.  Details of the usage of this response
+   code can be found in Section 23.2.
+
+21.5 Server Failure 5xx
+
+   5xx responses are failure responses given when a server itself has
+   erred.
+
+21.5.1 500 Server Internal Error
+
+   The server encountered an unexpected condition that prevented it from
+   fulfilling the request.  The client MAY display the specific error
+   condition and MAY retry the request after several seconds.
+
+   If the condition is temporary, the server MAY indicate when the
+   client may retry the request using the Retry-After header field.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 190]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.5.2 501 Not Implemented
+
+   The server does not support the functionality required to fulfill the
+   request.  This is the appropriate response when a UAS does not
+   recognize the request method and is not capable of supporting it for
+   any user.  (Proxies forward all requests regardless of method.)
+
+   Note that a 405 (Method Not Allowed) is sent when the server
+   recognizes the request method, but that method is not allowed or
+   supported.
+
+21.5.3 502 Bad Gateway
+
+   The server, while acting as a gateway or proxy, received an invalid
+   response from the downstream server it accessed in attempting to
+   fulfill the request.
+
+21.5.4 503 Service Unavailable
+
+   The server is temporarily unable to process the request due to a
+   temporary overloading or maintenance of the server.  The server MAY
+   indicate when the client should retry the request in a Retry-After
+   header field.  If no Retry-After is given, the client MUST act as if
+   it had received a 500 (Server Internal Error) response.
+
+   A client (proxy or UAC) receiving a 503 (Service Unavailable) SHOULD
+   attempt to forward the request to an alternate server.  It SHOULD NOT
+   forward any other requests to that server for the duration specified
+   in the Retry-After header field, if present.
+
+   Servers MAY refuse the connection or drop the request instead of
+   responding with 503 (Service Unavailable).
+
+21.5.5 504 Server Time-out
+
+   The server did not receive a timely response from an external server
+   it accessed in attempting to process the request.  408 (Request
+   Timeout) should be used instead if there was no response within the
+   period specified in the Expires header field from the upstream
+   server.
+
+21.5.6 505 Version Not Supported
+
+   The server does not support, or refuses to support, the SIP protocol
+   version that was used in the request.  The server is indicating that
+   it is unable or unwilling to complete the request using the same
+   major version as the client, other than with this error message.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 191]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+21.5.7 513 Message Too Large
+
+   The server was unable to process the request since the message length
+   exceeded its capabilities.
+
+21.6 Global Failures 6xx
+
+   6xx responses indicate that a server has definitive information about
+   a particular user, not just the particular instance indicated in the
+   Request-URI.
+
+21.6.1 600 Busy Everywhere
+
+   The callee's end system was contacted successfully but the callee is
+   busy and does not wish to take the call at this time.  The response
+   MAY indicate a better time to call in the Retry-After header field.
+   If the callee does not wish to reveal the reason for declining the
+   call, the callee uses status code 603 (Decline) instead.  This status
+   response is returned only if the client knows that no other end point
+   (such as a voice mail system) will answer the request.  Otherwise,
+   486 (Busy Here) should be returned.
+
+21.6.2 603 Decline
+
+   The callee's machine was successfully contacted but the user
+   explicitly does not wish to or cannot participate.  The response MAY
+   indicate a better time to call in the Retry-After header field.  This
+   status response is returned only if the client knows that no other
+   end point will answer the request.
+
+21.6.3 604 Does Not Exist Anywhere
+
+   The server has authoritative information that the user indicated in
+   the Request-URI does not exist anywhere.
+
+21.6.4 606 Not Acceptable
+
+   The user's agent was contacted successfully but some aspects of the
+   session description such as the requested media, bandwidth, or
+   addressing style were not acceptable.
+
+   A 606 (Not Acceptable) response means that the user wishes to
+   communicate, but cannot adequately support the session described.
+   The 606 (Not Acceptable) response MAY contain a list of reasons in a
+   Warning header field describing why the session described cannot be
+   supported.  Warning reason codes are listed in Section 20.43.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 192]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   A message body containing a description of media capabilities MAY be
+   present in the response, which is formatted according to the Accept
+   header field in the INVITE (or application/sdp if not present), the
+   same as a message body in a 200 (OK) response to an OPTIONS request.
+
+   It is hoped that negotiation will not frequently be needed, and when
+   a new user is being invited to join an already existing conference,
+   negotiation may not be possible.  It is up to the invitation
+   initiator to decide whether or not to act on a 606 (Not Acceptable)
+   response.
+
+   This status response is returned only if the client knows that no
+   other end point will answer the request.
+
+22 Usage of HTTP Authentication
+
+   SIP provides a stateless, challenge-based mechanism for
+   authentication that is based on authentication in HTTP.  Any time
+   that a proxy server or UA receives a request (with the exceptions
+   given in Section 22.1), it MAY challenge the initiator of the request
+   to provide assurance of its identity.  Once the originator has been
+   identified, the recipient of the request SHOULD ascertain whether or
+   not this user is authorized to make the request in question.  No
+   authorization systems are recommended or discussed in this document.
+
+   The "Digest" authentication mechanism described in this section
+   provides message authentication and replay protection only, without
+   message integrity or confidentiality.  Protective measures above and
+   beyond those provided by Digest need to be taken to prevent active
+   attackers from modifying SIP requests and responses.
+
+   Note that due to its weak security, the usage of "Basic"
+   authentication has been deprecated.  Servers MUST NOT accept
+   credentials using the "Basic" authorization scheme, and servers also
+   MUST NOT challenge with "Basic".  This is a change from RFC 2543.
+
+22.1 Framework
+
+   The framework for SIP authentication closely parallels that of HTTP
+   (RFC 2617 [17]).  In particular, the BNF for auth-scheme, auth-param,
+   challenge, realm, realm-value, and credentials is identical (although
+   the usage of "Basic" as a scheme is not permitted).  In SIP, a UAS
+   uses the 401 (Unauthorized) response to challenge the identity of a
+   UAC.  Additionally, registrars and redirect servers MAY make use of
+   401 (Unauthorized) responses for authentication, but proxies MUST
+   NOT, and instead MAY use the 407 (Proxy Authentication Required)
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 193]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   response.  The requirements for inclusion of the Proxy-Authenticate,
+   Proxy-Authorization, WWW-Authenticate, and Authorization in the
+   various messages are identical to those described in RFC 2617 [17].
+
+   Since SIP does not have the concept of a canonical root URL, the
+   notion of protection spaces is interpreted differently in SIP.  The
+   realm string alone defines the protection domain.  This is a change
+   from RFC 2543, in which the Request-URI and the realm together
+   defined the protection domain.
+
+      This previous definition of protection domain caused some amount
+      of confusion since the Request-URI sent by the UAC and the
+      Request-URI received by the challenging server might be different,
+      and indeed the final form of the Request-URI might not be known to
+      the UAC.  Also, the previous definition depended on the presence
+      of a SIP URI in the Request-URI and seemed to rule out alternative
+      URI schemes (for example, the tel URL).
+
+   Operators of user agents or proxy servers that will authenticate
+   received requests MUST adhere to the following guidelines for
+   creation of a realm string for their server:
+
+      o  Realm strings MUST be globally unique.  It is RECOMMENDED that
+         a realm string contain a hostname or domain name, following the
+         recommendation in Section 3.2.1 of RFC 2617 [17].
+
+      o  Realm strings SHOULD present a human-readable identifier that
+         can be rendered to a user.
+
+   For example:
+
+      INVITE sip:bob@biloxi.com SIP/2.0
+      Authorization: Digest realm="biloxi.com", <...>
+
+   Generally, SIP authentication is meaningful for a specific realm, a
+   protection domain.  Thus, for Digest authentication, each such
+   protection domain has its own set of usernames and passwords.  If a
+   server does not require authentication for a particular request, it
+   MAY accept a default username, "anonymous", which has no password
+   (password of "").  Similarly, UACs representing many users, such as
+   PSTN gateways, MAY have their own device-specific username and
+   password, rather than accounts for particular users, for their realm.
+
+   While a server can legitimately challenge most SIP requests, there
+   are two requests defined by this document that require special
+   handling for authentication: ACK and CANCEL.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 194]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Under an authentication scheme that uses responses to carry values
+   used to compute nonces (such as Digest), some problems come up for
+   any requests that take no response, including ACK.  For this reason,
+   any credentials in the INVITE that were accepted by a server MUST be
+   accepted by that server for the ACK.  UACs creating an ACK message
+   will duplicate all of the Authorization and Proxy-Authorization
+   header field values that appeared in the INVITE to which the ACK
+   corresponds.  Servers MUST NOT attempt to challenge an ACK.
+
+   Although the CANCEL method does take a response (a 2xx), servers MUST
+   NOT attempt to challenge CANCEL requests since these requests cannot
+   be resubmitted.  Generally, a CANCEL request SHOULD be accepted by a
+   server if it comes from the same hop that sent the request being
+   canceled (provided that some sort of transport or network layer
+   security association, as described in Section 26.2.1, is in place).
+
+   When a UAC receives a challenge, it SHOULD render to the user the
+   contents of the "realm" parameter in the challenge (which appears in
+   either a WWW-Authenticate header field or Proxy-Authenticate header
+   field) if the UAC device does not already know of a credential for
+   the realm in question.  A service provider that pre-configures UAs
+   with credentials for its realm should be aware that users will not
+   have the opportunity to present their own credentials for this realm
+   when challenged at a pre-configured device.
+
+   Finally, note that even if a UAC can locate credentials that are
+   associated with the proper realm, the potential exists that these
+   credentials may no longer be valid or that the challenging server
+   will not accept these credentials for whatever reason (especially
+   when "anonymous" with no password is submitted).  In this instance a
+   server may repeat its challenge, or it may respond with a 403
+   Forbidden.  A UAC MUST NOT re-attempt requests with the credentials
+   that have just been rejected (though the request may be retried if
+   the nonce was stale).
+
+22.2 User-to-User Authentication
+
+   When a UAS receives a request from a UAC, the UAS MAY authenticate
+   the originator before the request is processed.  If no credentials
+   (in the Authorization header field) are provided in the request, the
+   UAS can challenge the originator to provide credentials by rejecting
+   the request with a 401 (Unauthorized) status code.
+
+   The WWW-Authenticate response-header field MUST be included in 401
+   (Unauthorized) response messages.  The field value consists of at
+   least one challenge that indicates the authentication scheme(s) and
+   parameters applicable to the realm.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 195]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   An example of the WWW-Authenticate header field in a 401 challenge
+   is:
+
+      WWW-Authenticate: Digest
+              realm="biloxi.com",
+              qop="auth,auth-int",
+              nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+              opaque="5ccc069c403ebaf9f0171e9517f40e41"
+
+   When the originating UAC receives the 401 (Unauthorized), it SHOULD,
+   if it is able, re-originate the request with the proper credentials.
+   The UAC may require input from the originating user before
+   proceeding.  Once authentication credentials have been supplied
+   (either directly by the user, or discovered in an internal keyring),
+   UAs SHOULD cache the credentials for a given value of the To header
+   field and "realm" and attempt to re-use these values on the next
+   request for that destination.  UAs MAY cache credentials in any way
+   they would like.
+
+   If no credentials for a realm can be located, UACs MAY attempt to
+   retry the request with a username of "anonymous" and no password (a
+   password of "").
+
+   Once credentials have been located, any UA that wishes to
+   authenticate itself with a UAS or registrar -- usually, but not
+   necessarily, after receiving a 401 (Unauthorized) response -- MAY do
+   so by including an Authorization header field with the request.  The
+   Authorization field value consists of credentials containing the
+   authentication information of the UA for the realm of the resource
+   being requested as well as parameters required in support of
+   authentication and replay protection.
+
+   An example of the Authorization header field is:
+
+      Authorization: Digest username="bob",
+              realm="biloxi.com",
+              nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+              uri="sip:bob@biloxi.com",
+              qop=auth,
+              nc=00000001,
+              cnonce="0a4f113b",
+              response="6629fae49393a05397450978507c4ef1",
+              opaque="5ccc069c403ebaf9f0171e9517f40e41"
+
+   When a UAC resubmits a request with its credentials after receiving a
+   401 (Unauthorized) or 407 (Proxy Authentication Required) response,
+   it MUST increment the CSeq header field value as it would normally
+   when sending an updated request.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 196]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+22.3 Proxy-to-User Authentication
+
+   Similarly, when a UAC sends a request to a proxy server, the proxy
+   server MAY authenticate the originator before the request is
+   processed.  If no credentials (in the Proxy-Authorization header
+   field) are provided in the request, the proxy can challenge the
+   originator to provide credentials by rejecting the request with a 407
+   (Proxy Authentication Required) status code.  The proxy MUST populate
+   the 407 (Proxy Authentication Required) message with a Proxy-
+   Authenticate header field value applicable to the proxy for the
+   requested resource.
+
+   The use of Proxy-Authenticate and Proxy-Authorization parallel that
+   described in [17], with one difference.  Proxies MUST NOT add values
+   to the Proxy-Authorization header field.  All 407 (Proxy
+   Authentication Required) responses MUST be forwarded upstream toward
+   the UAC following the procedures for any other response.  It is the
+   UAC's responsibility to add the Proxy-Authorization header field
+   value containing credentials for the realm of the proxy that has
+   asked for authentication.
+
+      If a proxy were to resubmit a request adding a Proxy-Authorization
+      header field value, it would need to increment the CSeq in the new
+      request.  However, this would cause the UAC that submitted the
+      original request to discard a response from the UAS, as the CSeq
+      value would be different.
+
+   When the originating UAC receives the 407 (Proxy Authentication
+   Required) it SHOULD, if it is able, re-originate the request with the
+   proper credentials.  It should follow the same procedures for the
+   display of the "realm" parameter that are given above for responding
+   to 401.
+
+   If no credentials for a realm can be located, UACs MAY attempt to
+   retry the request with a username of "anonymous" and no password (a
+   password of "").
+
+   The UAC SHOULD also cache the credentials used in the re-originated
+   request.
+
+   The following rule is RECOMMENDED for proxy credential caching:
+
+   If a UA receives a Proxy-Authenticate header field value in a 401/407
+   response to a request with a particular Call-ID, it should
+   incorporate credentials for that realm in all subsequent requests
+   that contain the same Call-ID.  These credentials MUST NOT be cached
+   across dialogs; however, if a UA is configured with the realm of its
+   local outbound proxy, when one exists, then the UA MAY cache
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 197]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   credentials for that realm across dialogs.  Note that this does mean
+   a future request in a dialog could contain credentials that are not
+   needed by any proxy along the Route header path.
+
+   Any UA that wishes to authenticate itself to a proxy server --
+   usually, but not necessarily, after receiving a 407 (Proxy
+   Authentication Required) response -- MAY do so by including a Proxy-
+   Authorization header field value with the request.  The Proxy-
+   Authorization request-header field allows the client to identify
+   itself (or its user) to a proxy that requires authentication.  The
+   Proxy-Authorization header field value consists of credentials
+   containing the authentication information of the UA for the proxy
+   and/or realm of the resource being requested.
+
+   A Proxy-Authorization header field value applies only to the proxy
+   whose realm is identified in the "realm" parameter (this proxy may
+   previously have demanded authentication using the Proxy-Authenticate
+   field).  When multiple proxies are used in a chain, a Proxy-
+   Authorization header field value MUST NOT be consumed by any proxy
+   whose realm does not match the "realm" parameter specified in that
+   value.
+
+   Note that if an authentication scheme that does not support realms is
+   used in the Proxy-Authorization header field, a proxy server MUST
+   attempt to parse all Proxy-Authorization header field values to
+   determine whether one of them has what the proxy server considers to
+   be valid credentials.  Because this is potentially very time-
+   consuming in large networks, proxy servers SHOULD use an
+   authentication scheme that supports realms in the Proxy-Authorization
+   header field.
+
+   If a request is forked (as described in Section 16.7), various proxy
+   servers and/or UAs may wish to challenge the UAC.  In this case, the
+   forking proxy server is responsible for aggregating these challenges
+   into a single response.  Each WWW-Authenticate and Proxy-Authenticate
+   value received in responses to the forked request MUST be placed into
+   the single response that is sent by the forking proxy to the UA; the
+   ordering of these header field values is not significant.
+
+      When a proxy server issues a challenge in response to a request,
+      it will not proxy the request until the UAC has retried the
+      request with valid credentials.  A forking proxy may forward a
+      request simultaneously to multiple proxy servers that require
+      authentication, each of which in turn will not forward the request
+      until the originating UAC has authenticated itself in their
+      respective realm.  If the UAC does not provide credentials for
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 198]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      each challenge, the proxy servers that issued the challenges will
+      not forward requests to the UA where the destination user might be
+      located, and therefore, the virtues of forking are largely lost.
+
+   When resubmitting its request in response to a 401 (Unauthorized) or
+   407 (Proxy Authentication Required) that contains multiple
+   challenges, a UAC MAY include an Authorization value for each WWW-
+   Authenticate value and a Proxy-Authorization value for each Proxy-
+   Authenticate value for which the UAC wishes to supply a credential.
+   As noted above, multiple credentials in a request SHOULD be
+   differentiated by the "realm" parameter.
+
+   It is possible for multiple challenges associated with the same realm
+   to appear in the same 401 (Unauthorized) or 407 (Proxy Authentication
+   Required).  This can occur, for example, when multiple proxies within
+   the same administrative domain, which use a common realm, are reached
+   by a forking request.  When it retries a request, a UAC MAY therefore
+   supply multiple credentials in Authorization or Proxy-Authorization
+   header fields with the same "realm" parameter value.  The same
+   credentials SHOULD be used for the same realm.
+
+22.4 The Digest Authentication Scheme
+
+   This section describes the modifications and clarifications required
+   to apply the HTTP Digest authentication scheme to SIP.  The SIP
+   scheme usage is almost completely identical to that for HTTP [17].
+
+   Since RFC 2543 is based on HTTP Digest as defined in RFC 2069 [39],
+   SIP servers supporting RFC 2617 MUST ensure they are backwards
+   compatible with RFC 2069.  Procedures for this backwards
+   compatibility are specified in RFC 2617.  Note, however, that SIP
+   servers MUST NOT accept or request Basic authentication.
+
+   The rules for Digest authentication follow those defined in [17],
+   with "HTTP/1.1" replaced by "SIP/2.0" in addition to the following
+   differences:
+
+      1.  The URI included in the challenge has the following BNF:
+
+          URI  =  SIP-URI / SIPS-URI
+
+      2.  The BNF in RFC 2617 has an error in that the 'uri' parameter
+          of the Authorization header field for HTTP Digest
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 199]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+          authentication is not enclosed in quotation marks.  (The
+          example in Section 3.5 of RFC 2617 is correct.)  For SIP, the
+          'uri' MUST be enclosed in quotation marks.
+
+      3.  The BNF for digest-uri-value is:
+
+          digest-uri-value  =  Request-URI ; as defined in Section 25
+
+      4.  The example procedure for choosing a nonce based on Etag does
+          not work for SIP.
+
+      5.  The text in RFC 2617 [17] regarding cache operation does not
+          apply to SIP.
+
+      6.  RFC 2617 [17] requires that a server check that the URI in the
+          request line and the URI included in the Authorization header
+          field point to the same resource.  In a SIP context, these two
+          URIs may refer to different users, due to forwarding at some
+          proxy.  Therefore, in SIP, a server MAY check that the
+          Request-URI in the Authorization header field value
+          corresponds to a user for whom the server is willing to accept
+          forwarded or direct requests, but it is not necessarily a
+          failure if the two fields are not equivalent.
+
+      7.  As a clarification to the calculation of the A2 value for
+          message integrity assurance in the Digest authentication
+          scheme, implementers should assume, when the entity-body is
+          empty (that is, when SIP messages have no body) that the hash
+          of the entity-body resolves to the MD5 hash of an empty
+          string, or:
+
+             H(entity-body) = MD5("") =
+          "d41d8cd98f00b204e9800998ecf8427e"
+
+      8.  RFC 2617 notes that a cnonce value MUST NOT be sent in an
+          Authorization (and by extension Proxy-Authorization) header
+          field if no qop directive has been sent.  Therefore, any
+          algorithms that have a dependency on the cnonce (including
+          "MD5-Sess") require that the qop directive be sent.  Use of
+          the "qop" parameter is optional in RFC 2617 for the purposes
+          of backwards compatibility with RFC 2069; since RFC 2543 was
+          based on RFC 2069, the "qop" parameter must unfortunately
+          remain optional for clients and servers to receive.  However,
+          servers MUST always send a "qop" parameter in WWW-Authenticate
+          and Proxy-Authenticate header field values.  If a client
+          receives a "qop" parameter in a challenge header field, it
+          MUST send the "qop" parameter in any resulting authorization
+          header field.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 200]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   RFC 2543 did not allow usage of the Authentication-Info header field
+   (it effectively used RFC 2069).  However, we now allow usage of this
+   header field, since it provides integrity checks over the bodies and
+   provides mutual authentication.  RFC 2617 [17] defines mechanisms for
+   backwards compatibility using the qop attribute in the request.
+   These mechanisms MUST be used by a server to determine if the client
+   supports the new mechanisms in RFC 2617 that were not specified in
+   RFC 2069.
+
+23 S/MIME
+
+   SIP messages carry MIME bodies and the MIME standard includes
+   mechanisms for securing MIME contents to ensure both integrity and
+   confidentiality (including the 'multipart/signed' and
+   'application/pkcs7-mime' MIME types, see RFC 1847 [22], RFC 2630 [23]
+   and RFC 2633 [24]).  Implementers should note, however, that there
+   may be rare network intermediaries (not typical proxy servers) that
+   rely on viewing or modifying the bodies of SIP messages (especially
+   SDP), and that secure MIME may prevent these sorts of intermediaries
+   from functioning.
+
+      This applies particularly to certain types of firewalls.
+
+      The PGP mechanism for encrypting the header fields and bodies of
+      SIP messages described in RFC 2543 has been deprecated.
+
+23.1 S/MIME Certificates
+
+   The certificates that are used to identify an end-user for the
+   purposes of S/MIME differ from those used by servers in one important
+   respect - rather than asserting that the identity of the holder
+   corresponds to a particular hostname, these certificates assert that
+   the holder is identified by an end-user address.  This address is
+   composed of the concatenation of the "userinfo" "@" and "domainname"
+   portions of a SIP or SIPS URI (in other words, an email address of
+   the form "bob@biloxi.com"), most commonly corresponding to a user's
+   address-of-record.
+
+   These certificates are also associated with keys that are used to
+   sign or encrypt bodies of SIP messages.  Bodies are signed with the
+   private key of the sender (who may include their public key with the
+   message as appropriate), but bodies are encrypted with the public key
+   of the intended recipient.  Obviously, senders must have
+   foreknowledge of the public key of recipients in order to encrypt
+   message bodies.  Public keys can be stored within a UA on a virtual
+   keyring.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 201]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Each user agent that supports S/MIME MUST contain a keyring
+   specifically for end-users' certificates.  This keyring should map
+   between addresses of record and corresponding certificates.  Over
+   time, users SHOULD use the same certificate when they populate the
+   originating URI of signaling (the From header field) with the same
+   address-of-record.
+
+   Any mechanisms depending on the existence of end-user certificates
+   are seriously limited in that there is virtually no consolidated
+   authority today that provides certificates for end-user applications.
+   However, users SHOULD acquire certificates from known public
+   certificate authorities.  As an alternative, users MAY create self-
+   signed certificates.  The implications of self-signed certificates
+   are explored further in Section 26.4.2.  Implementations may also use
+   pre-configured certificates in deployments in which a previous trust
+   relationship exists between all SIP entities.
+
+   Above and beyond the problem of acquiring an end-user certificate,
+   there are few well-known centralized directories that distribute
+   end-user certificates.  However, the holder of a certificate SHOULD
+   publish their certificate in any public directories as appropriate.
+   Similarly, UACs SHOULD support a mechanism for importing (manually or
+   automatically) certificates discovered in public directories
+   corresponding to the target URIs of SIP requests.
+
+23.2 S/MIME Key Exchange
+
+   SIP itself can also be used as a means to distribute public keys in
+   the following manner.
+
+   Whenever the CMS SignedData message is used in S/MIME for SIP, it
+   MUST contain the certificate bearing the public key necessary to
+   verify the signature.
+
+   When a UAC sends a request containing an S/MIME body that initiates a
+   dialog, or sends a non-INVITE request outside the context of a
+   dialog, the UAC SHOULD structure the body as an S/MIME
+   'multipart/signed' CMS SignedData body.  If the desired CMS service
+   is EnvelopedData (and the public key of the target user is known),
+   the UAC SHOULD send the EnvelopedData message encapsulated within a
+   SignedData message.
+
+   When a UAS receives a request containing an S/MIME CMS body that
+   includes a certificate, the UAS SHOULD first validate the
+   certificate, if possible, with any available root certificates for
+   certificate authorities.  The UAS SHOULD also determine the subject
+   of the certificate (for S/MIME, the SubjectAltName will contain the
+   appropriate identity) and compare this value to the From header field
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 202]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   of the request.  If the certificate cannot be verified, because it is
+   self-signed, or signed by no known authority, or if it is verifiable
+   but its subject does not correspond to the From header field of
+   request, the UAS MUST notify its user of the status of the
+   certificate (including the subject of the certificate, its signer,
+   and any key fingerprint information) and request explicit permission
+   before proceeding.  If the certificate was successfully verified and
+   the subject of the certificate corresponds to the From header field
+   of the SIP request, or if the user (after notification) explicitly
+   authorizes the use of the certificate, the UAS SHOULD add this
+   certificate to a local keyring, indexed by the address-of-record of
+   the holder of the certificate.
+
+   When a UAS sends a response containing an S/MIME body that answers
+   the first request in a dialog, or a response to a non-INVITE request
+   outside the context of a dialog, the UAS SHOULD structure the body as
+   an S/MIME 'multipart/signed' CMS SignedData body.  If the desired CMS
+   service is EnvelopedData, the UAS SHOULD send the EnvelopedData
+   message encapsulated within a SignedData message.
+
+   When a UAC receives a response containing an S/MIME CMS body that
+   includes a certificate, the UAC SHOULD first validate the
+   certificate, if possible, with any appropriate root certificate.  The
+   UAC SHOULD also determine the subject of the certificate and compare
+   this value to the To field of the response; although the two may very
+   well be different, and this is not necessarily indicative of a
+   security breach.  If the certificate cannot be verified because it is
+   self-signed, or signed by no known authority, the UAC MUST notify its
+   user of the status of the certificate (including the subject of the
+   certificate, its signator, and any key fingerprint information) and
+   request explicit permission before proceeding.  If the certificate
+   was successfully verified, and the subject of the certificate
+   corresponds to the To header field in the response, or if the user
+   (after notification) explicitly authorizes the use of the
+   certificate, the UAC SHOULD add this certificate to a local keyring,
+   indexed by the address-of-record of the holder of the certificate.
+   If the UAC had not transmitted its own certificate to the UAS in any
+   previous transaction, it SHOULD use a CMS SignedData body for its
+   next request or response.
+
+   On future occasions, when the UA receives requests or responses that
+   contain a From header field corresponding to a value in its keyring,
+   the UA SHOULD compare the certificate offered in these messages with
+   the existing certificate in its keyring.  If there is a discrepancy,
+   the UA MUST notify its user of a change of the certificate
+   (preferably in terms that indicate that this is a potential security
+   breach) and acquire the user's permission before continuing to
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 203]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   process the signaling.  If the user authorizes this certificate, it
+   SHOULD be added to the keyring alongside any previous value(s) for
+   this address-of-record.
+
+   Note well however, that this key exchange mechanism does not
+   guarantee the secure exchange of keys when self-signed certificates,
+   or certificates signed by an obscure authority, are used - it is
+   vulnerable to well-known attacks.  In the opinion of the authors,
+   however, the security it provides is proverbially better than
+   nothing; it is in fact comparable to the widely used SSH application.
+   These limitations are explored in greater detail in Section 26.4.2.
+
+   If a UA receives an S/MIME body that has been encrypted with a public
+   key unknown to the recipient, it MUST reject the request with a 493
+   (Undecipherable) response.  This response SHOULD contain a valid
+   certificate for the respondent (corresponding, if possible, to any
+   address of record given in the To header field of the rejected
+   request) within a MIME body with a 'certs-only' "smime-type"
+   parameter.
+
+   A 493 (Undecipherable) sent without any certificate indicates that
+   the respondent cannot or will not utilize S/MIME encrypted messages,
+   though they may still support S/MIME signatures.
+
+   Note that a user agent that receives a request containing an S/MIME
+   body that is not optional (with a Content-Disposition header
+   "handling" parameter of "required") MUST reject the request with a
+   415 Unsupported Media Type response if the MIME type is not
+   understood.  A user agent that receives such a response when S/MIME
+   is sent SHOULD notify its user that the remote device does not
+   support S/MIME, and it MAY subsequently resend the request without
+   S/MIME, if appropriate; however, this 415 response may constitute a
+   downgrade attack.
+
+   If a user agent sends an S/MIME body in a request, but receives a
+   response that contains a MIME body that is not secured, the UAC
+   SHOULD notify its user that the session could not be secured.
+   However, if a user agent that supports S/MIME receives a request with
+   an unsecured body, it SHOULD NOT respond with a secured body, but if
+   it expects S/MIME from the sender (for example, because the sender's
+   From header field value corresponds to an identity on its keychain),
+   the UAS SHOULD notify its user that the session could not be secured.
+
+   A number of conditions that arise in the previous text call for the
+   notification of the user when an anomalous certificate-management
+   event occurs.  Users might well ask what they should do under these
+   circumstances.  First and foremost, an unexpected change in a
+   certificate, or an absence of security when security is expected, are
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 204]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   causes for caution but not necessarily indications that an attack is
+   in progress.  Users might abort any connection attempt or refuse a
+   connection request they have received; in telephony parlance, they
+   could hang up and call back.  Users may wish to find an alternate
+   means to contact the other party and confirm that their key has
+   legitimately changed.  Note that users are sometimes compelled to
+   change their certificates, for example when they suspect that the
+   secrecy of their private key has been compromised.  When their
+   private key is no longer private, users must legitimately generate a
+   new key and re-establish trust with any users that held their old
+   key.
+
+   Finally, if during the course of a dialog a UA receives a certificate
+   in a CMS SignedData message that does not correspond with the
+   certificates previously exchanged during a dialog, the UA MUST notify
+   its user of the change, preferably in terms that indicate that this
+   is a potential security breach.
+
+23.3 Securing MIME bodies
+
+   There are two types of secure MIME bodies that are of interest to
+   SIP: use of these bodies should follow the S/MIME specification [24]
+   with a few variations.
+
+      o  "multipart/signed" MUST be used only with CMS detached
+         signatures.
+
+            This allows backwards compatibility with non-S/MIME-
+            compliant recipients.
+
+      o  S/MIME bodies SHOULD have a Content-Disposition header field,
+         and the value of the "handling" parameter SHOULD be "required."
+
+      o  If a UAC has no certificate on its keyring associated with the
+         address-of-record to which it wants to send a request, it
+         cannot send an encrypted "application/pkcs7-mime" MIME message.
+         UACs MAY send an initial request such as an OPTIONS message
+         with a CMS detached signature in order to solicit the
+         certificate of the remote side (the signature SHOULD be over a
+         "message/sip" body of the type described in Section 23.4).
+
+            Note that future standardization work on S/MIME may define
+            non-certificate based keys.
+
+      o  Senders of S/MIME bodies SHOULD use the "SMIMECapabilities"
+         (see Section 2.5.2 of [24]) attribute to express their
+         capabilities and preferences for further communications.  Note
+         especially that senders MAY use the "preferSignedData"
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 205]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         capability to encourage receivers to respond with CMS
+         SignedData messages (for example, when sending an OPTIONS
+         request as described above).
+
+      o  S/MIME implementations MUST at a minimum support SHA1 as a
+         digital signature algorithm, and 3DES as an encryption
+         algorithm.  All other signature and encryption algorithms MAY
+         be supported.  Implementations can negotiate support for these
+         algorithms with the "SMIMECapabilities" attribute.
+
+      o  Each S/MIME body in a SIP message SHOULD be signed with only
+         one certificate.  If a UA receives a message with multiple
+         signatures, the outermost signature should be treated as the
+         single certificate for this body.  Parallel signatures SHOULD
+         NOT be used.
+
+         The following is an example of an encrypted S/MIME SDP body
+         within a SIP message:
+
+        INVITE sip:bob@biloxi.com SIP/2.0
+        Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+        To: Bob <sip:bob@biloxi.com>
+        From: Alice <sip:alice@atlanta.com>;tag=1928301774
+        Call-ID: a84b4c76e66710
+        CSeq: 314159 INVITE
+        Max-Forwards: 70
+        Contact: <sip:alice@pc33.atlanta.com>
+        Content-Type: application/pkcs7-mime; smime-type=enveloped-data;
+             name=smime.p7m
+        Content-Disposition: attachment; filename=smime.p7m
+           handling=required
+
+      *******************************************************
+      * Content-Type: application/sdp                       *
+      *                                                     *
+      * v=0                                                 *
+      * o=alice 53655765 2353687637 IN IP4 pc33.atlanta.com *
+      * s=-                                                 *
+      * t=0 0                                               *
+      * c=IN IP4 pc33.atlanta.com                           *
+      * m=audio 3456 RTP/AVP 0 1 3 99                       *
+      * a=rtpmap:0 PCMU/8000                                *
+      *******************************************************
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 206]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+23.4 SIP Header Privacy and Integrity using S/MIME: Tunneling SIP
+
+   As a means of providing some degree of end-to-end authentication,
+   integrity or confidentiality for SIP header fields, S/MIME can
+   encapsulate entire SIP messages within MIME bodies of type
+   "message/sip" and then apply MIME security to these bodies in the
+   same manner as typical SIP bodies.  These encapsulated SIP requests
+   and responses do not constitute a separate dialog or transaction,
+   they are a copy of the "outer" message that is used to verify
+   integrity or to supply additional information.
+
+   If a UAS receives a request that contains a tunneled "message/sip"
+   S/MIME body, it SHOULD include a tunneled "message/sip" body in the
+   response with the same smime-type.
+
+   Any traditional MIME bodies (such as SDP) SHOULD be attached to the
+   "inner" message so that they can also benefit from S/MIME security.
+   Note that "message/sip" bodies can be sent as a part of a MIME
+   "multipart/mixed" body if any unsecured MIME types should also be
+   transmitted in a request.
+
+23.4.1 Integrity and Confidentiality Properties of SIP Headers
+
+   When the S/MIME integrity or confidentiality mechanisms are used,
+   there may be discrepancies between the values in the "inner" message
+   and values in the "outer" message.  The rules for handling any such
+   differences for all of the header fields described in this document
+   are given in this section.
+
+   Note that for the purposes of loose timestamping, all SIP messages
+   that tunnel "message/sip" SHOULD contain a Date header in both the
+   "inner" and "outer" headers.
+
+23.4.1.1 Integrity
+
+   Whenever integrity checks are performed, the integrity of a header
+   field should be determined by matching the value of the header field
+   in the signed body with that in the "outer" messages using the
+   comparison rules of SIP as described in 20.
+
+   Header fields that can be legitimately modified by proxy servers are:
+   Request-URI, Via, Record-Route, Route, Max-Forwards, and Proxy-
+   Authorization.  If these header fields are not intact end-to-end,
+   implementations SHOULD NOT consider this a breach of security.
+   Changes to any other header fields defined in this document
+   constitute an integrity violation; users MUST be notified of a
+   discrepancy.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 207]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+23.4.1.2 Confidentiality
+
+   When messages are encrypted, header fields may be included in the
+   encrypted body that are not present in the "outer" message.
+
+   Some header fields must always have a plaintext version because they
+   are required header fields in requests and responses - these include:
+
+   To, From, Call-ID, CSeq, Contact.  While it is probably not useful to
+   provide an encrypted alternative for the Call-ID, CSeq, or Contact,
+   providing an alternative to the information in the "outer" To or From
+   is permitted.  Note that the values in an encrypted body are not used
+   for the purposes of identifying transactions or dialogs - they are
+   merely informational.  If the From header field in an encrypted body
+   differs from the value in the "outer" message, the value within the
+   encrypted body SHOULD be displayed to the user, but MUST NOT be used
+   in the "outer" header fields of any future messages.
+
+   Primarily, a user agent will want to encrypt header fields that have
+   an end-to-end semantic, including: Subject, Reply-To, Organization,
+   Accept, Accept-Encoding, Accept-Language, Alert-Info, Error-Info,
+   Authentication-Info, Expires, In-Reply-To, Require, Supported,
+   Unsupported, Retry-After, User-Agent, Server, and Warning.  If any of
+   these header fields are present in an encrypted body, they should be
+   used instead of any "outer" header fields, whether this entails
+   displaying the header field values to users or setting internal
+   states in the UA.  They SHOULD NOT however be used in the "outer"
+   headers of any future messages.
+
+   If present, the Date header field MUST always be the same in the
+   "inner" and "outer" headers.
+
+   Since MIME bodies are attached to the "inner" message,
+   implementations will usually encrypt MIME-specific header fields,
+   including: MIME-Version, Content-Type, Content-Length, Content-
+   Language, Content-Encoding and Content-Disposition.  The "outer"
+   message will have the proper MIME header fields for S/MIME bodies.
+   These header fields (and any MIME bodies they preface) should be
+   treated as normal MIME header fields and bodies received in a SIP
+   message.
+
+   It is not particularly useful to encrypt the following header fields:
+   Min-Expires, Timestamp, Authorization, Priority, and WWW-
+   Authenticate.  This category also includes those header fields that
+   can be changed by proxy servers (described in the preceding section).
+   UAs SHOULD never include these in an "inner" message if they are not
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 208]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   included in the "outer" message.  UAs that receive any of these
+   header fields in an encrypted body SHOULD ignore the encrypted
+   values.
+
+   Note that extensions to SIP may define additional header fields; the
+   authors of these extensions should describe the integrity and
+   confidentiality properties of such header fields.  If a SIP UA
+   encounters an unknown header field with an integrity violation, it
+   MUST ignore the header field.
+
+23.4.2 Tunneling Integrity and Authentication
+
+   Tunneling SIP messages within S/MIME bodies can provide integrity for
+   SIP header fields if the header fields that the sender wishes to
+   secure are replicated in a "message/sip" MIME body signed with a CMS
+   detached signature.
+
+   Provided that the "message/sip" body contains at least the
+   fundamental dialog identifiers (To, From, Call-ID, CSeq), then a
+   signed MIME body can provide limited authentication.  At the very
+   least, if the certificate used to sign the body is unknown to the
+   recipient and cannot be verified, the signature can be used to
+   ascertain that a later request in a dialog was transmitted by the
+   same certificate-holder that initiated the dialog.  If the recipient
+   of the signed MIME body has some stronger incentive to trust the
+   certificate (they were able to validate it, they acquired it from a
+   trusted repository, or they have used it frequently) then the
+   signature can be taken as a stronger assertion of the identity of the
+   subject of the certificate.
+
+   In order to eliminate possible confusions about the addition or
+   subtraction of entire header fields, senders SHOULD replicate all
+   header fields from the request within the signed body.  Any message
+   bodies that require integrity protection MUST be attached to the
+   "inner" message.
+
+   If a Date header is present in a message with a signed body, the
+   recipient SHOULD compare the header field value with its own internal
+   clock, if applicable.  If a significant time discrepancy is detected
+   (on the order of an hour or more), the user agent SHOULD alert the
+   user to the anomaly, and note that it is a potential security breach.
+
+   If an integrity violation in a message is detected by its recipient,
+   the message MAY be rejected with a 403 (Forbidden) response if it is
+   a request, or any existing dialog MAY be terminated.  UAs SHOULD
+   notify users of this circumstance and request explicit guidance on
+   how to proceed.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 209]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The following is an example of the use of a tunneled "message/sip"
+   body:
+
+      INVITE sip:bob@biloxi.com SIP/2.0
+      Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+      To: Bob <sip:bob@biloxi.com>
+      From: Alice <sip:alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710
+      CSeq: 314159 INVITE
+      Max-Forwards: 70
+      Date: Thu, 21 Feb 2002 13:02:03 GMT
+      Contact: <sip:alice@pc33.atlanta.com>
+      Content-Type: multipart/signed;
+        protocol="application/pkcs7-signature";
+        micalg=sha1; boundary=boundary42
+      Content-Length: 568
+
+      --boundary42
+      Content-Type: message/sip
+
+      INVITE sip:bob@biloxi.com SIP/2.0
+      Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+      To: Bob <bob@biloxi.com>
+      From: Alice <alice@atlanta.com>;tag=1928301774
+      Call-ID: a84b4c76e66710
+      CSeq: 314159 INVITE
+      Max-Forwards: 70
+      Date: Thu, 21 Feb 2002 13:02:03 GMT
+      Contact: <sip:alice@pc33.atlanta.com>
+      Content-Type: application/sdp
+      Content-Length: 147
+
+      v=0
+      o=UserA 2890844526 2890844526 IN IP4 here.com
+      s=Session SDP
+      c=IN IP4 pc33.atlanta.com
+      t=0 0
+      m=audio 49172 RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+
+      --boundary42
+      Content-Type: application/pkcs7-signature; name=smime.p7s
+      Content-Transfer-Encoding: base64
+      Content-Disposition: attachment; filename=smime.p7s;
+         handling=required
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 210]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT6
+      4VQpfyF467GhIGfHfYT6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnj
+      n8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGfHfYT6ghyHhHUujpfyF4
+      7GhIGfHfYT64VQbnj756
+
+      --boundary42-
+
+23.4.3 Tunneling Encryption
+
+   It may also be desirable to use this mechanism to encrypt a
+   "message/sip" MIME body within a CMS EnvelopedData message S/MIME
+   body, but in practice, most header fields are of at least some use to
+   the network; the general use of encryption with S/MIME is to secure
+   message bodies like SDP rather than message headers.  Some
+   informational header fields, such as the Subject or Organization
+   could perhaps warrant end-to-end security.  Headers defined by future
+   SIP applications might also require obfuscation.
+
+   Another possible application of encrypting header fields is selective
+   anonymity.  A request could be constructed with a From header field
+   that contains no personal information (for example,
+   sip:anonymous@anonymizer.invalid).  However, a second From header
+   field containing the genuine address-of-record of the originator
+   could be encrypted within a "message/sip" MIME body where it will
+   only be visible to the endpoints of a dialog.
+
+      Note that if this mechanism is used for anonymity, the From header
+      field will no longer be usable by the recipient of a message as an
+      index to their certificate keychain for retrieving the proper
+      S/MIME key to associated with the sender.  The message must first
+      be decrypted, and the "inner" From header field MUST be used as an
+      index.
+
+   In order to provide end-to-end integrity, encrypted "message/sip"
+   MIME bodies SHOULD be signed by the sender.  This creates a
+   "multipart/signed" MIME body that contains an encrypted body and a
+   signature, both of type "application/pkcs7-mime".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 211]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   In the following example, of an encrypted and signed message, the
+   text boxed in asterisks ("*") is encrypted:
+
+        INVITE sip:bob@biloxi.com SIP/2.0
+        Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+        To: Bob <sip:bob@biloxi.com>
+        From: Anonymous <sip:anonymous@atlanta.com>;tag=1928301774
+        Call-ID: a84b4c76e66710
+        CSeq: 314159 INVITE
+        Max-Forwards: 70
+        Date: Thu, 21 Feb 2002 13:02:03 GMT
+        Contact: <sip:pc33.atlanta.com>
+        Content-Type: multipart/signed;
+          protocol="application/pkcs7-signature";
+          micalg=sha1; boundary=boundary42
+        Content-Length: 568
+
+        --boundary42
+        Content-Type: application/pkcs7-mime; smime-type=enveloped-data;
+             name=smime.p7m
+        Content-Transfer-Encoding: base64
+        Content-Disposition: attachment; filename=smime.p7m
+           handling=required
+        Content-Length: 231
+
+      ***********************************************************
+      * Content-Type: message/sip                               *
+      *                                                         *
+      * INVITE sip:bob@biloxi.com SIP/2.0                       *
+      * Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8 *
+      * To: Bob <bob@biloxi.com>                                *
+      * From: Alice <alice@atlanta.com>;tag=1928301774          *
+      * Call-ID: a84b4c76e66710                                 *
+      * CSeq: 314159 INVITE                                     *
+      * Max-Forwards: 70                                        *
+      * Date: Thu, 21 Feb 2002 13:02:03 GMT                     *
+      * Contact: <sip:alice@pc33.atlanta.com>                   *
+      *                                                         *
+      * Content-Type: application/sdp                           *
+      *                                                         *
+      * v=0                                                     *
+      * o=alice 53655765 2353687637 IN IP4 pc33.atlanta.com     *
+      * s=Session SDP                                           *
+      * t=0 0                                                   *
+      * c=IN IP4 pc33.atlanta.com                               *
+      * m=audio 3456 RTP/AVP 0 1 3 99                           *
+      * a=rtpmap:0 PCMU/8000                                    *
+      ***********************************************************
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 212]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+        --boundary42
+        Content-Type: application/pkcs7-signature; name=smime.p7s
+        Content-Transfer-Encoding: base64
+        Content-Disposition: attachment; filename=smime.p7s;
+           handling=required
+
+        ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT6
+        4VQpfyF467GhIGfHfYT6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnj
+        n8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGfHfYT6ghyHhHUujpfyF4
+        7GhIGfHfYT64VQbnj756
+
+        --boundary42-
+
+24 Examples
+
+   In the following examples, we often omit the message body and the
+   corresponding Content-Length and Content-Type header fields for
+   brevity.
+
+24.1 Registration
+
+   Bob registers on start-up.  The message flow is shown in Figure 9.
+   Note that the authentication usually required for registration is not
+   shown for simplicity.
+
+                  biloxi.com         Bob's
+                   registrar       softphone
+                      |                |
+                      |   REGISTER F1  |
+                      |<---------------|
+                      |    200 OK F2   |
+                      |--------------->|
+
+                  Figure 9: SIP Registration Example
+
+   F1 REGISTER Bob -> Registrar
+
+       REGISTER sip:registrar.biloxi.com SIP/2.0
+       Via: SIP/2.0/UDP bobspc.biloxi.com:5060;branch=z9hG4bKnashds7
+       Max-Forwards: 70
+       To: Bob <sip:bob@biloxi.com>
+       From: Bob <sip:bob@biloxi.com>;tag=456248
+       Call-ID: 843817637684230@998sdasdh09
+       CSeq: 1826 REGISTER
+       Contact: <sip:bob@192.0.2.4>
+       Expires: 7200
+       Content-Length: 0
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 213]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The registration expires after two hours.  The registrar responds
+   with a 200 OK:
+
+   F2 200 OK Registrar -> Bob
+
+        SIP/2.0 200 OK
+        Via: SIP/2.0/UDP bobspc.biloxi.com:5060;branch=z9hG4bKnashds7
+         ;received=192.0.2.4
+        To: Bob <sip:bob@biloxi.com>;tag=2493k59kd
+        From: Bob <sip:bob@biloxi.com>;tag=456248
+        Call-ID: 843817637684230@998sdasdh09
+        CSeq: 1826 REGISTER
+        Contact: <sip:bob@192.0.2.4>
+        Expires: 7200
+        Content-Length: 0
+
+24.2 Session Setup
+
+   This example contains the full details of the example session setup
+   in Section 4.  The message flow is shown in Figure 1.  Note that
+   these flows show the minimum required set of header fields - some
+   other header fields such as Allow and Supported would normally be
+   present.
+
+F1 INVITE Alice -> atlanta.com proxy
+
+INVITE sip:bob@biloxi.com SIP/2.0
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+Max-Forwards: 70
+To: Bob <sip:bob@biloxi.com>
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:alice@pc33.atlanta.com>
+Content-Type: application/sdp
+Content-Length: 142
+
+(Alice's SDP not shown)
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 214]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+F2 100 Trying atlanta.com proxy -> Alice
+
+SIP/2.0 100 Trying
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Content-Length: 0
+
+F3 INVITE atlanta.com proxy -> biloxi.com proxy
+
+INVITE sip:bob@biloxi.com SIP/2.0
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+Max-Forwards: 69
+To: Bob <sip:bob@biloxi.com>
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:alice@pc33.atlanta.com>
+Content-Type: application/sdp
+Content-Length: 142
+
+(Alice's SDP not shown)
+
+F4 100 Trying biloxi.com proxy -> atlanta.com proxy
+
+SIP/2.0 100 Trying
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 215]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+F5 INVITE biloxi.com proxy -> Bob
+
+INVITE sip:bob@192.0.2.4 SIP/2.0
+Via: SIP/2.0/UDP server10.biloxi.com;branch=z9hG4bK4b43c2ff8.1
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+Max-Forwards: 68
+To: Bob <sip:bob@biloxi.com>
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:alice@pc33.atlanta.com>
+Content-Type: application/sdp
+Content-Length: 142
+
+(Alice's SDP not shown)
+
+F6 180 Ringing Bob -> biloxi.com proxy
+
+SIP/2.0 180 Ringing
+Via: SIP/2.0/UDP server10.biloxi.com;branch=z9hG4bK4b43c2ff8.1
+ ;received=192.0.2.3
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+Contact: <sip:bob@192.0.2.4>
+CSeq: 314159 INVITE
+Content-Length: 0
+
+F7 180 Ringing biloxi.com proxy -> atlanta.com proxy
+
+SIP/2.0 180 Ringing
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+Contact: <sip:bob@192.0.2.4>
+CSeq: 314159 INVITE
+Content-Length: 0
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 216]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+F8 180 Ringing atlanta.com proxy -> Alice
+
+SIP/2.0 180 Ringing
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+Contact: <sip:bob@192.0.2.4>
+CSeq: 314159 INVITE
+Content-Length: 0
+
+F9 200 OK Bob -> biloxi.com proxy
+
+SIP/2.0 200 OK
+Via: SIP/2.0/UDP server10.biloxi.com;branch=z9hG4bK4b43c2ff8.1
+ ;received=192.0.2.3
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:bob@192.0.2.4>
+Content-Type: application/sdp
+Content-Length: 131
+
+(Bob's SDP not shown)
+
+F10 200 OK biloxi.com proxy -> atlanta.com proxy
+
+SIP/2.0 200 OK
+Via: SIP/2.0/UDP bigbox3.site3.atlanta.com;branch=z9hG4bK77ef4c2312983.1
+ ;received=192.0.2.2
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:bob@192.0.2.4>
+Content-Type: application/sdp
+Content-Length: 131
+
+(Bob's SDP not shown)
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 217]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+F11 200 OK atlanta.com proxy -> Alice
+
+SIP/2.0 200 OK
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8
+ ;received=192.0.2.1
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 INVITE
+Contact: <sip:bob@192.0.2.4>
+Content-Type: application/sdp
+Content-Length: 131
+
+(Bob's SDP not shown)
+
+F12 ACK Alice -> Bob
+
+ACK sip:bob@192.0.2.4 SIP/2.0
+Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds9
+Max-Forwards: 70
+To: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+From: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 314159 ACK
+Content-Length: 0
+
+   The media session between Alice and Bob is now established.
+
+   Bob hangs up first.  Note that Bob's SIP phone maintains its own CSeq
+   numbering space, which, in this example, begins with 231.  Since Bob
+   is making the request, the To and From URIs and tags have been
+   swapped.
+
+F13 BYE Bob -> Alice
+
+BYE sip:alice@pc33.atlanta.com SIP/2.0
+Via: SIP/2.0/UDP 192.0.2.4;branch=z9hG4bKnashds10
+Max-Forwards: 70
+From: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+To: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 231 BYE
+Content-Length: 0
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 218]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+F14 200 OK Alice -> Bob
+
+SIP/2.0 200 OK
+Via: SIP/2.0/UDP 192.0.2.4;branch=z9hG4bKnashds10
+From: Bob <sip:bob@biloxi.com>;tag=a6c85cf
+To: Alice <sip:alice@atlanta.com>;tag=1928301774
+Call-ID: a84b4c76e66710
+CSeq: 231 BYE
+Content-Length: 0
+
+   The SIP Call Flows document [40] contains further examples of SIP
+   messages.
+
+25  Augmented BNF for the SIP Protocol
+
+   All of the mechanisms specified in this document are described in
+   both prose and an augmented Backus-Naur Form (BNF) defined in RFC
+   2234 [10].  Section 6.1 of RFC 2234 defines a set of core rules that
+   are used by this specification, and not repeated here.  Implementers
+   need to be familiar with the notation and content of RFC 2234 in
+   order to understand this specification.  Certain basic rules are in
+   uppercase, such as SP, LWS, HTAB, CRLF, DIGIT, ALPHA, etc.  Angle
+   brackets are used within definitions to clarify the use of rule
+   names.
+
+   The use of square brackets is redundant syntactically.  It is used as
+   a semantic hint that the specific parameter is optional to use.
+
+25.1 Basic Rules
+
+   The following rules are used throughout this specification to
+   describe basic parsing constructs.  The US-ASCII coded character set
+   is defined by ANSI X3.4-1986.
+
+      alphanum  =  ALPHA / DIGIT
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 219]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Several rules are incorporated from RFC 2396 [5] but are updated to
+   make them compliant with RFC 2234 [10].  These include:
+
+      reserved    =  ";" / "/" / "?" / ":" / "@" / "&" / "=" / "+"
+                     / "$" / ","
+      unreserved  =  alphanum / mark
+      mark        =  "-" / "_" / "." / "!" / "~" / "*" / "'"
+                     / "(" / ")"
+      escaped     =  "%" HEXDIG HEXDIG
+
+   SIP header field values can be folded onto multiple lines if the
+   continuation line begins with a space or horizontal tab.  All linear
+   white space, including folding, has the same semantics as SP.  A
+   recipient MAY replace any linear white space with a single SP before
+   interpreting the field value or forwarding the message downstream.
+   This is intended to behave exactly as HTTP/1.1 as described in RFC
+   2616 [8].  The SWS construct is used when linear white space is
+   optional, generally between tokens and separators.
+
+      LWS  =  [*WSP CRLF] 1*WSP ; linear whitespace
+      SWS  =  [LWS] ; sep whitespace
+
+   To separate the header name from the rest of value, a colon is used,
+   which, by the above rule, allows whitespace before, but no line
+   break, and whitespace after, including a linebreak.  The HCOLON
+   defines this construct.
+
+      HCOLON  =  *( SP / HTAB ) ":" SWS
+
+   The TEXT-UTF8 rule is only used for descriptive field contents and
+   values that are not intended to be interpreted by the message parser.
+   Words of *TEXT-UTF8 contain characters from the UTF-8 charset (RFC
+   2279 [7]).  The TEXT-UTF8-TRIM rule is used for descriptive field
+   contents that are n t quoted strings, where leading and trailing LWS
+   is not meaningful.  In this regard, SIP differs from HTTP, which uses
+   the ISO 8859-1 character set.
+
+      TEXT-UTF8-TRIM  =  1*TEXT-UTF8char *(*LWS TEXT-UTF8char)
+      TEXT-UTF8char   =  %x21-7E / UTF8-NONASCII
+      UTF8-NONASCII   =  %xC0-DF 1UTF8-CONT
+                      /  %xE0-EF 2UTF8-CONT
+                      /  %xF0-F7 3UTF8-CONT
+                      /  %xF8-Fb 4UTF8-CONT
+                      /  %xFC-FD 5UTF8-CONT
+      UTF8-CONT       =  %x80-BF
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 220]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   A CRLF is allowed in the definition of TEXT-UTF8-TRIM only as part of
+   a header field continuation.  It is expected that the folding LWS
+   will be replaced with a single SP before interpretation of the TEXT-
+   UTF8-TRIM value.
+
+   Hexadecimal numeric characters are used in several protocol elements.
+   Some elements (authentication) force hex alphas to be lower case.
+
+      LHEX  =  DIGIT / %x61-66 ;lowercase a-f
+
+   Many SIP header field values consist of words separated by LWS or
+   special characters.  Unless otherwise stated, tokens are case-
+   insensitive.  These special characters MUST be in a quoted string to
+   be used within a parameter value.  The word construct is used in
+   Call-ID to allow most separators to be used.
+
+      token       =  1*(alphanum / "-" / "." / "!" / "%" / "*"
+                     / "_" / "+" / "`" / "'" / "~" )
+      separators  =  "(" / ")" / "<" / ">" / "@" /
+                     "," / ";" / ":" / "\" / DQUOTE /
+                     "/" / "[" / "]" / "?" / "=" /
+                     "{" / "}" / SP / HTAB
+      word        =  1*(alphanum / "-" / "." / "!" / "%" / "*" /
+                     "_" / "+" / "`" / "'" / "~" /
+                     "(" / ")" / "<" / ">" /
+                     ":" / "\" / DQUOTE /
+                     "/" / "[" / "]" / "?" /
+                     "{" / "}" )
+
+   When tokens are used or separators are used between elements,
+   whitespace is often allowed before or after these characters:
+
+      STAR    =  SWS "*" SWS ; asterisk
+      SLASH   =  SWS "/" SWS ; slash
+      EQUAL   =  SWS "=" SWS ; equal
+      LPAREN  =  SWS "(" SWS ; left parenthesis
+      RPAREN  =  SWS ")" SWS ; right parenthesis
+      RAQUOT  =  ">" SWS ; right angle quote
+      LAQUOT  =  SWS "<"; left angle quote
+      COMMA   =  SWS "," SWS ; comma
+      SEMI    =  SWS ";" SWS ; semicolon
+      COLON   =  SWS ":" SWS ; colon
+      LDQUOT  =  SWS DQUOTE; open double quotation mark
+      RDQUOT  =  DQUOTE SWS ; close double quotation mark
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 221]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Comments can be included in some SIP header fields by surrounding the
+   comment text with parentheses.  Comments are only allowed in fields
+   containing "comment" as part of their field value definition.  In all
+   other fields, parentheses are considered part of the field value.
+
+      comment  =  LPAREN *(ctext / quoted-pair / comment) RPAREN
+      ctext    =  %x21-27 / %x2A-5B / %x5D-7E / UTF8-NONASCII
+                  / LWS
+
+   ctext includes all chars except left and right parens and backslash.
+   A string of text is parsed as a single word if it is quoted using
+   double-quote marks.  In quoted strings, quotation marks (") and
+   backslashes (\) need to be escaped.
+
+      quoted-string  =  SWS DQUOTE *(qdtext / quoted-pair ) DQUOTE
+      qdtext         =  LWS / %x21 / %x23-5B / %x5D-7E
+                        / UTF8-NONASCII
+
+   The backslash character ("\") MAY be used as a single-character
+   quoting mechanism only within quoted-string and comment constructs.
+   Unlike HTTP/1.1, the characters CR and LF cannot be escaped by this
+   mechanism to avoid conflict with line folding and header separation.
+
+quoted-pair  =  "\" (%x00-09 / %x0B-0C
+                / %x0E-7F)
+
+SIP-URI          =  "sip:" [ userinfo ] hostport
+                    uri-parameters [ headers ]
+SIPS-URI         =  "sips:" [ userinfo ] hostport
+                    uri-parameters [ headers ]
+userinfo         =  ( user / telephone-subscriber ) [ ":" password ] "@"
+user             =  1*( unreserved / escaped / user-unreserved )
+user-unreserved  =  "&" / "=" / "+" / "$" / "," / ";" / "?" / "/"
+password         =  *( unreserved / escaped /
+                    "&" / "=" / "+" / "$" / "," )
+hostport         =  host [ ":" port ]
+host             =  hostname / IPv4address / IPv6reference
+hostname         =  *( domainlabel "." ) toplabel [ "." ]
+domainlabel      =  alphanum
+                    / alphanum *( alphanum / "-" ) alphanum
+toplabel         =  ALPHA / ALPHA *( alphanum / "-" ) alphanum
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 222]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+IPv4address    =  1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+IPv6reference  =  "[" IPv6address "]"
+IPv6address    =  hexpart [ ":" IPv4address ]
+hexpart        =  hexseq / hexseq "::" [ hexseq ] / "::" [ hexseq ]
+hexseq         =  hex4 *( ":" hex4)
+hex4           =  1*4HEXDIG
+port           =  1*DIGIT
+
+   The BNF for telephone-subscriber can be found in RFC 2806 [9].  Note,
+   however, that any characters allowed there that are not allowed in
+   the user part of the SIP URI MUST be escaped.
+
+uri-parameters    =  *( ";" uri-parameter)
+uri-parameter     =  transport-param / user-param / method-param
+                     / ttl-param / maddr-param / lr-param / other-param
+transport-param   =  "transport="
+                     ( "udp" / "tcp" / "sctp" / "tls"
+                     / other-transport)
+other-transport   =  token
+user-param        =  "user=" ( "phone" / "ip" / other-user)
+other-user        =  token
+method-param      =  "method=" Method
+ttl-param         =  "ttl=" ttl
+maddr-param       =  "maddr=" host
+lr-param          =  "lr"
+other-param       =  pname [ "=" pvalue ]
+pname             =  1*paramchar
+pvalue            =  1*paramchar
+paramchar         =  param-unreserved / unreserved / escaped
+param-unreserved  =  "[" / "]" / "/" / ":" / "&" / "+" / "$"
+
+headers         =  "?" header *( "&" header )
+header          =  hname "=" hvalue
+hname           =  1*( hnv-unreserved / unreserved / escaped )
+hvalue          =  *( hnv-unreserved / unreserved / escaped )
+hnv-unreserved  =  "[" / "]" / "/" / "?" / ":" / "+" / "$"
+
+SIP-message    =  Request / Response
+Request        =  Request-Line
+                  *( message-header )
+                  CRLF
+                  [ message-body ]
+Request-Line   =  Method SP Request-URI SP SIP-Version CRLF
+Request-URI    =  SIP-URI / SIPS-URI / absoluteURI
+absoluteURI    =  scheme ":" ( hier-part / opaque-part )
+hier-part      =  ( net-path / abs-path ) [ "?" query ]
+net-path       =  "//" authority [ abs-path ]
+abs-path       =  "/" path-segments
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 223]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+opaque-part    =  uric-no-slash *uric
+uric           =  reserved / unreserved / escaped
+uric-no-slash  =  unreserved / escaped / ";" / "?" / ":" / "@"
+                  / "&" / "=" / "+" / "$" / ","
+path-segments  =  segment *( "/" segment )
+segment        =  *pchar *( ";" param )
+param          =  *pchar
+pchar          =  unreserved / escaped /
+                  ":" / "@" / "&" / "=" / "+" / "$" / ","
+scheme         =  ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+authority      =  srvr / reg-name
+srvr           =  [ [ userinfo "@" ] hostport ]
+reg-name       =  1*( unreserved / escaped / "$" / ","
+                  / ";" / ":" / "@" / "&" / "=" / "+" )
+query          =  *uric
+SIP-Version    =  "SIP" "/" 1*DIGIT "." 1*DIGIT
+
+message-header  =  (Accept
+                /  Accept-Encoding
+                /  Accept-Language
+                /  Alert-Info
+                /  Allow
+                /  Authentication-Info
+                /  Authorization
+                /  Call-ID
+                /  Call-Info
+                /  Contact
+                /  Content-Disposition
+                /  Content-Encoding
+                /  Content-Language
+                /  Content-Length
+                /  Content-Type
+                /  CSeq
+                /  Date
+                /  Error-Info
+                /  Expires
+                /  From
+                /  In-Reply-To
+                /  Max-Forwards
+                /  MIME-Version
+                /  Min-Expires
+                /  Organization
+                /  Priority
+                /  Proxy-Authenticate
+                /  Proxy-Authorization
+                /  Proxy-Require
+                /  Record-Route
+                /  Reply-To
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 224]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+                /  Require
+                /  Retry-After
+                /  Route
+                /  Server
+                /  Subject
+                /  Supported
+                /  Timestamp
+                /  To
+                /  Unsupported
+                /  User-Agent
+                /  Via
+                /  Warning
+                /  WWW-Authenticate
+                /  extension-header) CRLF
+
+INVITEm           =  %x49.4E.56.49.54.45 ; INVITE in caps
+ACKm              =  %x41.43.4B ; ACK in caps
+OPTIONSm          =  %x4F.50.54.49.4F.4E.53 ; OPTIONS in caps
+BYEm              =  %x42.59.45 ; BYE in caps
+CANCELm           =  %x43.41.4E.43.45.4C ; CANCEL in caps
+REGISTERm         =  %x52.45.47.49.53.54.45.52 ; REGISTER in caps
+Method            =  INVITEm / ACKm / OPTIONSm / BYEm
+                     / CANCELm / REGISTERm
+                     / extension-method
+extension-method  =  token
+Response          =  Status-Line
+                     *( message-header )
+                     CRLF
+                     [ message-body ]
+
+Status-Line     =  SIP-Version SP Status-Code SP Reason-Phrase CRLF
+Status-Code     =  Informational
+               /   Redirection
+               /   Success
+               /   Client-Error
+               /   Server-Error
+               /   Global-Failure
+               /   extension-code
+extension-code  =  3DIGIT
+Reason-Phrase   =  *(reserved / unreserved / escaped
+                   / UTF8-NONASCII / UTF8-CONT / SP / HTAB)
+
+Informational  =  "100"  ;  Trying
+              /   "180"  ;  Ringing
+              /   "181"  ;  Call Is Being Forwarded
+              /   "182"  ;  Queued
+              /   "183"  ;  Session Progress
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 225]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Success  =  "200"  ;  OK
+
+Redirection  =  "300"  ;  Multiple Choices
+            /   "301"  ;  Moved Permanently
+            /   "302"  ;  Moved Temporarily
+            /   "305"  ;  Use Proxy
+            /   "380"  ;  Alternative Service
+
+Client-Error  =  "400"  ;  Bad Request
+             /   "401"  ;  Unauthorized
+             /   "402"  ;  Payment Required
+             /   "403"  ;  Forbidden
+             /   "404"  ;  Not Found
+             /   "405"  ;  Method Not Allowed
+             /   "406"  ;  Not Acceptable
+             /   "407"  ;  Proxy Authentication Required
+             /   "408"  ;  Request Timeout
+             /   "410"  ;  Gone
+             /   "413"  ;  Request Entity Too Large
+             /   "414"  ;  Request-URI Too Large
+             /   "415"  ;  Unsupported Media Type
+             /   "416"  ;  Unsupported URI Scheme
+             /   "420"  ;  Bad Extension
+             /   "421"  ;  Extension Required
+             /   "423"  ;  Interval Too Brief
+             /   "480"  ;  Temporarily not available
+             /   "481"  ;  Call Leg/Transaction Does Not Exist
+             /   "482"  ;  Loop Detected
+             /   "483"  ;  Too Many Hops
+             /   "484"  ;  Address Incomplete
+             /   "485"  ;  Ambiguous
+             /   "486"  ;  Busy Here
+             /   "487"  ;  Request Terminated
+             /   "488"  ;  Not Acceptable Here
+             /   "491"  ;  Request Pending
+             /   "493"  ;  Undecipherable
+
+Server-Error  =  "500"  ;  Internal Server Error
+             /   "501"  ;  Not Implemented
+             /   "502"  ;  Bad Gateway
+             /   "503"  ;  Service Unavailable
+             /   "504"  ;  Server Time-out
+             /   "505"  ;  SIP Version not supported
+             /   "513"  ;  Message Too Large
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 226]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Global-Failure  =  "600"  ;  Busy Everywhere
+               /   "603"  ;  Decline
+               /   "604"  ;  Does not exist anywhere
+               /   "606"  ;  Not Acceptable
+
+Accept         =  "Accept" HCOLON
+                   [ accept-range *(COMMA accept-range) ]
+accept-range   =  media-range *(SEMI accept-param)
+media-range    =  ( "*/*"
+                  / ( m-type SLASH "*" )
+                  / ( m-type SLASH m-subtype )
+                  ) *( SEMI m-parameter )
+accept-param   =  ("q" EQUAL qvalue) / generic-param
+qvalue         =  ( "0" [ "." 0*3DIGIT ] )
+                  / ( "1" [ "." 0*3("0") ] )
+generic-param  =  token [ EQUAL gen-value ]
+gen-value      =  token / host / quoted-string
+
+Accept-Encoding  =  "Accept-Encoding" HCOLON
+                     [ encoding *(COMMA encoding) ]
+encoding         =  codings *(SEMI accept-param)
+codings          =  content-coding / "*"
+content-coding   =  token
+
+Accept-Language  =  "Accept-Language" HCOLON
+                     [ language *(COMMA language) ]
+language         =  language-range *(SEMI accept-param)
+language-range   =  ( ( 1*8ALPHA *( "-" 1*8ALPHA ) ) / "*" )
+
+Alert-Info   =  "Alert-Info" HCOLON alert-param *(COMMA alert-param)
+alert-param  =  LAQUOT absoluteURI RAQUOT *( SEMI generic-param )
+
+Allow  =  "Allow" HCOLON [Method *(COMMA Method)]
+
+Authorization     =  "Authorization" HCOLON credentials
+credentials       =  ("Digest" LWS digest-response)
+                     / other-response
+digest-response   =  dig-resp *(COMMA dig-resp)
+dig-resp          =  username / realm / nonce / digest-uri
+                      / dresponse / algorithm / cnonce
+                      / opaque / message-qop
+                      / nonce-count / auth-param
+username          =  "username" EQUAL username-value
+username-value    =  quoted-string
+digest-uri        =  "uri" EQUAL LDQUOT digest-uri-value RDQUOT
+digest-uri-value  =  rquest-uri ; Equal to request-uri as specified
+                     by HTTP/1.1
+message-qop       =  "qop" EQUAL qop-value
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 227]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+cnonce            =  "cnonce" EQUAL cnonce-value
+cnonce-value      =  nonce-value
+nonce-count       =  "nc" EQUAL nc-value
+nc-value          =  8LHEX
+dresponse         =  "response" EQUAL request-digest
+request-digest    =  LDQUOT 32LHEX RDQUOT
+auth-param        =  auth-param-name EQUAL
+                     ( token / quoted-string )
+auth-param-name   =  token
+other-response    =  auth-scheme LWS auth-param
+                     *(COMMA auth-param)
+auth-scheme       =  token
+
+Authentication-Info  =  "Authentication-Info" HCOLON ainfo
+                        *(COMMA ainfo)
+ainfo                =  nextnonce / message-qop
+                         / response-auth / cnonce
+                         / nonce-count
+nextnonce            =  "nextnonce" EQUAL nonce-value
+response-auth        =  "rspauth" EQUAL response-digest
+response-digest      =  LDQUOT *LHEX RDQUOT
+
+Call-ID  =  ( "Call-ID" / "i" ) HCOLON callid
+callid   =  word [ "@" word ]
+
+Call-Info   =  "Call-Info" HCOLON info *(COMMA info)
+info        =  LAQUOT absoluteURI RAQUOT *( SEMI info-param)
+info-param  =  ( "purpose" EQUAL ( "icon" / "info"
+               / "card" / token ) ) / generic-param
+
+Contact        =  ("Contact" / "m" ) HCOLON
+                  ( STAR / (contact-param *(COMMA contact-param)))
+contact-param  =  (name-addr / addr-spec) *(SEMI contact-params)
+name-addr      =  [ display-name ] LAQUOT addr-spec RAQUOT
+addr-spec      =  SIP-URI / SIPS-URI / absoluteURI
+display-name   =  *(token LWS)/ quoted-string
+
+contact-params     =  c-p-q / c-p-expires
+                      / contact-extension
+c-p-q              =  "q" EQUAL qvalue
+c-p-expires        =  "expires" EQUAL delta-seconds
+contact-extension  =  generic-param
+delta-seconds      =  1*DIGIT
+
+Content-Disposition   =  "Content-Disposition" HCOLON
+                         disp-type *( SEMI disp-param )
+disp-type             =  "render" / "session" / "icon" / "alert"
+                         / disp-extension-token
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 228]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+disp-param            =  handling-param / generic-param
+handling-param        =  "handling" EQUAL
+                         ( "optional" / "required"
+                         / other-handling )
+other-handling        =  token
+disp-extension-token  =  token
+
+Content-Encoding  =  ( "Content-Encoding" / "e" ) HCOLON
+                     content-coding *(COMMA content-coding)
+
+Content-Language  =  "Content-Language" HCOLON
+                     language-tag *(COMMA language-tag)
+language-tag      =  primary-tag *( "-" subtag )
+primary-tag       =  1*8ALPHA
+subtag            =  1*8ALPHA
+
+Content-Length  =  ( "Content-Length" / "l" ) HCOLON 1*DIGIT
+Content-Type     =  ( "Content-Type" / "c" ) HCOLON media-type
+media-type       =  m-type SLASH m-subtype *(SEMI m-parameter)
+m-type           =  discrete-type / composite-type
+discrete-type    =  "text" / "image" / "audio" / "video"
+                    / "application" / extension-token
+composite-type   =  "message" / "multipart" / extension-token
+extension-token  =  ietf-token / x-token
+ietf-token       =  token
+x-token          =  "x-" token
+m-subtype        =  extension-token / iana-token
+iana-token       =  token
+m-parameter      =  m-attribute EQUAL m-value
+m-attribute      =  token
+m-value          =  token / quoted-string
+
+CSeq  =  "CSeq" HCOLON 1*DIGIT LWS Method
+
+Date          =  "Date" HCOLON SIP-date
+SIP-date      =  rfc1123-date
+rfc1123-date  =  wkday "," SP date1 SP time SP "GMT"
+date1         =  2DIGIT SP month SP 4DIGIT
+                 ; day month year (e.g., 02 Jun 1982)
+time          =  2DIGIT ":" 2DIGIT ":" 2DIGIT
+                 ; 00:00:00 - 23:59:59
+wkday         =  "Mon" / "Tue" / "Wed"
+                 / "Thu" / "Fri" / "Sat" / "Sun"
+month         =  "Jan" / "Feb" / "Mar" / "Apr"
+                 / "May" / "Jun" / "Jul" / "Aug"
+                 / "Sep" / "Oct" / "Nov" / "Dec"
+
+Error-Info  =  "Error-Info" HCOLON error-uri *(COMMA error-uri)
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 229]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+error-uri   =  LAQUOT absoluteURI RAQUOT *( SEMI generic-param )
+
+Expires     =  "Expires" HCOLON delta-seconds
+From        =  ( "From" / "f" ) HCOLON from-spec
+from-spec   =  ( name-addr / addr-spec )
+               *( SEMI from-param )
+from-param  =  tag-param / generic-param
+tag-param   =  "tag" EQUAL token
+
+In-Reply-To  =  "In-Reply-To" HCOLON callid *(COMMA callid)
+
+Max-Forwards  =  "Max-Forwards" HCOLON 1*DIGIT
+
+MIME-Version  =  "MIME-Version" HCOLON 1*DIGIT "." 1*DIGIT
+
+Min-Expires  =  "Min-Expires" HCOLON delta-seconds
+
+Organization  =  "Organization" HCOLON [TEXT-UTF8-TRIM]
+
+Priority        =  "Priority" HCOLON priority-value
+priority-value  =  "emergency" / "urgent" / "normal"
+                   / "non-urgent" / other-priority
+other-priority  =  token
+
+Proxy-Authenticate  =  "Proxy-Authenticate" HCOLON challenge
+challenge           =  ("Digest" LWS digest-cln *(COMMA digest-cln))
+                       / other-challenge
+other-challenge     =  auth-scheme LWS auth-param
+                       *(COMMA auth-param)
+digest-cln          =  realm / domain / nonce
+                        / opaque / stale / algorithm
+                        / qop-options / auth-param
+realm               =  "realm" EQUAL realm-value
+realm-value         =  quoted-string
+domain              =  "domain" EQUAL LDQUOT URI
+                       *( 1*SP URI ) RDQUOT
+URI                 =  absoluteURI / abs-path
+nonce               =  "nonce" EQUAL nonce-value
+nonce-value         =  quoted-string
+opaque              =  "opaque" EQUAL quoted-string
+stale               =  "stale" EQUAL ( "true" / "false" )
+algorithm           =  "algorithm" EQUAL ( "MD5" / "MD5-sess"
+                       / token )
+qop-options         =  "qop" EQUAL LDQUOT qop-value
+                       *("," qop-value) RDQUOT
+qop-value           =  "auth" / "auth-int" / token
+
+Proxy-Authorization  =  "Proxy-Authorization" HCOLON credentials
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 230]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Proxy-Require  =  "Proxy-Require" HCOLON option-tag
+                  *(COMMA option-tag)
+option-tag     =  token
+
+Record-Route  =  "Record-Route" HCOLON rec-route *(COMMA rec-route)
+rec-route     =  name-addr *( SEMI rr-param )
+rr-param      =  generic-param
+
+Reply-To      =  "Reply-To" HCOLON rplyto-spec
+rplyto-spec   =  ( name-addr / addr-spec )
+                 *( SEMI rplyto-param )
+rplyto-param  =  generic-param
+Require       =  "Require" HCOLON option-tag *(COMMA option-tag)
+
+Retry-After  =  "Retry-After" HCOLON delta-seconds
+                [ comment ] *( SEMI retry-param )
+
+retry-param  =  ("duration" EQUAL delta-seconds)
+                / generic-param
+
+Route        =  "Route" HCOLON route-param *(COMMA route-param)
+route-param  =  name-addr *( SEMI rr-param )
+
+Server           =  "Server" HCOLON server-val *(LWS server-val)
+server-val       =  product / comment
+product          =  token [SLASH product-version]
+product-version  =  token
+
+Subject  =  ( "Subject" / "s" ) HCOLON [TEXT-UTF8-TRIM]
+
+Supported  =  ( "Supported" / "k" ) HCOLON
+              [option-tag *(COMMA option-tag)]
+
+Timestamp  =  "Timestamp" HCOLON 1*(DIGIT)
+               [ "." *(DIGIT) ] [ LWS delay ]
+delay      =  *(DIGIT) [ "." *(DIGIT) ]
+
+To        =  ( "To" / "t" ) HCOLON ( name-addr
+             / addr-spec ) *( SEMI to-param )
+to-param  =  tag-param / generic-param
+
+Unsupported  =  "Unsupported" HCOLON option-tag *(COMMA option-tag)
+User-Agent  =  "User-Agent" HCOLON server-val *(LWS server-val)
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 231]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Via               =  ( "Via" / "v" ) HCOLON via-parm *(COMMA via-parm)
+via-parm          =  sent-protocol LWS sent-by *( SEMI via-params )
+via-params        =  via-ttl / via-maddr
+                     / via-received / via-branch
+                     / via-extension
+via-ttl           =  "ttl" EQUAL ttl
+via-maddr         =  "maddr" EQUAL host
+via-received      =  "received" EQUAL (IPv4address / IPv6address)
+via-branch        =  "branch" EQUAL token
+via-extension     =  generic-param
+sent-protocol     =  protocol-name SLASH protocol-version
+                     SLASH transport
+protocol-name     =  "SIP" / token
+protocol-version  =  token
+transport         =  "UDP" / "TCP" / "TLS" / "SCTP"
+                     / other-transport
+sent-by           =  host [ COLON port ]
+ttl               =  1*3DIGIT ; 0 to 255
+
+Warning        =  "Warning" HCOLON warning-value *(COMMA warning-value)
+warning-value  =  warn-code SP warn-agent SP warn-text
+warn-code      =  3DIGIT
+warn-agent     =  hostport / pseudonym
+                  ;  the name or pseudonym of the server adding
+                  ;  the Warning header, for use in debugging
+warn-text      =  quoted-string
+pseudonym      =  token
+
+WWW-Authenticate  =  "WWW-Authenticate" HCOLON challenge
+
+extension-header  =  header-name HCOLON header-value
+header-name       =  token
+header-value      =  *(TEXT-UTF8char / UTF8-CONT / LWS)
+message-body  =  *OCTET
+
+26 Security Considerations: Threat Model and Security Usage
+   Recommendations
+
+   SIP is not an easy protocol to secure.  Its use of intermediaries,
+   its multi-faceted trust relationships, its expected usage between
+   elements with no trust at all, and its user-to-user operation make
+   security far from trivial.  Security solutions are needed that are
+   deployable today, without extensive coordination, in a wide variety
+   of environments and usages.  In order to meet these diverse needs,
+   several distinct mechanisms applicable to different aspects and
+   usages of SIP will be required.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 232]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Note that the security of SIP signaling itself has no bearing on the
+   security of protocols used in concert with SIP such as RTP, or with
+   the security implications of any specific bodies SIP might carry
+   (although MIME security plays a substantial role in securing SIP).
+   Any media associated with a session can be encrypted end-to-end
+   independently of any associated SIP signaling.  Media encryption is
+   outside the scope of this document.
+
+   The considerations that follow first examine a set of classic threat
+   models that broadly identify the security needs of SIP.  The set of
+   security services required to address these threats is then detailed,
+   followed by an explanation of several security mechanisms that can be
+   used to provide these services.  Next, the requirements for
+   implementers of SIP are enumerated, along with exemplary deployments
+   in which these security mechanisms could be used to improve the
+   security of SIP.  Some notes on privacy conclude this section.
+
+26.1 Attacks and Threat Models
+
+   This section details some threats that should be common to most
+   deployments of SIP.  These threats have been chosen specifically to
+   illustrate each of the security services that SIP requires.
+
+   The following examples by no means provide an exhaustive list of the
+   threats against SIP; rather, these are "classic" threats that
+   demonstrate the need for particular security services that can
+   potentially prevent whole categories of threats.
+
+   These attacks assume an environment in which attackers can
+   potentially read any packet on the network - it is anticipated that
+   SIP will frequently be used on the public Internet.  Attackers on the
+   network may be able to modify packets (perhaps at some compromised
+   intermediary).  Attackers may wish to steal services, eavesdrop on
+   communications, or disrupt sessions.
+
+26.1.1 Registration Hijacking
+
+   The SIP registration mechanism allows a user agent to identify itself
+   to a registrar as a device at which a user (designated by an address
+   of record) is located.  A registrar assesses the identity asserted in
+   the From header field of a REGISTER message to determine whether this
+   request can modify the contact addresses associated with the
+   address-of-record in the To header field.  While these two fields are
+   frequently the same, there are many valid deployments in which a
+   third-party may register contacts on a user's behalf.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 233]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The From header field of a SIP request, however, can be modified
+   arbitrarily by the owner of a UA, and this opens the door to
+   malicious registrations.  An attacker that successfully impersonates
+   a party authorized to change contacts associated with an address-of-
+   record could, for example, de-register all existing contacts for a
+   URI and then register their own device as the appropriate contact
+   address, thereby directing all requests for the affected user to the
+   attacker's device.
+
+   This threat belongs to a family of threats that rely on the absence
+   of cryptographic assurance of a request's originator.  Any SIP UAS
+   that represents a valuable service (a gateway that interworks SIP
+   requests with traditional telephone calls, for example) might want to
+   control access to its resources by authenticating requests that it
+   receives.  Even end-user UAs, for example SIP phones, have an
+   interest in ascertaining the identities of originators of requests.
+
+   This threat demonstrates the need for security services that enable
+   SIP entities to authenticate the originators of requests.
+
+26.1.2 Impersonating a Server
+
+   The domain to which a request is destined is generally specified in
+   the Request-URI.  UAs commonly contact a server in this domain
+   directly in order to deliver a request.  However, there is always a
+   possibility that an attacker could impersonate the remote server, and
+   that the UA's request could be intercepted by some other party.
+
+   For example, consider a case in which a redirect server at one
+   domain, chicago.com, impersonates a redirect server at another
+   domain, biloxi.com.  A user agent sends a request to biloxi.com, but
+   the redirect server at chicago.com answers with a forged response
+   that has appropriate SIP header fields for a response from
+   biloxi.com.  The forged contact addresses in the redirection response
+   could direct the originating UA to inappropriate or insecure
+   resources, or simply prevent requests for biloxi.com from succeeding.
+
+   This family of threats has a vast membership, many of which are
+   critical.  As a converse to the registration hijacking threat,
+   consider the case in which a registration sent to biloxi.com is
+   intercepted by chicago.com, which replies to the intercepted
+   registration with a forged 301 (Moved Permanently) response.  This
+   response might seem to come from biloxi.com yet designate chicago.com
+   as the appropriate registrar.  All future REGISTER requests from the
+   originating UA would then go to chicago.com.
+
+   Prevention of this threat requires a means by which UAs can
+   authenticate the servers to whom they send requests.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 234]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+26.1.3 Tampering with Message Bodies
+
+   As a matter of course, SIP UAs route requests through trusted proxy
+   servers.  Regardless of how that trust is established (authentication
+   of proxies is discussed elsewhere in this section), a UA may trust a
+   proxy server to route a request, but not to inspect or possibly
+   modify the bodies contained in that request.
+
+   Consider a UA that is using SIP message bodies to communicate session
+   encryption keys for a media session.  Although it trusts the proxy
+   server of the domain it is contacting to deliver signaling properly,
+   it may not want the administrators of that domain to be capable of
+   decrypting any subsequent media session.  Worse yet, if the proxy
+   server were actively malicious, it could modify the session key,
+   either acting as a man-in-the-middle, or perhaps changing the
+   security characteristics requested by the originating UA.
+
+   This family of threats applies not only to session keys, but to most
+   conceivable forms of content carried end-to-end in SIP.  These might
+   include MIME bodies that should be rendered to the user, SDP, or
+   encapsulated telephony signals, among others.  Attackers might
+   attempt to modify SDP bodies, for example, in order to point RTP
+   media streams to a wiretapping device in order to eavesdrop on
+   subsequent voice communications.
+
+   Also note that some header fields in SIP are meaningful end-to-end,
+   for example, Subject.  UAs might be protective of these header fields
+   as well as bodies (a malicious intermediary changing the Subject
+   header field might make an important request appear to be spam, for
+   example).  However, since many header fields are legitimately
+   inspected or altered by proxy servers as a request is routed, not all
+   header fields should be secured end-to-end.
+
+   For these reasons, the UA might want to secure SIP message bodies,
+   and in some limited cases header fields, end-to-end.  The security
+   services required for bodies include confidentiality, integrity, and
+   authentication.  These end-to-end services should be independent of
+   the means used to secure interactions with intermediaries such as
+   proxy servers.
+
+26.1.4 Tearing Down Sessions
+
+   Once a dialog has been established by initial messaging, subsequent
+   requests can be sent that modify the state of the dialog and/or
+   session.  It is critical that principals in a session can be certain
+   that such requests are not forged by attackers.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 235]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Consider a case in which a third-party attacker captures some initial
+   messages in a dialog shared by two parties in order to learn the
+   parameters of the session (To tag, From tag, and so forth) and then
+   inserts a BYE request into the session.  The attacker could opt to
+   forge the request such that it seemed to come from either
+   participant.  Once the BYE is received by its target, the session
+   will be torn down prematurely.
+
+   Similar mid-session threats include the transmission of forged re-
+   INVITEs that alter the session (possibly to reduce session security
+   or redirect media streams as part of a wiretapping attack).
+
+   The most effective countermeasure to this threat is the
+   authentication of the sender of the BYE.  In this instance, the
+   recipient needs only know that the BYE came from the same party with
+   whom the corresponding dialog was established (as opposed to
+   ascertaining the absolute identity of the sender).  Also, if the
+   attacker is unable to learn the parameters of the session due to
+   confidentiality, it would not be possible to forge the BYE.  However,
+   some intermediaries (like proxy servers) will need to inspect those
+   parameters as the session is established.
+
+26.1.5 Denial of Service and Amplification
+
+   Denial-of-service attacks focus on rendering a particular network
+   element unavailable, usually by directing an excessive amount of
+   network traffic at its interfaces.  A distributed denial-of-service
+   attack allows one network user to cause multiple network hosts to
+   flood a target host with a large amount of network traffic.
+
+   In many architectures, SIP proxy servers face the public Internet in
+   order to accept requests from worldwide IP endpoints.  SIP creates a
+   number of potential opportunities for distributed denial-of-service
+   attacks that must be recognized and addressed by the implementers and
+   operators of SIP systems.
+
+   Attackers can create bogus requests that contain a falsified source
+   IP address and a corresponding Via header field that identify a
+   targeted host as the originator of the request and then send this
+   request to a large number of SIP network elements, thereby using
+   hapless SIP UAs or proxies to generate denial-of-service traffic
+   aimed at the target.
+
+   Similarly, attackers might use falsified Route header field values in
+   a request that identify the target host and then send such messages
+   to forking proxies that will amplify messaging sent to the target.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 236]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Record-Route could be used to similar effect when the attacker is
+   certain that the SIP dialog initiated by the request will result in
+   numerous transactions originating in the backwards direction.
+
+   A number of denial-of-service attacks open up if REGISTER requests
+   are not properly authenticated and authorized by registrars.
+   Attackers could de-register some or all users in an administrative
+   domain, thereby preventing these users from being invited to new
+   sessions.  An attacker could also register a large number of contacts
+   designating the same host for a given address-of-record in order to
+   use the registrar and any associated proxy servers as amplifiers in a
+   denial-of-service attack.  Attackers might also attempt to deplete
+   available memory and disk resources of a registrar by registering
+   huge numbers of bindings.
+
+   The use of multicast to transmit SIP requests can greatly increase
+   the potential for denial-of-service attacks.
+
+   These problems demonstrate a general need to define architectures
+   that minimize the risks of denial-of-service, and the need to be
+   mindful in recommendations for security mechanisms of this class of
+   attacks.
+
+26.2 Security Mechanisms
+
+   From the threats described above, we gather that the fundamental
+   security services required for the SIP protocol are: preserving the
+   confidentiality and integrity of messaging, preventing replay attacks
+   or message spoofing, providing for the authentication and privacy of
+   the participants in a session, and preventing denial-of-service
+   attacks.  Bodies within SIP messages separately require the security
+   services of confidentiality, integrity, and authentication.
+
+   Rather than defining new security mechanisms specific to SIP, SIP
+   reuses wherever possible existing security models derived from the
+   HTTP and SMTP space.
+
+   Full encryption of messages provides the best means to preserve the
+   confidentiality of signaling - it can also guarantee that messages
+   are not modified by any malicious intermediaries.  However, SIP
+   requests and responses cannot be naively encrypted end-to-end in
+   their entirety because message fields such as the Request-URI, Route,
+   and Via need to be visible to proxies in most network architectures
+   so that SIP requests are routed correctly.  Note that proxy servers
+   need to modify some features of messages as well (such as adding Via
+   header field values) in order for SIP to function.  Proxy servers
+   must therefore be trusted, to some degree, by SIP UAs.  To this
+   purpose, low-layer security mechanisms for SIP are recommended, which
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 237]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   encrypt the entire SIP requests or responses on the wire on a hop-
+   by-hop basis, and that allow endpoints to verify the identity of
+   proxy servers to whom they send requests.
+
+   SIP entities also have a need to identify one another in a secure
+   fashion.  When a SIP endpoint asserts the identity of its user to a
+   peer UA or to a proxy server, that identity should in some way be
+   verifiable.  A cryptographic authentication mechanism is provided in
+   SIP to address this requirement.
+
+   An independent security mechanism for SIP message bodies supplies an
+   alternative means of end-to-end mutual authentication, as well as
+   providing a limit on the degree to which user agents must trust
+   intermediaries.
+
+26.2.1 Transport and Network Layer Security
+
+   Transport or network layer security encrypts signaling traffic,
+   guaranteeing message confidentiality and integrity.
+
+   Oftentimes, certificates are used in the establishment of lower-layer
+   security, and these certificates can also be used to provide a means
+   of authentication in many architectures.
+
+   Two popular alternatives for providing security at the transport and
+   network layer are, respectively, TLS [25] and IPSec [26].
+
+   IPSec is a set of network-layer protocol tools that collectively can
+   be used as a secure replacement for traditional IP (Internet
+   Protocol).  IPSec is most commonly used in architectures in which a
+   set of hosts or administrative domains have an existing trust
+   relationship with one another.  IPSec is usually implemented at the
+   operating system level in a host, or on a security gateway that
+   provides confidentiality and integrity for all traffic it receives
+   from a particular interface (as in a VPN architecture).  IPSec can
+   also be used on a hop-by-hop basis.
+
+   In many architectures IPSec does not require integration with SIP
+   applications; IPSec is perhaps best suited to deployments in which
+   adding security directly to SIP hosts would be arduous.  UAs that
+   have a pre-shared keying relationship with their first-hop proxy
+   server are also good candidates to use IPSec.  Any deployment of
+   IPSec for SIP would require an IPSec profile describing the protocol
+   tools that would be required to secure SIP.  No such profile is given
+   in this document.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 238]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   TLS provides transport-layer security over connection-oriented
+   protocols (for the purposes of this document, TCP); "tls" (signifying
+   TLS over TCP) can be specified as the desired transport protocol
+   within a Via header field value or a SIP-URI.  TLS is most suited to
+   architectures in which hop-by-hop security is required between hosts
+   with no pre-existing trust association.  For example, Alice trusts
+   her local proxy server, which after a certificate exchange decides to
+   trust Bob's local proxy server, which Bob trusts, hence Bob and Alice
+   can communicate securely.
+
+   TLS must be tightly coupled with a SIP application.  Note that
+   transport mechanisms are specified on a hop-by-hop basis in SIP, thus
+   a UA that sends requests over TLS to a proxy server has no assurance
+   that TLS will be used end-to-end.
+
+   The TLS_RSA_WITH_AES_128_CBC_SHA ciphersuite [6] MUST be supported at
+   a minimum by implementers when TLS is used in a SIP application.  For
+   purposes of backwards compatibility, proxy servers, redirect servers,
+   and registrars SHOULD support TLS_RSA_WITH_3DES_EDE_CBC_SHA.
+   Implementers MAY also support any other ciphersuite.
+
+26.2.2 SIPS URI Scheme
+
+   The SIPS URI scheme adheres to the syntax of the SIP URI (described
+   in 19), although the scheme string is "sips" rather than "sip".  The
+   semantics of SIPS are very different from the SIP URI, however.  SIPS
+   allows resources to specify that they should be reached securely.
+
+   A SIPS URI can be used as an address-of-record for a particular user
+   - the URI by which the user is canonically known (on their business
+   cards, in the From header field of their requests, in the To header
+   field of REGISTER requests).  When used as the Request-URI of a
+   request, the SIPS scheme signifies that each hop over which the
+   request is forwarded, until the request reaches the SIP entity
+   responsible for the domain portion of the Request-URI, must be
+   secured with TLS; once it reaches the domain in question it is
+   handled in accordance with local security and routing policy, quite
+   possibly using TLS for any last hop to a UAS.  When used by the
+   originator of a request (as would be the case if they employed a SIPS
+   URI as the address-of-record of the target), SIPS dictates that the
+   entire request path to the target domain be so secured.
+
+   The SIPS scheme is applicable to many of the other ways in which SIP
+   URIs are used in SIP today in addition to the Request-URI, including
+   in addresses-of-record, contact addresses (the contents of Contact
+   headers, including those of REGISTER methods), and Route headers.  In
+   each instance, the SIPS URI scheme allows these existing fields to
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 239]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   designate secure resources.  The manner in which a SIPS URI is
+   dereferenced in any of these contexts has its own security properties
+   which are detailed in [4].
+
+   The use of SIPS in particular entails that mutual TLS authentication
+   SHOULD be employed, as SHOULD the ciphersuite
+   TLS_RSA_WITH_AES_128_CBC_SHA.  Certificates received in the
+   authentication process SHOULD be validated with root certificates
+   held by the client; failure to validate a certificate SHOULD result
+   in the failure of the request.
+
+      Note that in the SIPS URI scheme, transport is independent of TLS,
+      and thus "sips:alice@atlanta.com;transport=tcp" and
+      "sips:alice@atlanta.com;transport=sctp" are both valid (although
+      note that UDP is not a valid transport for SIPS).  The use of
+      "transport=tls" has consequently been deprecated, partly because
+      it was specific to a single hop of the request.  This is a change
+      since RFC 2543.
+
+   Users that distribute a SIPS URI as an address-of-record may elect to
+   operate devices that refuse requests over insecure transports.
+
+26.2.3 HTTP Authentication
+
+   SIP provides a challenge capability, based on HTTP authentication,
+   that relies on the 401 and 407 response codes as well as header
+   fields for carrying challenges and credentials.  Without significant
+   modification, the reuse of the HTTP Digest authentication scheme in
+   SIP allows for replay protection and one-way authentication.
+
+   The usage of Digest authentication in SIP is detailed in Section 22.
+
+26.2.4 S/MIME
+
+   As is discussed above, encrypting entire SIP messages end-to-end for
+   the purpose of confidentiality is not appropriate because network
+   intermediaries (like proxy servers) need to view certain header
+   fields in order to route messages correctly, and if these
+   intermediaries are excluded from security associations, then SIP
+   messages will essentially be non-routable.
+
+   However, S/MIME allows SIP UAs to encrypt MIME bodies within SIP,
+   securing these bodies end-to-end without affecting message headers.
+   S/MIME can provide end-to-end confidentiality and integrity for
+   message bodies, as well as mutual authentication.  It is also
+   possible to use S/MIME to provide a form of integrity and
+   confidentiality for SIP header fields through SIP message tunneling.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 240]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The usage of S/MIME in SIP is detailed in Section 23.
+
+26.3 Implementing Security Mechanisms
+
+26.3.1 Requirements for Implementers of SIP
+
+   Proxy servers, redirect servers, and registrars MUST implement TLS,
+   and MUST support both mutual and one-way authentication.  It is
+   strongly RECOMMENDED that UAs be capable initiating TLS; UAs MAY also
+   be capable of acting as a TLS server.  Proxy servers, redirect
+   servers, and registrars SHOULD possess a site certificate whose
+   subject corresponds to their canonical hostname.  UAs MAY have
+   certificates of their own for mutual authentication with TLS, but no
+   provisions are set forth in this document for their use.  All SIP
+   elements that support TLS MUST have a mechanism for validating
+   certificates received during TLS negotiation; this entails possession
+   of one or more root certificates issued by certificate authorities
+   (preferably well-known distributors of site certificates comparable
+   to those that issue root certificates for web browsers).
+
+   All SIP elements that support TLS MUST also support the SIPS URI
+   scheme.
+
+   Proxy servers, redirect servers, registrars, and UAs MAY also
+   implement IPSec or other lower-layer security protocols.
+
+   When a UA attempts to contact a proxy server, redirect server, or
+   registrar, the UAC SHOULD initiate a TLS connection over which it
+   will send SIP messages.  In some architectures, UASs MAY receive
+   requests over such TLS connections as well.
+
+   Proxy servers, redirect servers, registrars, and UAs MUST implement
+   Digest Authorization, encompassing all of the aspects required in 22.
+   Proxy servers, redirect servers, and registrars SHOULD be configured
+   with at least one Digest realm, and at least one "realm" string
+   supported by a given server SHOULD correspond to the server's
+   hostname or domainname.
+
+   UAs MAY support the signing and encrypting of MIME bodies, and
+   transference of credentials with S/MIME as described in Section 23.
+   If a UA holds one or more root certificates of certificate
+   authorities in order to validate certificates for TLS or IPSec, it
+   SHOULD be capable of reusing these to verify S/MIME certificates, as
+   appropriate.  A UA MAY hold root certificates specifically for
+   validating S/MIME certificates.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 241]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Note that is it anticipated that future security extensions may
+      upgrade the normative strength associated with S/MIME as S/MIME
+      implementations appear and the problem space becomes better
+      understood.
+
+26.3.2 Security Solutions
+
+   The operation of these security mechanisms in concert can follow the
+   existing web and email security models to some degree.  At a high
+   level, UAs authenticate themselves to servers (proxy servers,
+   redirect servers, and registrars) with a Digest username and
+   password; servers authenticate themselves to UAs one hop away, or to
+   another server one hop away (and vice versa), with a site certificate
+   delivered by TLS.
+
+   On a peer-to-peer level, UAs trust the network to authenticate one
+   another ordinarily; however, S/MIME can also be used to provide
+   direct authentication when the network does not, or if the network
+   itself is not trusted.
+
+   The following is an illustrative example in which these security
+   mechanisms are used by various UAs and servers to prevent the sorts
+   of threats described in Section 26.1.  While implementers and network
+   administrators MAY follow the normative guidelines given in the
+   remainder of this section, these are provided only as example
+   implementations.
+
+26.3.2.1 Registration
+
+   When a UA comes online and registers with its local administrative
+   domain, it SHOULD establish a TLS connection with its registrar
+   (Section 10 describes how the UA reaches its registrar).  The
+   registrar SHOULD offer a certificate to the UA, and the site
+   identified by the certificate MUST correspond with the domain in
+   which the UA intends to register; for example, if the UA intends to
+   register the address-of-record 'alice@atlanta.com', the site
+   certificate must identify a host within the atlanta.com domain (such
+   as sip.atlanta.com).  When it receives the TLS Certificate message,
+   the UA SHOULD verify the certificate and inspect the site identified
+   by the certificate.  If the certificate is invalid, revoked, or if it
+   does not identify the appropriate party, the UA MUST NOT send the
+   REGISTER message and otherwise proceed with the registration.
+
+      When a valid certificate has been provided by the registrar, the
+      UA knows that the registrar is not an attacker who might redirect
+      the UA, steal passwords, or attempt any similar attacks.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 242]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The UA then creates a REGISTER request that SHOULD be addressed to a
+   Request-URI corresponding to the site certificate received from the
+   registrar.  When the UA sends the REGISTER request over the existing
+   TLS connection, the registrar SHOULD challenge the request with a 401
+   (Proxy Authentication Required) response.  The "realm" parameter
+   within the Proxy-Authenticate header field of the response SHOULD
+   correspond to the domain previously given by the site certificate.
+   When the UAC receives the challenge, it SHOULD either prompt the user
+   for credentials or take an appropriate credential from a keyring
+   corresponding to the "realm" parameter in the challenge.  The
+   username of this credential SHOULD correspond with the "userinfo"
+   portion of the URI in the To header field of the REGISTER request.
+   Once the Digest credentials have been inserted into an appropriate
+   Proxy-Authorization header field, the REGISTER should be resubmitted
+   to the registrar.
+
+      Since the registrar requires the user agent to authenticate
+      itself, it would be difficult for an attacker to forge REGISTER
+      requests for the user's address-of-record.  Also note that since
+      the REGISTER is sent over a confidential TLS connection, attackers
+      will not be able to intercept the REGISTER to record credentials
+      for any possible replay attack.
+
+   Once the registration has been accepted by the registrar, the UA
+   SHOULD leave this TLS connection open provided that the registrar
+   also acts as the proxy server to which requests are sent for users in
+   this administrative domain.  The existing TLS connection will be
+   reused to deliver incoming requests to the UA that has just completed
+   registration.
+
+      Because the UA has already authenticated the server on the other
+      side of the TLS connection, all requests that come over this
+      connection are known to have passed through the proxy server -
+      attackers cannot create spoofed requests that appear to have been
+      sent through that proxy server.
+
+26.3.2.2 Interdomain Requests
+
+   Now let's say that Alice's UA would like to initiate a session with a
+   user in a remote administrative domain, namely "bob@biloxi.com".  We
+   will also say that the local administrative domain (atlanta.com) has
+   a local outbound proxy.
+
+   The proxy server that handles inbound requests for an administrative
+   domain MAY also act as a local outbound proxy; for simplicity's sake
+   we'll assume this to be the case for atlanta.com (otherwise the user
+   agent would initiate a new TLS connection to a separate server at
+   this point).  Assuming that the client has completed the registration
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 243]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   process described in the preceding section, it SHOULD reuse the TLS
+   connection to the local proxy server when it sends an INVITE request
+   to another user.  The UA SHOULD reuse cached credentials in the
+   INVITE to avoid prompting the user unnecessarily.
+
+   When the local outbound proxy server has validated the credentials
+   presented by the UA in the INVITE, it SHOULD inspect the Request-URI
+   to determine how the message should be routed (see [4]).  If the
+   "domainname" portion of the Request-URI had corresponded to the local
+   domain (atlanta.com) rather than biloxi.com, then the proxy server
+   would have consulted its location service to determine how best to
+   reach the requested user.
+
+      Had "alice@atlanta.com" been attempting to contact, say,
+      "alex@atlanta.com", the local proxy would have proxied to the
+      request to the TLS connection Alex had established with the
+      registrar when he registered.  Since Alex would receive this
+      request over his authenticated channel, he would be assured that
+      Alice's request had been authorized by the proxy server of the
+      local administrative domain.
+
+   However, in this instance the Request-URI designates a remote domain.
+   The local outbound proxy server at atlanta.com SHOULD therefore
+   establish a TLS connection with the remote proxy server at
+   biloxi.com.  Since both of the participants in this TLS connection
+   are servers that possess site certificates, mutual TLS authentication
+   SHOULD occur.  Each side of the connection SHOULD verify and inspect
+   the certificate of the other, noting the domain name that appears in
+   the certificate for comparison with the header fields of SIP
+   messages.  The atlanta.com proxy server, for example, SHOULD verify
+   at this stage that the certificate received from the remote side
+   corresponds with the biloxi.com domain.  Once it has done so, and TLS
+   negotiation has completed, resulting in a secure channel between the
+   two proxies, the atlanta.com proxy can forward the INVITE request to
+   biloxi.com.
+
+   The proxy server at biloxi.com SHOULD inspect the certificate of the
+   proxy server at atlanta.com in turn and compare the domain asserted
+   by the certificate with the "domainname" portion of the From header
+   field in the INVITE request.  The biloxi proxy MAY have a strict
+   security policy that requires it to reject requests that do not match
+   the administrative domain from which they have been proxied.
+
+      Such security policies could be instituted to prevent the SIP
+      equivalent of SMTP 'open relays' that are frequently exploited to
+      generate spam.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 244]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   This policy, however, only guarantees that the request came from the
+   domain it ascribes to itself; it does not allow biloxi.com to
+   ascertain how atlanta.com authenticated Alice.  Only if biloxi.com
+   has some other way of knowing atlanta.com's authentication policies
+   could it possibly ascertain how Alice proved her identity.
+   biloxi.com might then institute an even stricter policy that forbids
+   requests that come from domains that are not known administratively
+   to share a common authentication policy with biloxi.com.
+
+   Once the INVITE has been approved by the biloxi proxy, the proxy
+   server SHOULD identify the existing TLS channel, if any, associated
+   with the user targeted by this request (in this case
+   "bob@biloxi.com").  The INVITE should be proxied through this channel
+   to Bob.  Since the request is received over a TLS connection that had
+   previously been authenticated as the biloxi proxy, Bob knows that the
+   From header field was not tampered with and that atlanta.com has
+   validated Alice, although not necessarily whether or not to trust
+   Alice's identity.
+
+   Before they forward the request, both proxy servers SHOULD add a
+   Record-Route header field to the request so that all future requests
+   in this dialog will pass through the proxy servers.  The proxy
+   servers can thereby continue to provide security services for the
+   lifetime of this dialog.  If the proxy servers do not add themselves
+   to the Record-Route, future messages will pass directly end-to-end
+   between Alice and Bob without any security services (unless the two
+   parties agree on some independent end-to-end security such as
+   S/MIME).  In this respect the SIP trapezoid model can provide a nice
+   structure where conventions of agreement between the site proxies can
+   provide a reasonably secure channel between Alice and Bob.
+
+      An attacker preying on this architecture would, for example, be
+      unable to forge a BYE request and insert it into the signaling
+      stream between Bob and Alice because the attacker has no way of
+      ascertaining the parameters of the session and also because the
+      integrity mechanism transitively protects the traffic between
+      Alice and Bob.
+
+26.3.2.3 Peer-to-Peer Requests
+
+   Alternatively, consider a UA asserting the identity
+   "carol@chicago.com" that has no local outbound proxy.  When Carol
+   wishes to send an INVITE to "bob@biloxi.com", her UA SHOULD initiate
+   a TLS connection with the biloxi proxy directly (using the mechanism
+   described in [4] to determine how to best to reach the given
+   Request-URI).  When her UA receives a certificate from the biloxi
+   proxy, it SHOULD be verified normally before she passes her INVITE
+   across the TLS connection.  However, Carol has no means of proving
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 245]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   her identity to the biloxi proxy, but she does have a CMS-detached
+   signature over a "message/sip" body in the INVITE.  It is unlikely in
+   this instance that Carol would have any credentials in the biloxi.com
+   realm, since she has no formal association with biloxi.com.  The
+   biloxi proxy MAY also have a strict policy that precludes it from
+   even bothering to challenge requests that do not have biloxi.com in
+   the "domainname" portion of the From header field - it treats these
+   users as unauthenticated.
+
+   The biloxi proxy has a policy for Bob that all non-authenticated
+   requests should be redirected to the appropriate contact address
+   registered against 'bob@biloxi.com', namely <sip:bob@192.0.2.4>.
+   Carol receives the redirection response over the TLS connection she
+   established with the biloxi proxy, so she trusts the veracity of the
+   contact address.
+
+   Carol SHOULD then establish a TCP connection with the designated
+   address and send a new INVITE with a Request-URI containing the
+   received contact address (recomputing the signature in the body as
+   the request is readied).  Bob receives this INVITE on an insecure
+   interface, but his UA inspects and, in this instance, recognizes the
+   From header field of the request and subsequently matches a locally
+   cached certificate with the one presented in the signature of the
+   body of the INVITE.  He replies in similar fashion, authenticating
+   himself to Carol, and a secure dialog begins.
+
+      Sometimes firewalls or NATs in an administrative domain could
+      preclude the establishment of a direct TCP connection to a UA.  In
+      these cases, proxy servers could also potentially relay requests
+      to UAs in a way that has no trust implications (for example,
+      forgoing an existing TLS connection and forwarding the request
+      over cleartext TCP) as local policy dictates.
+
+26.3.2.4 DoS Protection
+
+   In order to minimize the risk of a denial-of-service attack against
+   architectures using these security solutions, implementers should
+   take note of the following guidelines.
+
+   When the host on which a SIP proxy server is operating is routable
+   from the public Internet, it SHOULD be deployed in an administrative
+   domain with defensive operational policies (blocking source-routed
+   traffic, preferably filtering ping traffic).  Both TLS and IPSec can
+   also make use of bastion hosts at the edges of administrative domains
+   that participate in the security associations to aggregate secure
+   tunnels and sockets.  These bastion hosts can also take the brunt of
+   denial-of-service attacks, ensuring that SIP hosts within the
+   administrative domain are not encumbered with superfluous messaging.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 246]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   No matter what security solutions are deployed, floods of messages
+   directed at proxy servers can lock up proxy server resources and
+   prevent desirable traffic from reaching its destination.  There is a
+   computational expense associated with processing a SIP transaction at
+   a proxy server, and that expense is greater for stateful proxy
+   servers than it is for stateless proxy servers.  Therefore, stateful
+   proxies are more susceptible to flooding than stateless proxy
+   servers.
+
+   UAs and proxy servers SHOULD challenge questionable requests with
+   only a single 401 (Unauthorized) or 407 (Proxy Authentication
+   Required), forgoing the normal response retransmission algorithm, and
+   thus behaving statelessly towards unauthenticated requests.
+
+      Retransmitting the 401 (Unauthorized) or 407 (Proxy Authentication
+      Required) status response amplifies the problem of an attacker
+      using a falsified header field value (such as Via) to direct
+      traffic to a third party.
+
+   In summary, the mutual authentication of proxy servers through
+   mechanisms such as TLS significantly reduces the potential for rogue
+   intermediaries to introduce falsified requests or responses that can
+   deny service.  This commensurately makes it harder for attackers to
+   make innocent SIP nodes into agents of amplification.
+
+26.4 Limitations
+
+   Although these security mechanisms, when applied in a judicious
+   manner, can thwart many threats, there are limitations in the scope
+   of the mechanisms that must be understood by implementers and network
+   operators.
+
+26.4.1 HTTP Digest
+
+   One of the primary limitations of using HTTP Digest in SIP is that
+   the integrity mechanisms in Digest do not work very well for SIP.
+   Specifically, they offer protection of the Request-URI and the method
+   of a message, but not for any of the header fields that UAs would
+   most likely wish to secure.
+
+   The existing replay protection mechanisms described in RFC 2617 also
+   have some limitations for SIP.  The next-nonce mechanism, for
+   example, does not support pipelined requests.  The nonce-count
+   mechanism should be used for replay protection.
+
+   Another limitation of HTTP Digest is the scope of realms.  Digest is
+   valuable when a user wants to authenticate themselves to a resource
+   with which they have a pre-existing association, like a service
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 247]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   provider of which the user is a customer (which is quite a common
+   scenario and thus Digest provides an extremely useful function).  By
+   way of contrast, the scope of TLS is interdomain or multirealm, since
+   certificates are often globally verifiable, so that the UA can
+   authenticate the server with no pre-existing association.
+
+26.4.2 S/MIME
+
+   The largest outstanding defect with the S/MIME mechanism is the lack
+   of a prevalent public key infrastructure for end users.  If self-
+   signed certificates (or certificates that cannot be verified by one
+   of the participants in a dialog) are used, the SIP-based key exchange
+   mechanism described in Section 23.2 is susceptible to a man-in-the-
+   middle attack with which an attacker can potentially inspect and
+   modify S/MIME bodies.  The attacker needs to intercept the first
+   exchange of keys between the two parties in a dialog, remove the
+   existing CMS-detached signatures from the request and response, and
+   insert a different CMS-detached signature containing a certificate
+   supplied by the attacker (but which seems to be a certificate for the
+   proper address-of-record).  Each party will think they have exchanged
+   keys with the other, when in fact each has the public key of the
+   attacker.
+
+   It is important to note that the attacker can only leverage this
+   vulnerability on the first exchange of keys between two parties - on
+   subsequent occasions, the alteration of the key would be noticeable
+   to the UAs.  It would also be difficult for the attacker to remain in
+   the path of all future dialogs between the two parties over time (as
+   potentially days, weeks, or years pass).
+
+   SSH is susceptible to the same man-in-the-middle attack on the first
+   exchange of keys; however, it is widely acknowledged that while SSH
+   is not perfect, it does improve the security of connections.  The use
+   of key fingerprints could provide some assistance to SIP, just as it
+   does for SSH.  For example, if two parties use SIP to establish a
+   voice communications session, each could read off the fingerprint of
+   the key they received from the other, which could be compared against
+   the original.  It would certainly be more difficult for the man-in-
+   the-middle to emulate the voices of the participants than their
+   signaling (a practice that was used with the Clipper chip-based
+   secure telephone).
+
+   The S/MIME mechanism allows UAs to send encrypted requests without
+   preamble if they possess a certificate for the destination address-
+   of-record on their keyring.  However, it is possible that any
+   particular device registered for an address-of-record will not hold
+   the certificate that has been previously employed by the device's
+   current user, and that it will therefore be unable to process an
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 248]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   encrypted request properly, which could lead to some avoidable error
+   signaling.  This is especially likely when an encrypted request is
+   forked.
+
+   The keys associated with S/MIME are most useful when associated with
+   a particular user (an address-of-record) rather than a device (a UA).
+   When users move between devices, it may be difficult to transport
+   private keys securely between UAs; how such keys might be acquired by
+   a device is outside the scope of this document.
+
+   Another, more prosaic difficulty with the S/MIME mechanism is that it
+   can result in very large messages, especially when the SIP tunneling
+   mechanism described in Section 23.4 is used.  For that reason, it is
+   RECOMMENDED that TCP should be used as a transport protocol when
+   S/MIME tunneling is employed.
+
+26.4.3 TLS
+
+   The most commonly voiced concern about TLS is that it cannot run over
+   UDP; TLS requires a connection-oriented underlying transport
+   protocol, which for the purposes of this document means TCP.
+
+   It may also be arduous for a local outbound proxy server and/or
+   registrar to maintain many simultaneous long-lived TLS connections
+   with numerous UAs.  This introduces some valid scalability concerns,
+   especially for intensive ciphersuites.  Maintaining redundancy of
+   long-lived TLS connections, especially when a UA is solely
+   responsible for their establishment, could also be cumbersome.
+
+   TLS only allows SIP entities to authenticate servers to which they
+   are adjacent; TLS offers strictly hop-by-hop security.  Neither TLS,
+   nor any other mechanism specified in this document, allows clients to
+   authenticate proxy servers to whom they cannot form a direct TCP
+   connection.
+
+26.4.4 SIPS URIs
+
+   Actually using TLS on every segment of a request path entails that
+   the terminating UAS must be reachable over TLS (perhaps registering
+   with a SIPS URI as a contact address).  This is the preferred use of
+   SIPS.  Many valid architectures, however, use TLS to secure part of
+   the request path, but rely on some other mechanism for the final hop
+   to a UAS, for example.  Thus SIPS cannot guarantee that TLS usage
+   will be truly end-to-end.  Note that since many UAs will not accept
+   incoming TLS connections, even those UAs that do support TLS may be
+   required to maintain persistent TLS connections as described in the
+   TLS limitations section above in order to receive requests over TLS
+   as a UAS.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 249]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Location services are not required to provide a SIPS binding for a
+   SIPS Request-URI.  Although location services are commonly populated
+   by user registrations (as described in Section 10.2.1), various other
+   protocols and interfaces could conceivably supply contact addresses
+   for an AOR, and these tools are free to map SIPS URIs to SIP URIs as
+   appropriate.  When queried for bindings, a location service returns
+   its contact addresses without regard for whether it received a
+   request with a SIPS Request-URI.  If a redirect server is accessing
+   the location service, it is up to the entity that processes the
+   Contact header field of a redirection to determine the propriety of
+   the contact addresses.
+
+   Ensuring that TLS will be used for all of the request segments up to
+   the target domain is somewhat complex.  It is possible that
+   cryptographically authenticated proxy servers along the way that are
+   non-compliant or compromised may choose to disregard the forwarding
+   rules associated with SIPS (and the general forwarding rules in
+   Section 16.6).  Such malicious intermediaries could, for example,
+   retarget a request from a SIPS URI to a SIP URI in an attempt to
+   downgrade security.
+
+   Alternatively, an intermediary might legitimately retarget a request
+   from a SIP to a SIPS URI.  Recipients of a request whose Request-URI
+   uses the SIPS URI scheme thus cannot assume on the basis of the
+   Request-URI alone that SIPS was used for the entire request path
+   (from the client onwards).
+
+   To address these concerns, it is RECOMMENDED that recipients of a
+   request whose Request-URI contains a SIP or SIPS URI inspect the To
+   header field value to see if it contains a SIPS URI (though note that
+   it does not constitute a breach of security if this URI has the same
+   scheme but is not equivalent to the URI in the To header field).
+   Although clients may choose to populate the Request-URI and To header
+   field of a request differently, when SIPS is used this disparity
+   could be interpreted as a possible security violation, and the
+   request could consequently be rejected by its recipient.  Recipients
+   MAY also inspect the Via header chain in order to double-check
+   whether or not TLS was used for the entire request path until the
+   local administrative domain was reached.  S/MIME may also be used by
+   the originating UAC to help ensure that the original form of the To
+   header field is carried end-to-end.
+
+   If the UAS has reason to believe that the scheme of the Request-URI
+   has been improperly modified in transit, the UA SHOULD notify its
+   user of a potential security breach.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 250]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   As a further measure to prevent downgrade attacks, entities that
+   accept only SIPS requests MAY also refuse connections on insecure
+   ports.
+
+   End users will undoubtedly discern the difference between SIPS and
+   SIP URIs, and they may manually edit them in response to stimuli.
+   This can either benefit or degrade security.  For example, if an
+   attacker corrupts a DNS cache, inserting a fake record set that
+   effectively removes all SIPS records for a proxy server, then any
+   SIPS requests that traverse this proxy server may fail.  When a user,
+   however, sees that repeated calls to a SIPS AOR are failing, they
+   could on some devices manually convert the scheme from SIPS to SIP
+   and retry.  Of course, there are some safeguards against this (if the
+   destination UA is truly paranoid it could refuse all non-SIPS
+   requests), but it is a limitation worth noting.  On the bright side,
+   users might also divine that 'SIPS' would be valid even when they are
+   presented only with a SIP URI.
+
+26.5 Privacy
+
+   SIP messages frequently contain sensitive information about their
+   senders - not just what they have to say, but with whom they
+   communicate, when they communicate and for how long, and from where
+   they participate in sessions.  Many applications and their users
+   require that this sort of private information be hidden from any
+   parties that do not need to know it.
+
+   Note that there are also less direct ways in which private
+   information can be divulged.  If a user or service chooses to be
+   reachable at an address that is guessable from the person's name and
+   organizational affiliation (which describes most addresses-of-
+   record), the traditional method of ensuring privacy by having an
+   unlisted "phone number" is compromised.  A user location service can
+   infringe on the privacy of the recipient of a session invitation by
+   divulging their specific whereabouts to the caller; an implementation
+   consequently SHOULD be able to restrict, on a per-user basis, what
+   kind of location and availability information is given out to certain
+   classes of callers.  This is a whole class of problem that is
+   expected to be studied further in ongoing SIP work.
+
+   In some cases, users may want to conceal personal information in
+   header fields that convey identity.  This can apply not only to the
+   From and related headers representing the originator of the request,
+   but also the To - it may not be appropriate to convey to the final
+   destination a speed-dialing nickname, or an unexpanded identifier for
+   a group of targets, either of which would be removed from the
+   Request-URI as the request is routed, but not changed in the To
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 251]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   header field if the two were initially identical.  Thus it MAY be
+   desirable for privacy reasons to create a To header field that
+   differs from the Request-URI.
+
+27 IANA Considerations
+
+   All method names, header field names, status codes, and option tags
+   used in SIP applications are registered with IANA through
+   instructions in an IANA Considerations section in an RFC.
+
+   The specification instructs the IANA to create four new sub-
+   registries under http://www.iana.org/assignments/sip-parameters:
+   Option Tags, Warning Codes (warn-codes), Methods and Response Codes,
+   added to the sub-registry of Header Fields that is already present
+   there.
+
+27.1 Option Tags
+
+   This specification establishes the Option Tags sub-registry under
+   http://www.iana.org/assignments/sip-parameters.
+
+   Option tags are used in header fields such as Require, Supported,
+   Proxy-Require, and Unsupported in support of SIP compatibility
+   mechanisms for extensions (Section 19.2).  The option tag itself is a
+   string that is associated with a particular SIP option (that is, an
+   extension).  It identifies the option to SIP endpoints.
+
+   Option tags are registered by the IANA when they are published in
+   standards track RFCs.  The IANA Considerations section of the RFC
+   must include the following information, which appears in the IANA
+   registry along with the RFC number of the publication.
+
+      o  Name of the option tag.  The name MAY be of any length, but
+         SHOULD be no more than twenty characters long.  The name MUST
+         consist of alphanum (Section 25) characters only.
+
+      o  Descriptive text that describes the extension.
+
+27.2 Warn-Codes
+
+   This specification establishes the Warn-codes sub-registry under
+   http://www.iana.org/assignments/sip-parameters and initiates its
+   population with the warn-codes listed in Section 20.43.  Additional
+   warn-codes are registered by RFC publication.
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 252]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   The descriptive text for the table of warn-codes is:
+
+   Warning codes provide information supplemental to the status code in
+   SIP response messages when the failure of the transaction results
+   from a Session Description Protocol (SDP) (RFC 2327 [1]) problem.
+
+   The "warn-code" consists of three digits.  A first digit of "3"
+   indicates warnings specific to SIP.  Until a future specification
+   describes uses of warn-codes other than 3xx, only 3xx warn-codes may
+   be registered.
+
+   Warnings 300 through 329 are reserved for indicating problems with
+   keywords in the session description, 330 through 339 are warnings
+   related to basic network services requested in the session
+   description, 370 through 379 are warnings related to quantitative QoS
+   parameters requested in the session description, and 390 through 399
+   are miscellaneous warnings that do not fall into one of the above
+   categories.
+
+27.3 Header Field Names
+
+   This obsoletes the IANA instructions about the header sub-registry
+   under http://www.iana.org/assignments/sip-parameters.
+
+   The following information needs to be provided in an RFC publication
+   in order to register a new header field name:
+
+      o  The RFC number in which the header is registered;
+
+      o  the name of the header field being registered;
+
+      o  a compact form version for that header field, if one is
+         defined;
+
+   Some common and widely used header fields MAY be assigned one-letter
+   compact forms (Section 7.3.3).  Compact forms can only be assigned
+   after SIP working group review, followed by RFC publication.
+
+27.4 Method and Response Codes
+
+   This specification establishes the Method and Response-Code sub-
+   registries under http://www.iana.org/assignments/sip-parameters and
+   initiates their population as follows.  The initial Methods table is:
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 253]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+         INVITE                   [RFC3261]
+         ACK                      [RFC3261]
+         BYE                      [RFC3261]
+         CANCEL                   [RFC3261]
+         REGISTER                 [RFC3261]
+         OPTIONS                  [RFC3261]
+         INFO                     [RFC2976]
+
+   The response code table is initially populated from Section 21, the
+   portions labeled Informational, Success, Redirection, Client-Error,
+   Server-Error, and Global-Failure.  The table has the following
+   format:
+
+      Type (e.g., Informational)
+            Number    Default Reason Phrase         [RFC3261]
+
+   The following information needs to be provided in an RFC publication
+   in order to register a new response code or method:
+
+      o  The RFC number in which the method or response code is
+         registered;
+
+      o  the number of the response code or name of the method being
+         registered;
+
+      o  the default reason phrase for that response code, if
+         applicable;
+
+27.5 The "message/sip" MIME type.
+
+   This document registers the "message/sip" MIME media type in order to
+   allow SIP messages to be tunneled as bodies within SIP, primarily for
+   end-to-end security purposes.  This media type is defined by the
+   following information:
+
+      Media type name: message
+      Media subtype name: sip
+      Required parameters: none
+
+      Optional parameters: version
+         version: The SIP-Version number of the enclosed message (e.g.,
+         "2.0").  If not present, the version defaults to "2.0".
+      Encoding scheme: SIP messages consist of an 8-bit header
+         optionally followed by a binary MIME data object.  As such, SIP
+         messages must be treated as binary.  Under normal circumstances
+         SIP messages are transported over binary-capable transports, no
+         special encodings are needed.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 254]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+      Security considerations: see below
+         Motivation and examples of this usage as a security mechanism
+         in concert with S/MIME are given in 23.4.
+
+27.6 New Content-Disposition Parameter Registrations
+
+   This document also registers four new Content-Disposition header
+   "disposition-types": alert, icon, session and render.  The authors
+   request that these values be recorded in the IANA registry for
+   Content-Dispositions.
+
+   Descriptions of these "disposition-types", including motivation and
+   examples, are given in Section 20.11.
+
+   Short descriptions suitable for the IANA registry are:
+
+      alert     the body is a custom ring tone to alert the user
+      icon      the body is displayed as an icon to the user
+      render    the body should be displayed to the user
+      session   the body describes a communications session, for
+                example, as RFC 2327 SDP body
+
+28 Changes From RFC 2543
+
+   This RFC revises RFC 2543.  It is mostly backwards compatible with
+   RFC 2543.  The changes described here fix many errors discovered in
+   RFC 2543 and provide information on scenarios not detailed in RFC
+   2543.  The protocol has been presented in a more cleanly layered
+   model here.
+
+   We break the differences into functional behavior that is a
+   substantial change from RFC 2543, which has impact on
+   interoperability or correct operation in some cases, and functional
+   behavior that is different from RFC 2543 but not a potential source
+   of interoperability problems.  There have been countless
+   clarifications as well, which are not documented here.
+
+28.1 Major Functional Changes
+
+   o  When a UAC wishes to terminate a call before it has been answered,
+      it sends CANCEL.  If the original INVITE still returns a 2xx, the
+      UAC then sends BYE.  BYE can only be sent on an existing call leg
+      (now called a dialog in this RFC), whereas it could be sent at any
+      time in RFC 2543.
+
+   o  The SIP BNF was converted to be RFC 2234 compliant.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 255]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   o  SIP URL BNF was made more general, allowing a greater set of
+      characters in the user part.  Furthermore, comparison rules were
+      simplified to be primarily case-insensitive, and detailed handling
+      of comparison in the presence of parameters was described.  The
+      most substantial change is that a URI with a parameter with the
+      default value does not match a URI without that parameter.
+
+   o  Removed Via hiding.  It had serious trust issues, since it relied
+      on the next hop to perform the obfuscation process.  Instead, Via
+      hiding can be done as a local implementation choice in stateful
+      proxies, and thus is no longer documented.
+
+   o  In RFC 2543, CANCEL and INVITE transactions were intermingled.
+      They are separated now.  When a user sends an INVITE and then a
+      CANCEL, the INVITE transaction still terminates normally.  A UAS
+      needs to respond to the original INVITE request with a 487
+      response.
+
+   o  Similarly, CANCEL and BYE transactions were intermingled; RFC 2543
+      allowed the UAS not to send a response to INVITE when a BYE was
+      received.  That is disallowed here.  The original INVITE needs a
+      response.
+
+   o  In RFC 2543, UAs needed to support only UDP.  In this RFC, UAs
+      need to support both UDP and TCP.
+
+   o  In RFC 2543, a forking proxy only passed up one challenge from
+      downstream elements in the event of multiple challenges.  In this
+      RFC, proxies are supposed to collect all challenges and place them
+      into the forwarded response.
+
+   o  In Digest credentials, the URI needs to be quoted; this is unclear
+      from RFC 2617 and RFC 2069 which are both inconsistent on it.
+
+   o  SDP processing has been split off into a separate specification
+      [13], and more fully specified as a formal offer/answer exchange
+      process that is effectively tunneled through SIP.  SDP is allowed
+      in INVITE/200 or 200/ACK for baseline SIP implementations; RFC
+      2543 alluded to the ability to use it in INVITE, 200, and ACK in a
+      single transaction, but this was not well specified.  More complex
+      SDP usages are allowed in extensions.
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 256]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   o  Added full support for IPv6 in URIs and in the Via header field.
+      Support for IPv6 in Via has required that its header field
+      parameters allow the square bracket and colon characters.  These
+      characters were previously not permitted.  In theory, this could
+      cause interop problems with older implementations.  However, we
+      have observed that most implementations accept any non-control
+      ASCII character in these parameters.
+
+   o  DNS SRV procedure is now documented in a separate specification
+      [4].  This procedure uses both SRV and NAPTR resource records and
+      no longer combines data from across SRV records as described in
+      RFC 2543.
+
+   o  Loop detection has been made optional, supplanted by a mandatory
+      usage of Max-Forwards.  The loop detection procedure in RFC 2543
+      had a serious bug which would report "spirals" as an error
+      condition when it was not.  The optional loop detection procedure
+      is more fully and correctly specified here.
+
+   o  Usage of tags is now mandatory (they were optional in RFC 2543),
+      as they are now the fundamental building blocks of dialog
+      identification.
+
+   o  Added the Supported header field, allowing for clients to indicate
+      what extensions are supported to a server, which can apply those
+      extensions to the response, and indicate their usage with a
+      Require in the response.
+
+   o  Extension parameters were missing from the BNF for several header
+      fields, and they have been added.
+
+   o  Handling of Route and Record-Route construction was very
+      underspecified in RFC 2543, and also not the right approach.  It
+      has been substantially reworked in this specification (and made
+      vastly simpler), and this is arguably the largest change.
+      Backwards compatibility is still provided for deployments that do
+      not use "pre-loaded routes", where the initial request has a set
+      of Route header field values obtained in some way outside of
+      Record-Route.  In those situations, the new mechanism is not
+      interoperable.
+
+   o  In RFC 2543, lines in a message could be terminated with CR, LF,
+      or CRLF.  This specification only allows CRLF.
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 257]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   o  Usage of Route in CANCEL and ACK was not well defined in RFC 2543.
+      It is now well specified; if a request had a Route header field,
+      its CANCEL or ACK for a non-2xx response to the request need to
+      carry the same Route header field values.  ACKs for 2xx responses
+      use the Route values learned from the Record-Route of the 2xx
+      responses.
+
+   o  RFC 2543 allowed multiple requests in a single UDP packet.  This
+      usage has been removed.
+
+   o  Usage of absolute time in the Expires header field and parameter
+      has been removed.  It caused interoperability problems in elements
+      that were not time synchronized, a common occurrence.  Relative
+      times are used instead.
+
+   o  The branch parameter of the Via header field value is now
+      mandatory for all elements to use.  It now plays the role of a
+      unique transaction identifier.  This avoids the complex and bug-
+      laden transaction identification rules from RFC 2543.  A magic
+      cookie is used in the parameter value to determine if the previous
+      hop has made the parameter globally unique, and comparison falls
+      back to the old rules when it is not present.  Thus,
+      interoperability is assured.
+
+   o  In RFC 2543, closure of a TCP connection was made equivalent to a
+      CANCEL.  This was nearly impossible to implement (and wrong) for
+      TCP connections between proxies.  This has been eliminated, so
+      that there is no coupling between TCP connection state and SIP
+      processing.
+
+   o  RFC 2543 was silent on whether a UA could initiate a new
+      transaction to a peer while another was in progress.  That is now
+      specified here.  It is allowed for non-INVITE requests, disallowed
+      for INVITE.
+
+   o  PGP was removed.  It was not sufficiently specified, and not
+      compatible with the more complete PGP MIME.  It was replaced with
+      S/MIME.
+
+   o  Added the "sips" URI scheme for end-to-end TLS.  This scheme is
+      not backwards compatible with RFC 2543.  Existing elements that
+      receive a request with a SIPS URI scheme in the Request-URI will
+      likely reject the request.  This is actually a feature; it ensures
+      that a call to a SIPS URI is only delivered if all path hops can
+      be secured.
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 258]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   o  Additional security features were added with TLS, and these are
+      described in a much larger and complete security considerations
+      section.
+
+   o  In RFC 2543, a proxy was not required to forward provisional
+      responses from 101 to 199 upstream.  This was changed to MUST.
+      This is important, since many subsequent features depend on
+      delivery of all provisional responses from 101 to 199.
+
+   o  Little was said about the 503 response code in RFC 2543.  It has
+      since found substantial use in indicating failure or overload
+      conditions in proxies.  This requires somewhat special treatment.
+      Specifically, receipt of a 503 should trigger an attempt to
+      contact the next element in the result of a DNS SRV lookup.  Also,
+      503 response is only forwarded upstream by a proxy under certain
+      conditions.
+
+   o  RFC 2543 defined, but did no sufficiently specify, a mechanism for
+      UA authentication of a server.  That has been removed.  Instead,
+      the mutual authentication procedures of RFC 2617 are allowed.
+
+   o  A UA cannot send a BYE for a call until it has received an ACK for
+      the initial INVITE.  This was allowed in RFC 2543 but leads to a
+      potential race condition.
+
+   o  A UA or proxy cannot send CANCEL for a transaction until it gets a
+      provisional response for the request.  This was allowed in RFC
+      2543 but leads to potential race conditions.
+
+   o  The action parameter in registrations has been deprecated.  It was
+      insufficient for any useful services, and caused conflicts when
+      application processing was applied in proxies.
+
+   o  RFC 2543 had a number of special cases for multicast.  For
+      example, certain responses were suppressed, timers were adjusted,
+      and so on.  Multicast now plays a more limited role, and the
+      protocol operation is unaffected by usage of multicast as opposed
+      to unicast.  The limitations as a result of that are documented.
+
+   o  Basic authentication has been removed entirely and its usage
+      forbidden.
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 259]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   o  Proxies no longer forward a 6xx immediately on receiving it.
+      Instead, they CANCEL pending branches immediately.  This avoids a
+      potential race condition that would result in a UAC getting a 6xx
+      followed by a 2xx.  In all cases except this race condition, the
+      result will be the same - the 6xx is forwarded upstream.
+
+   o  RFC 2543 did not address the problem of request merging.  This
+      occurs when a request forks at a proxy and later rejoins at an
+      element.  Handling of merging is done only at a UA, and procedures
+      are defined for rejecting all but the first request.
+
+28.2 Minor Functional Changes
+
+   o  Added the Alert-Info, Error-Info, and Call-Info header fields for
+      optional content presentation to users.
+
+   o  Added the Content-Language, Content-Disposition and MIME-Version
+      header fields.
+
+   o  Added a "glare handling" mechanism to deal with the case where
+      both parties send each other a re-INVITE simultaneously.  It uses
+      the new 491 (Request Pending) error code.
+
+   o  Added the In-Reply-To and Reply-To header fields for supporting
+      the return of missed calls or messages at a later time.
+
+   o  Added TLS and SCTP as valid SIP transports.
+
+   o  There were a variety of mechanisms described for handling failures
+      at any time during a call; those are now generally unified.  BYE
+      is sent to terminate.
+
+   o  RFC 2543 mandated retransmission of INVITE responses over TCP, but
+      noted it was really only needed for 2xx.  That was an artifact of
+      insufficient protocol layering.  With a more coherent transaction
+      layer defined here, that is no longer needed.  Only 2xx responses
+      to INVITEs are retransmitted over TCP.
+
+   o  Client and server transaction machines are now driven based on
+      timeouts rather than retransmit counts.  This allows the state
+      machines to be properly specified for TCP and UDP.
+
+   o  The Date header field is used in REGISTER responses to provide a
+      simple means for auto-configuration of dates in user agents.
+
+   o  Allowed a registrar to reject registrations with expirations that
+      are too short in duration.  Defined the 423 response code and the
+      Min-Expires for this purpose.
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 260]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+29 Normative References
+
+   [1]  Handley, M. and V. Jacobson, "SDP: Session Description
+        Protocol", RFC 2327, April 1998.
+
+   [2]  Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [3]  Resnick, P., "Internet Message Format", RFC 2822, April 2001.
+
+   [4]  Rosenberg, J. and H. Schulzrinne, "SIP: Locating SIP Servers",
+        RFC 3263, June 2002.
+
+   [5]  Berners-Lee, T., Fielding, R. and L. Masinter, "Uniform Resource
+        Identifiers (URI): Generic Syntax", RFC 2396, August 1998.
+
+   [6]  Chown, P., "Advanced Encryption Standard (AES) Ciphersuites for
+        Transport Layer Security (TLS)", RFC 3268, June 2002.
+
+   [7]  Yergeau, F., "UTF-8, a transformation format of ISO 10646", RFC
+        2279, January 1998.
+
+   [8]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L.,
+        Leach, P. and T. Berners-Lee, "Hypertext Transfer Protocol --
+        HTTP/1.1", RFC 2616, June 1999.
+
+   [9]  Vaha-Sipila, A., "URLs for Telephone Calls", RFC 2806, April
+        2000.
+
+   [10] Crocker, D. and P. Overell, "Augmented BNF for Syntax
+        Specifications: ABNF", RFC 2234, November 1997.
+
+   [11] Freed, F. and N. Borenstein, "Multipurpose Internet Mail
+        Extensions (MIME) Part Two: Media Types", RFC 2046, November
+        1996.
+
+   [12] Eastlake, D., Crocker, S. and J. Schiller, "Randomness
+        Recommendations for Security", RFC 1750, December 1994.
+
+   [13] Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model with
+        SDP", RFC 3264, June 2002.
+
+   [14] Postel, J., "User Datagram Protocol", STD 6, RFC 768, August
+        1980.
+
+   [15] Postel, J., "DoD Standard Transmission Control Protocol", RFC
+        761, January 1980.
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 261]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   [16] Stewart, R., Xie, Q., Morneault, K., Sharp, C., Schwarzbauer,
+        H., Taylor, T., Rytina, I., Kalla, M., Zhang, L. and V. Paxson,
+        "Stream Control Transmission Protocol", RFC 2960, October 2000.
+
+   [17] Franks, J., Hallam-Baker, P., Hostetler, J., Lawrence, S.,
+        Leach, P., Luotonen, A. and L. Stewart, "HTTP authentication:
+        Basic and Digest Access Authentication", RFC 2617, June 1999.
+
+   [18] Troost, R., Dorner, S. and K. Moore, "Communicating Presentation
+        Information in Internet Messages: The Content-Disposition Header
+        Field", RFC 2183, August 1997.
+
+   [19] Zimmerer, E., Peterson, J., Vemuri, A., Ong, L., Audet, F.,
+        Watson, M. and M. Zonoun, "MIME media types for ISUP and QSIG
+        Objects", RFC 3204, December 2001.
+
+   [20] Braden, R., "Requirements for Internet Hosts - Application and
+        Support", STD 3, RFC 1123, October 1989.
+
+   [21] Alvestrand, H., "IETF Policy on Character Sets and Languages",
+        BCP 18, RFC 2277, January 1998.
+
+   [22] Galvin, J., Murphy, S., Crocker, S. and N. Freed, "Security
+        Multiparts for MIME: Multipart/Signed and Multipart/Encrypted",
+        RFC 1847, October 1995.
+
+   [23] Housley, R., "Cryptographic Message Syntax", RFC 2630, June
+        1999.
+
+   [24] Ramsdell B., "S/MIME Version 3 Message Specification", RFC 2633,
+        June 1999.
+
+   [25] Dierks, T. and C. Allen, "The TLS Protocol Version 1.0", RFC
+        2246, January 1999.
+
+   [26] Kent, S. and R. Atkinson, "Security Architecture for the
+        Internet Protocol", RFC 2401, November 1998.
+
+30 Informative References
+
+   [27] R. Pandya, "Emerging mobile and personal communication systems,"
+        IEEE Communications Magazine, Vol. 33, pp. 44--52, June 1995.
+
+   [28] Schulzrinne, H., Casner, S., Frederick, R. and V. Jacobson,
+        "RTP:  A Transport Protocol for Real-Time Applications", RFC
+        1889, January 1996.
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 262]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   [29] Schulzrinne, H., Rao, R. and R. Lanphier, "Real Time Streaming
+        Protocol (RTSP)", RFC 2326, April 1998.
+
+   [30] Cuervo, F., Greene, N., Rayhan, A., Huitema, C., Rosen, B. and
+        J. Segers, "Megaco Protocol Version 1.0", RFC 3015, November
+        2000.
+
+   [31] Handley, M., Schulzrinne, H., Schooler, E. and J. Rosenberg,
+        "SIP: Session Initiation Protocol", RFC 2543, March 1999.
+
+   [32] Hoffman, P., Masinter, L. and J. Zawinski, "The mailto URL
+        scheme", RFC 2368, July 1998.
+
+   [33] E. M. Schooler, "A multicast user directory service for
+        synchronous rendezvous," Master's Thesis CS-TR-96-18, Department
+        of Computer Science, California Institute of Technology,
+        Pasadena, California, Aug. 1996.
+
+   [34] Donovan, S., "The SIP INFO Method", RFC 2976, October 2000.
+
+   [35] Rivest, R., "The MD5 Message-Digest Algorithm", RFC 1321, April
+        1992.
+
+   [36] Dawson, F. and T. Howes, "vCard MIME Directory Profile", RFC
+        2426, September 1998.
+
+   [37] Good, G., "The LDAP Data Interchange Format (LDIF) - Technical
+        Specification", RFC 2849, June 2000.
+
+   [38] Palme, J., "Common Internet Message Headers",  RFC 2076,
+        February 1997.
+
+   [39] Franks, J., Hallam-Baker, P., Hostetler, J., Leach, P.,
+        Luotonen, A., Sink, E. and L. Stewart, "An Extension to HTTP:
+        Digest Access Authentication", RFC 2069, January 1997.
+
+   [40] Johnston, A., Donovan, S., Sparks, R., Cunningham, C., Willis,
+        D., Rosenberg, J., Summers, K. and H. Schulzrinne, "SIP Call
+        Flow Examples", Work in Progress.
+
+   [41] E. M. Schooler, "Case study: multimedia conference control in a
+        packet-switched teleconferencing system," Journal of
+        Internetworking:  Research and Experience, Vol. 4, pp. 99--120,
+        June 1993.  ISI reprint series ISI/RS-93-359.
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 263]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   [42] H. Schulzrinne, "Personal mobility for multimedia services in
+        the Internet," in European Workshop on Interactive Distributed
+        Multimedia Systems and Services (IDMS), (Berlin, Germany), Mar.
+        1996.
+
+   [43] Floyd, S., "Congestion Control Principles", RFC 2914, September
+        2000.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 264]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+A Table of Timer Values
+
+   Table 4 summarizes the meaning and defaults of the various timers
+   used by this specification.
+
+Timer    Value            Section               Meaning
+----------------------------------------------------------------------
+T1       500ms default    Section 17.1.1.1     RTT Estimate
+T2       4s               Section 17.1.2.2     The maximum retransmit
+                                               interval for non-INVITE
+                                               requests and INVITE
+                                               responses
+T4       5s               Section 17.1.2.2     Maximum duration a
+                                               message will
+                                               remain in the network
+Timer A  initially T1     Section 17.1.1.2     INVITE request retransmit
+                                               interval, for UDP only
+Timer B  64*T1            Section 17.1.1.2     INVITE transaction
+                                               timeout timer
+Timer C  > 3min           Section 16.6         proxy INVITE transaction
+                           bullet 11            timeout
+Timer D  > 32s for UDP    Section 17.1.1.2     Wait time for response
+         0s for TCP/SCTP                       retransmits
+Timer E  initially T1     Section 17.1.2.2     non-INVITE request
+                                               retransmit interval,
+                                               UDP only
+Timer F  64*T1            Section 17.1.2.2     non-INVITE transaction
+                                               timeout timer
+Timer G  initially T1     Section 17.2.1       INVITE response
+                                               retransmit interval
+Timer H  64*T1            Section 17.2.1       Wait time for
+                                               ACK receipt
+Timer I  T4 for UDP       Section 17.2.1       Wait time for
+         0s for TCP/SCTP                       ACK retransmits
+Timer J  64*T1 for UDP    Section 17.2.2       Wait time for
+         0s for TCP/SCTP                       non-INVITE request
+                                               retransmits
+Timer K  T4 for UDP       Section 17.1.2.2     Wait time for
+         0s for TCP/SCTP                       response retransmits
+
+                   Table 4: Summary of timers
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 265]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Acknowledgments
+
+   We wish to thank the members of the IETF MMUSIC and SIP WGs for their
+   comments and suggestions.  Detailed comments were provided by Ofir
+   Arkin, Brian Bidulock, Jim Buller, Neil Deason, Dave Devanathan,
+   Keith Drage, Bill Fenner, Cedric Fluckiger, Yaron Goland, John
+   Hearty, Bernie Hoeneisen, Jo Hornsby, Phil Hoffer, Christian Huitema,
+   Hisham Khartabil, Jean Jervis, Gadi Karmi, Peter Kjellerstedt, Anders
+   Kristensen, Jonathan Lennox, Gethin Liddell, Allison Mankin, William
+   Marshall, Rohan Mahy, Keith Moore, Vern Paxson, Bob Penfield, Moshe
+   J. Sambol, Chip Sharp, Igor Slepchin, Eric Tremblay, and Rick
+   Workman.
+
+   Brian Rosen provided the compiled BNF.
+
+   Jean Mahoney provided technical writing assistance.
+
+   This work is based, inter alia, on [41,42].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 266]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Authors' Addresses
+
+   Authors addresses are listed alphabetically for the editors, the
+   writers, and then the original authors of RFC 2543.  All listed
+   authors actively contributed large amounts of text to this document.
+
+   Jonathan Rosenberg
+   dynamicsoft
+   72 Eagle Rock Ave
+   East Hanover, NJ 07936
+   USA
+
+   EMail:  jdrosen@dynamicsoft.com
+
+
+   Henning Schulzrinne
+   Dept. of Computer Science
+   Columbia University
+   1214 Amsterdam Avenue
+   New York, NY 10027
+   USA
+
+   EMail:  schulzrinne@cs.columbia.edu
+
+
+   Gonzalo Camarillo
+   Ericsson
+   Advanced Signalling Research Lab.
+   FIN-02420 Jorvas
+   Finland
+
+   EMail:  Gonzalo.Camarillo@ericsson.com
+
+
+   Alan Johnston
+   WorldCom
+   100 South 4th Street
+   St. Louis, MO 63102
+   USA
+
+   EMail:  alan.johnston@wcom.com
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 267]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+   Jon Peterson
+   NeuStar, Inc
+   1800 Sutter Street, Suite 570
+   Concord, CA 94520
+   USA
+
+   EMail:  jon.peterson@neustar.com
+
+
+   Robert Sparks
+   dynamicsoft, Inc.
+   5100 Tennyson Parkway
+   Suite 1200
+   Plano, Texas 75024
+   USA
+
+   EMail:  rsparks@dynamicsoft.com
+
+
+   Mark Handley
+   International Computer Science Institute
+   1947 Center St, Suite 600
+   Berkeley, CA 94704
+   USA
+
+   EMail:  mjh@icir.org
+
+
+   Eve Schooler
+   AT&T Labs-Research
+   75 Willow Road
+   Menlo Park, CA 94025
+   USA
+
+   EMail: schooler@research.att.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 268]
+
+RFC 3261            SIP: Session Initiation Protocol           June 2002
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg, et. al.          Standards Track                   [Page 269]
+

--- a/rfcs/rfc3264.txt
+++ b/rfcs/rfc3264.txt
@@ -1,0 +1,1403 @@
+
+
+
+
+
+
+Network Working Group                                       J. Rosenberg
+Request for Comments: 3264                                   dynamicsoft
+Obsoletes: 2543                                           H. Schulzrinne
+Category: Standards Track                                    Columbia U.
+                                                               June 2002
+
+
+   An Offer/Answer Model with the Session Description Protocol (SDP)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This document defines a mechanism by which two entities can make use
+   of the Session Description Protocol (SDP) to arrive at a common view
+   of a multimedia session between them.  In the model, one participant
+   offers the other a description of the desired session from their
+   perspective, and the other participant answers with the desired
+   session from their perspective.  This offer/answer model is most
+   useful in unicast sessions where information from both participants
+   is needed for the complete view of the session.  The offer/answer
+   model is used by protocols like the Session Initiation Protocol
+   (SIP).
+
+Table of Contents
+
+   1          Introduction ........................................    2
+   2          Terminology .........................................    3
+   3          Definitions .........................................    3
+   4          Protocol Operation ..................................    4
+   5          Generating the Initial Offer ........................    5
+   5.1        Unicast Streams .....................................    5
+   5.2        Multicast Streams ...................................    8
+   6          Generating the Answer ...............................    9
+   6.1        Unicast Streams .....................................    9
+   6.2        Multicast Streams ...................................   12
+   7          Offerer Processing of the Answer ....................   12
+   8          Modifying the Session ...............................   13
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 1]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   8.1        Adding a Media Stream ...............................   13
+   8.2        Removing a Media Stream .............................   14
+   8.3        Modifying a Media Stream ............................   14
+   8.3.1      Modifying Address, Port or Transport ................   14
+   8.3.2      Changing the Set of Media Formats ...................   15
+   8.3.3      Changing Media Types ................................   17
+   8.3.4      Changing Attributes .................................   17
+   8.4        Putting a Unicast Media Stream on Hold ..............   17
+   9          Indicating Capabilities .............................   18
+   10         Example Offer/Answer Exchanges ......................   19
+   10.1       Basic Exchange ......................................   19
+   10.2       One of N Codec Selection ............................   21
+   11         Security Considerations .............................   23
+   12         IANA Considerations .................................   23
+   13         Acknowledgements ....................................   23
+   14         Normative References ................................   23
+   15         Informative References ..............................   24
+   16         Authors' Addresses ..................................   24
+   17         Full Copyright Statement.............................   25
+
+1 Introduction
+
+   The Session Description Protocol (SDP) [1] was originally conceived
+   as a way to describe multicast sessions carried on the Mbone.  The
+   Session Announcement Protocol (SAP) [6] was devised as a multicast
+   mechanism to carry SDP messages.  Although the SDP specification
+   allows for unicast operation, it is not complete.  Unlike multicast,
+   where there is a global view of the session that is used by all
+   participants, unicast sessions involve two participants, and a
+   complete view of the session requires information from both
+   participants, and agreement on parameters between them.
+
+   As an example, a multicast session requires conveying a single
+   multicast address for a particular media stream.  However, for a
+   unicast session, two addresses are needed - one for each participant.
+   As another example, a multicast session requires an indication of
+   which codecs will be used in the session.  However, for unicast, the
+   set of codecs needs to be determined by finding an overlap in the set
+   supported by each participant.
+
+   As a result, even though SDP has the expressiveness to describe
+   unicast sessions, it is missing the semantics and operational details
+   of how it is actually done.  In this document, we remedy that by
+   defining a simple offer/answer model based on SDP.  In this model,
+   one participant in the session generates an SDP message that
+   constitutes the offer - the set of media streams and codecs the
+   offerer wishes to use, along with the IP addresses and ports the
+   offerer would like to use to receive the media.  The offer is
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 2]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   conveyed to the other participant, called the answerer.  The answerer
+   generates an answer, which is an SDP message that responds to the
+   offer provided by the offerer.  The answer has a matching media
+   stream for each stream in the offer, indicating whether the stream is
+   accepted or not, along with the codecs that will be used and the IP
+   addresses and ports that the answerer wants to use to receive media.
+
+   It is also possible for a multicast session to work similar to a
+   unicast one; its parameters are negotiated between a pair of users as
+   in the unicast case, but both sides send packets to the same
+   multicast address, rather than unicast ones.  This document also
+   discusses the application of the offer/answer model to multicast
+   streams.
+
+   We also define guidelines for how the offer/answer model is used to
+   update a session after an initial offer/answer exchange.
+
+   The means by which the offers and answers are conveyed are outside
+   the scope of this document.  The offer/answer model defined here is
+   the mandatory baseline mechanism used by the Session Initiation
+   Protocol (SIP) [7].
+
+2 Terminology
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+   and "OPTIONAL" are to be interpreted as described in RFC 2119 [2] and
+   indicate requirement levels for compliant implementations.
+
+3 Definitions
+
+   The following terms are used throughout this document:
+
+      Agent: An agent is the protocol implementation involved in the
+         offer/answer exchange.  There are two agents involved in an
+         offer/answer exchange.
+
+      Answer: An SDP message sent by an answerer in response to an offer
+         received from an offerer.
+
+      Answerer: An agent which receives a session description from
+         another agent describing aspects of desired media
+         communication, and then responds to that with its own session
+         description.
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 3]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+      Media Stream: From RTSP [8], a media stream is a single media
+         instance, e.g., an audio stream or a video stream as well as a
+         single whiteboard or shared application group.  In SDP, a media
+         stream is described by an "m=" line and its associated
+         attributes.
+
+      Offer: An SDP message sent by an offerer.
+
+      Offerer: An agent which generates a session description in order
+         to create or modify a session.
+
+4 Protocol Operation
+
+   The offer/answer exchange assumes the existence of a higher layer
+   protocol (such as SIP) which is capable of exchanging SDP for the
+   purposes of session establishment between agents.
+
+   Protocol operation begins when one agent sends an initial offer to
+   another agent.  An offer is initial if it is outside of any context
+   that may have already been established through the higher layer
+   protocol.  It is assumed that the higher layer protocol provides
+   maintenance of some kind of context which allows the various SDP
+   exchanges to be associated together.
+
+   The agent receiving the offer MAY generate an answer, or it MAY
+   reject the offer.  The means for rejecting an offer are dependent on
+   the higher layer protocol.  The offer/answer exchange is atomic; if
+   the answer is rejected, the session reverts to the state prior to the
+   offer (which may be absence of a session).
+
+   At any time, either agent MAY generate a new offer that updates the
+   session.  However, it MUST NOT generate a new offer if it has
+   received an offer which it has not yet answered or rejected.
+   Furthermore, it MUST NOT generate a new offer if it has generated a
+   prior offer for which it has not yet received an answer or a
+   rejection.  If an agent receives an offer after having sent one, but
+   before receiving an answer to it, this is considered a "glare"
+   condition.
+
+      The term glare was originally used in circuit switched
+      telecommunications networks to describe the condition where two
+      switches both attempt to seize the same available circuit on the
+      same trunk at the same time.  Here, it means both agents have
+      attempted to send an updated offer at the same time.
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 4]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   The higher layer protocol needs to provide a means for resolving such
+   conditions.  The higher layer protocol will need to provide a means
+   for ordering of messages in each direction.  SIP meets these
+   requirements [7].
+
+5 Generating the Initial Offer
+
+   The offer (and answer) MUST be a valid SDP message, as defined by RFC
+   2327 [1], with one exception.  RFC 2327 mandates that either an e or
+   a p line is present in the SDP message.  This specification relaxes
+   that constraint; an SDP formulated for an offer/answer application
+   MAY omit both the e and p lines.  The numeric value of the session id
+   and version in the o line MUST be representable with a 64 bit signed
+   integer.  The initial value of the version MUST be less than
+   (2**62)-1, to avoid rollovers.  Although the SDP specification allows
+   for multiple session descriptions to be concatenated together into a
+   large SDP message, an SDP message used in the offer/answer model MUST
+   contain exactly one session description.
+
+   The SDP "s=" line conveys the subject of the session, which is
+   reasonably defined for multicast, but ill defined for unicast.  For
+   unicast sessions, it is RECOMMENDED that it consist of a single space
+   character (0x20) or a dash (-).
+
+      Unfortunately, SDP does not allow the "s=" line to be empty.
+
+   The SDP "t=" line conveys the time of the session.  Generally,
+   streams for unicast sessions are created and destroyed through
+   external signaling means, such as SIP.  In that case, the "t=" line
+   SHOULD have a value of "0 0".
+
+   The offer will contain zero or more media streams (each media stream
+   is described by an "m=" line and its associated attributes).  Zero
+   media streams implies that the offerer wishes to communicate, but
+   that the streams for the session will be added at a later time
+   through a modified offer.  The streams MAY be for a mix of unicast
+   and multicast; the latter obviously implies a multicast address in
+   the relevant "c=" line(s).
+
+   Construction of each offered stream depends on whether the stream is
+   multicast or unicast.
+
+5.1 Unicast Streams
+
+   If the offerer wishes to only send media on a stream to its peer, it
+   MUST mark the stream as sendonly with the "a=sendonly" attribute.  We
+   refer to a stream as being marked with a certain direction if a
+   direction attribute was present as either a media stream attribute or
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 5]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   a session attribute.  If the offerer wishes to only receive media
+   from its peer, it MUST mark the stream as recvonly.  If the offerer
+   wishes to communicate, but wishes to neither send nor receive media
+   at this time, it MUST mark the stream with an "a=inactive" attribute.
+   The inactive direction attribute is specified in RFC 3108 [3].  Note
+   that in the case of the Real Time Transport Protocol (RTP) [4], RTCP
+   is still sent and received for sendonly, recvonly, and inactive
+   streams.  That is, the directionality of the media stream has no
+   impact on the RTCP usage.  If the offerer wishes to both send and
+   receive media with its peer, it MAY include an "a=sendrecv"
+   attribute, or it MAY omit it, since sendrecv is the default.
+
+   For recvonly and sendrecv streams, the port number and address in the
+   offer indicate where the offerer would like to receive the media
+   stream.  For sendonly RTP streams, the address and port number
+   indirectly indicate where the offerer wants to receive RTCP reports.
+   Unless there is an explicit indication otherwise, reports are sent to
+   the port number one higher than the number indicated.  The IP address
+   and port present in the offer indicate nothing about the source IP
+   address and source port of RTP and RTCP packets that will be sent by
+   the offerer.  A port number of zero in the offer indicates that the
+   stream is offered but MUST NOT be used.  This has no useful semantics
+   in an initial offer, but is allowed for reasons of completeness,
+   since the answer can contain a zero port indicating a rejected stream
+   (Section 6).  Furthermore, existing streams can be terminated by
+   setting the port to zero (Section 8).  In general, a port number of
+   zero indicates that the media stream is not wanted.
+
+   The list of media formats for each media stream conveys two pieces of
+   information, namely the set of formats (codecs and any parameters
+   associated with the codec, in the case of RTP) that the offerer is
+   capable of sending and/or receiving (depending on the direction
+   attributes), and, in the case of RTP, the RTP payload type numbers
+   used to identify those formats.  If multiple formats are listed, it
+   means that the offerer is capable of making use of any of those
+   formats during the session.  In other words, the answerer MAY change
+   formats in the middle of the session, making use of any of the
+   formats listed, without sending a new offer.  For a sendonly stream,
+   the offer SHOULD indicate those formats the offerer is willing to
+   send for this stream.  For a recvonly stream, the offer SHOULD
+   indicate those formats the offerer is willing to receive for this
+   stream.  For a sendrecv stream, the offer SHOULD indicate those
+   codecs that the offerer is willing to send and receive with.
+
+   For recvonly RTP streams, the payload type numbers indicate the value
+   of the payload type field in RTP packets the offerer is expecting to
+   receive for that codec.  For sendonly RTP streams, the payload type
+   numbers indicate the value of the payload type field in RTP packets
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 6]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   the offerer is planning to send for that codec.  For sendrecv RTP
+   streams, the payload type numbers indicate the value of the payload
+   type field the offerer expects to receive, and would prefer to send.
+   However, for sendonly and sendrecv streams, the answer might indicate
+   different payload type numbers for the same codecs, in which case,
+   the offerer MUST send with the payload type numbers from the answer.
+
+      Different payload type numbers may be needed in each direction
+      because of interoperability concerns with H.323.
+
+   As per RFC 2327, fmtp parameters MAY be present to provide additional
+   parameters of the media format.
+
+   In the case of RTP streams, all media descriptions SHOULD contain
+   "a=rtpmap" mappings from RTP payload types to encodings.  If there is
+   no "a=rtpmap", the default payload type mapping, as defined by the
+   current profile in use (for example, RFC 1890 [5]) is to be used.
+
+      This allows easier migration away from static payload types.
+
+   In all cases, the formats in the "m=" line MUST be listed in order of
+   preference, with the first format listed being preferred.  In this
+   case, preferred means that the recipient of the offer SHOULD use the
+   format with the highest preference that is acceptable to it.
+
+   If the ptime attribute is present for a stream, it indicates the
+   desired packetization interval that the offerer would like to
+   receive.  The ptime attribute MUST be greater than zero.
+
+   If the bandwidth attribute is present for a stream, it indicates the
+   desired bandwidth that the offerer would like to receive.  A value of
+   zero is allowed, but discouraged.  It indicates that no media should
+   be sent.  In the case of RTP, it would also disable all RTCP.
+
+   If multiple media streams of different types are present, it means
+   that the offerer wishes to use those streams at the same time.  A
+   typical case is an audio and a video stream as part of a
+   videoconference.
+
+   If multiple media streams of the same type are present in an offer,
+   it means that the offerer wishes to send (and/or receive) multiple
+   streams of that type at the same time.  When sending multiple streams
+   of the same type, it is a matter of local policy as to how each media
+   source of that type (for example, a video camera and VCR in the case
+   of video) is mapped to each stream.  When a user has a single source
+   for a particular media type, only one policy makes sense: the source
+   is sent to each stream of the same type.  Each stream MAY use
+   different encodings.  When receiving multiple streams of the same
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 7]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   type, it is a matter of local policy as to how each stream is mapped
+   to the various media sinks for that particular type (for example,
+   speakers or a recording device in the case of audio).  There are a
+   few constraints on the policies, however.  First, when receiving
+   multiple streams of the same type, each stream MUST be mapped to at
+   least one sink for the purpose of presentation to the user.  In other
+   words, the intent of receiving multiple streams of the same type is
+   that they should all be presented in parallel, rather than choosing
+   just one.  Another constraint is that when multiple streams are
+   received and sent to the same sink, they MUST be combined in some
+   media specific way.  For example, in the case of two audio streams,
+   the received media from each might be mapped to the speakers.  In
+   that case, the combining operation would be to mix them.  In the case
+   of multiple instant messaging streams, where the sink is the screen,
+   the combining operation would be to present all of them to the user
+   interface.  The third constraint is that if multiple sources are
+   mapped to the same stream, those sources MUST be combined in some
+   media specific way before they are sent on the stream.  Although
+   policies beyond these constraints are flexible, an agent won't
+   generally want a policy that will copy media from its sinks to its
+   sources unless it is a conference server (i.e., don't copy received
+   media on one stream to another stream).
+
+   A typical usage example for multiple media streams of the same type
+   is a pre-paid calling card application, where the user can press and
+   hold the pound ("#") key at any time during a call to hangup and make
+   a new call on the same card.  This requires media from the user to
+   two destinations - the remote gateway, and the DTMF processing
+   application which looks for the pound.  This could be accomplished
+   with two media streams, one sendrecv to the gateway, and the other
+   sendonly (from the perspective of the user) to the DTMF application.
+
+   Once the offerer has sent the offer, it MUST be prepared to receive
+   media for any recvonly streams described by that offer.  It MUST be
+   prepared to send and receive media for any sendrecv streams in the
+   offer, and send media for any sendonly streams in the offer (of
+   course, it cannot actually send until the peer provides an answer
+   with the needed address and port information).  In the case of RTP,
+   even though it may receive media before the answer arrives, it will
+   not be able to send RTCP receiver reports until the answer arrives.
+
+5.2 Multicast Streams
+
+   If a session description contains a multicast media stream which is
+   listed as receive (send) only, it means that the participants,
+   including the offerer and answerer, can only receive (send) on that
+   stream.  This differs from the unicast view, where the directionality
+   refers to the flow of media between offerer and answerer.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 8]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Beyond that clarification, the semantics of an offered multicast
+   stream are exactly as described in RFC 2327 [1].
+
+6 Generating the Answer
+
+   The answer to an offered session description is based on the offered
+   session description.  If the answer is different from the offer in
+   any way (different IP addresses, ports, etc.), the origin line MUST
+   be different in the answer, since the answer is generated by a
+   different entity.  In that case, the version number in the "o=" line
+   of the answer is unrelated to the version number in the o line of the
+   offer.
+
+   For each "m=" line in the offer, there MUST be a corresponding "m="
+   line in the answer.  The answer MUST contain exactly the same number
+   of "m=" lines as the offer.  This allows for streams to be matched up
+   based on their order.  This implies that if the offer contained zero
+   "m=" lines, the answer MUST contain zero "m=" lines.
+
+   The "t=" line in the answer MUST equal that of the offer.  The time
+   of the session cannot be negotiated.
+
+   An offered stream MAY be rejected in the answer, for any reason.  If
+   a stream is rejected, the offerer and answerer MUST NOT generate
+   media (or RTCP packets) for that stream.  To reject an offered
+   stream, the port number in the corresponding stream in the answer
+   MUST be set to zero.  Any media formats listed are ignored.  At least
+   one MUST be present, as specified by SDP.
+
+   Constructing an answer for each offered stream differs for unicast
+   and multicast.
+
+6.1 Unicast Streams
+
+   If a stream is offered with a unicast address, the answer for that
+   stream MUST contain a unicast address.  The media type of the stream
+   in the answer MUST match that of the offer.
+
+   If a stream is offered as sendonly, the corresponding stream MUST be
+   marked as recvonly or inactive in the answer.  If a media stream is
+   listed as recvonly in the offer, the answer MUST be marked as
+   sendonly or inactive in the answer.  If an offered media stream is
+   listed as sendrecv (or if there is no direction attribute at the
+   media or session level, in which case the stream is sendrecv by
+   default), the corresponding stream in the answer MAY be marked as
+   sendonly, recvonly, sendrecv, or inactive.  If an offered media
+   stream is listed as inactive, it MUST be marked as inactive in the
+   answer.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 9]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   For streams marked as recvonly in the answer, the "m=" line MUST
+   contain at least one media format the answerer is willing to receive
+   with from amongst those listed in the offer.  The stream MAY indicate
+   additional media formats, not listed in the corresponding stream in
+   the offer, that the answerer is willing to receive.  For streams
+   marked as sendonly in the answer, the "m=" line MUST contain at least
+   one media format the answerer is willing to send from amongst those
+   listed in the offer.  For streams marked as sendrecv in the answer,
+   the "m=" line MUST contain at least one codec the answerer is willing
+   to both send and receive, from amongst those listed in the offer.
+   The stream MAY indicate additional media formats, not listed in the
+   corresponding stream in the offer, that the answerer is willing to
+   send or receive (of course, it will not be able to send them at this
+   time, since it was not listed in the offer).  For streams marked as
+   inactive in the answer, the list of media formats is constructed
+   based on the offer.  If the offer was sendonly, the list is
+   constructed as if the answer were recvonly.  Similarly, if the offer
+   was recvonly, the list is constructed as if the answer were sendonly,
+   and if the offer was sendrecv, the list is constructed as if the
+   answer were sendrecv.  If the offer was inactive, the list is
+   constructed as if the offer were actually sendrecv and the answer
+   were sendrecv.
+
+   The connection address and port in the answer indicate the address
+   where the answerer wishes to receive media (in the case of RTP, RTCP
+   will be received on the port which is one higher unless there is an
+   explicit indication otherwise).  This address and port MUST be
+   present even for sendonly streams; in the case of RTP, the port one
+   higher is still used to receive RTCP.
+
+   In the case of RTP, if a particular codec was referenced with a
+   specific payload type number in the offer, that same payload type
+   number SHOULD be used for that codec in the answer.  Even if the same
+   payload type number is used, the answer MUST contain rtpmap
+   attributes to define the payload type mappings for dynamic payload
+   types, and SHOULD contain mappings for static payload types.  The
+   media formats in the "m=" line MUST be listed in order of preference,
+   with the first format listed being preferred.  In this case,
+   preferred means that the offerer SHOULD use the format with the
+   highest preference from the answer.
+
+   Although the answerer MAY list the formats in their desired order of
+   preference, it is RECOMMENDED that unless there is a specific reason,
+   the answerer list formats in the same relative order they were
+   present in the offer.  In other words, if a stream in the offer lists
+   audio codecs 8, 22 and 48, in that order, and the answerer only
+   supports codecs 8 and 48, it is RECOMMENDED that, if the answerer has
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 10]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   no reason to change it, the ordering of codecs in the answer be 8,
+   48, and not 48, 8.  This helps assure that the same codec is used in
+   both directions.
+
+   The interpretation of fmtp parameters in an offer depends on the
+   parameters.  In many cases, those parameters describe specific
+   configurations of the media format, and should therefore be processed
+   as the media format value itself would be.  This means that the same
+   fmtp parameters with the same values MUST be present in the answer if
+   the media format they describe is present in the answer.  Other fmtp
+   parameters are more like parameters, for which it is perfectly
+   acceptable for each agent to use different values.  In that case, the
+   answer MAY contain fmtp parameters, and those MAY have the same
+   values as those in the offer, or they MAY be different.  SDP
+   extensions that define new parameters SHOULD specify the proper
+   interpretation in offer/answer.
+
+   The answerer MAY include a non-zero ptime attribute for any media
+   stream; this indicates the packetization interval that the answerer
+   would like to receive.  There is no requirement that the
+   packetization interval be the same in each direction for a particular
+   stream.
+
+   The answerer MAY include a bandwidth attribute for any media stream;
+   this indicates the bandwidth that the answerer would like the offerer
+   to use when sending media.  The value of zero is allowed, interpreted
+   as described in Section 5.
+
+   If the answerer has no media formats in common for a particular
+   offered stream, the answerer MUST reject that media stream by setting
+   the port to zero.
+
+   If there are no media formats in common for all streams, the entire
+   offered session is rejected.
+
+   Once the answerer has sent the answer, it MUST be prepared to receive
+   media for any recvonly streams described by that answer.  It MUST be
+   prepared to send and receive media for any sendrecv streams in the
+   answer, and it MAY send media immediately.  The answerer MUST be
+   prepared to receive media for recvonly or sendrecv streams using any
+   media formats listed for those streams in the answer, and it MAY send
+   media immediately.  When sending media, it SHOULD use a packetization
+   interval equal to the value of the ptime attribute in the offer, if
+   any was present.  It SHOULD send media using a bandwidth no higher
+   than the value of the bandwidth attribute in the offer, if any was
+   present.  The answerer MUST send using a media format in the offer
+   that is also listed in the answer, and SHOULD send using the most
+   preferred media format in the offer that is also listed in the
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 11]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   answer.  In the case of RTP, it MUST use the payload type numbers
+   from the offer, even if they differ from those in the answer.
+
+6.2 Multicast Streams
+
+   Unlike unicast, where there is a two-sided view of the stream, there
+   is only a single view of the stream for multicast.  As such,
+   generating an answer to a multicast offer generally involves
+   modifying a limited set of aspects of the stream.
+
+   If a multicast stream is accepted, the address and port information
+   in the answer MUST match that of the offer.  Similarly, the
+   directionality information in the answer (sendonly, recvonly, or
+   sendrecv) MUST equal that of the offer.  This is because all
+   participants in a multicast session need to have equivalent views of
+   the parameters of the session, an underlying assumption of the
+   multicast bias of RFC 2327.
+
+   The set of media formats in the answer MUST be equal to or be a
+   subset of those in the offer.  Removing a format is a way for the
+   answerer to indicate that the format is not supported.
+
+   The ptime and bandwidth attributes in the answer MUST equal the ones
+   in the offer, if present.  If not present, a non-zero ptime MAY be
+   added to the answer.
+
+7 Offerer Processing of the Answer
+
+   When the offerer receives the answer, it MAY send media on the
+   accepted stream(s) (assuming it is listed as sendrecv or recvonly in
+   the answer).  It MUST send using a media format listed in the answer,
+   and it SHOULD use the first media format listed in the answer when it
+   does send.
+
+      The reason this is a SHOULD, and not a MUST (its also a SHOULD,
+      and not a MUST, for the answerer), is because there will
+      oftentimes be a need to change codecs on the fly.  For example,
+      during silence periods, an agent might like to switch to a comfort
+      noise codec.  Or, if the user presses a number on the keypad, the
+      agent might like to send that using RFC 2833 [9].  Congestion
+      control might necessitate changing to a lower rate codec based on
+      feedback.
+
+   The offerer SHOULD send media according to the value of any ptime and
+   bandwidth attribute in the answer.
+
+   The offerer MAY immediately cease listening for media formats that
+   were listed in the initial offer, but not present in the answer.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 12]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+8 Modifying the Session
+
+   At any point during the session, either participant MAY issue a new
+   offer to modify characteristics of the session.  It is fundamental to
+   the operation of the offer/answer model that the exact same
+   offer/answer procedure defined above is used for modifying parameters
+   of an existing session.
+
+   The offer MAY be identical to the last SDP provided to the other
+   party (which may have been provided in an offer or an answer), or it
+   MAY be different.  We refer to the last SDP provided as the "previous
+   SDP".  If the offer is the same, the answer MAY be the same as the
+   previous SDP from the answerer, or it MAY be different.  If the
+   offered SDP is different from the previous SDP, some constraints are
+   placed on its construction, discussed below.
+
+   Nearly all aspects of the session can be modified.  New streams can
+   be added, existing streams can be deleted, and parameters of existing
+   streams can change.  When issuing an offer that modifies the session,
+   the "o=" line of the new SDP MUST be identical to that in the
+   previous SDP, except that the version in the origin field MUST
+   increment by one from the previous SDP.  If the version in the origin
+   line does not increment, the SDP MUST be identical to the SDP with
+   that version number.  The answerer MUST be prepared to receive an
+   offer that contains SDP with a version that has not changed; this is
+   effectively a no-op.  However, the answerer MUST generate a valid
+   answer (which MAY be the same as the previous SDP from the answerer,
+   or MAY be different), according to the procedures defined in Section
+   6.
+
+   If an SDP is offered, which is different from the previous SDP, the
+   new SDP MUST have a matching media stream for each media stream in
+   the previous SDP.  In other words, if the previous SDP had N "m="
+   lines, the new SDP MUST have at least N "m=" lines.  The i-th media
+   stream in the previous SDP, counting from the top, matches the i-th
+   media stream in the new SDP, counting from the top.  This matching is
+   necessary in order for the answerer to determine which stream in the
+   new SDP corresponds to a stream in the previous SDP.  Because of
+   these requirements, the number of "m=" lines in a stream never
+   decreases, but either stays the same or increases.  Deleted media
+   streams from a previous SDP MUST NOT be removed in a new SDP;
+   however, attributes for these streams need not be present.
+
+8.1 Adding a Media Stream
+
+   New media streams are created by new additional media descriptions
+   below the existing ones, or by reusing the "slot" used by an old
+   media stream which had been disabled by setting its port to zero.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 13]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Reusing its slot means that the new media description replaces the
+   old one, but retains its positioning relative to other media
+   descriptions in  the SDP.  New media descriptions MUST appear below
+   any existing media sections.  The rules for formatting these media
+   descriptions are identical to those described in Section 5.
+
+   When the answerer receives an SDP with more media descriptions than
+   the previous SDP from the offerer, or it receives an SDP with a media
+   stream in a slot where the port was previously zero, the answerer
+   knows that new media streams are being added.  These can be rejected
+   or accepted by placing an appropriately structured media description
+   in the answer.  The procedures for constructing the new media
+   description in the answer are described in Section 6.
+
+8.2 Removing a Media Stream
+
+   Existing media streams are removed by creating a new SDP with the
+   port number for that stream set to zero.  The stream description MAY
+   omit all attributes present previously, and MAY list just a single
+   media format.
+
+   A stream that is offered with a port of zero MUST be marked with port
+   zero in the answer.  Like the offer, the answer MAY omit all
+   attributes present previously, and MAY list just a single media
+   format from amongst those in the offer.
+
+   Removal of a media stream implies that media is no longer sent for
+   that stream, and any media that is received is discarded.  In the
+   case of RTP, RTCP transmission also ceases, as does processing of any
+   received RTCP packets.  Any resources associated with it can be
+   released.  The user interface might indicate that the stream has
+   terminated, by closing the associated window on a PC, for example.
+
+8.3 Modifying a Media Stream
+
+   Nearly all characteristics of a media stream can be modified.
+
+8.3.1 Modifying Address, Port or Transport
+
+   The port number for a stream MAY be changed.  To do this, the offerer
+   creates a new media description, with the port number in the m line
+   different from the corresponding stream in the previous SDP.  If only
+   the port number is to be changed, the rest of the media stream
+   description SHOULD remain unchanged.  The offerer MUST be prepared to
+   receive media on both the old and new ports as soon as the offer is
+   sent.  The offerer SHOULD NOT cease listening for media on the old
+   port until the answer is received and media arrives on the new port.
+   Doing so could result in loss of media during the transition.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 14]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Received, in this case, means that the media is passed to a media
+   sink.  This means that if there is a playout buffer, the agent would
+   continue to listen on the old port until the media on the new port
+   reached the top of the playout buffer.  At that time, it MAY cease
+   listening for media on the old port.
+
+   The corresponding media stream in the answer MAY be the same as the
+   stream in the previous SDP from the answerer, or it MAY be different.
+   If the updated stream is accepted by the answerer, the answerer
+   SHOULD begin sending traffic for that stream to the new port
+   immediately.  If the answerer changes the port from the previous SDP,
+   it MUST be prepared to receive media on both the old and new ports as
+   soon as the answer is sent.  The answerer MUST NOT cease listening
+   for media on the old port until media arrives on the new port.  At
+   that time, it MAY cease listening for media on the old port.  The
+   same is true for an offerer that sends an updated offer with a new
+   port; it MUST NOT cease listening for media on the old port until
+   media arrives on the new port.
+
+   Of course, if the offered stream is rejected, the offerer can cease
+   being prepared to receive using the new port as soon as the rejection
+   is received.
+
+   To change the IP address where media is sent to, the same procedure
+   is followed for changing the port number.  The only difference is
+   that the connection line is updated, not the port number.
+
+   The transport for a stream MAY be changed.  The process for doing
+   this is identical to changing the port, except the transport is
+   updated, not the port.
+
+8.3.2 Changing the Set of Media Formats
+
+   The list of media formats used in the session MAY be changed.  To do
+   this, the offerer creates a new media description, with the list of
+   media formats in the "m=" line different from the corresponding media
+   stream in the previous SDP.  This list MAY include new formats, and
+   MAY remove formats present from the previous SDP.  However, in the
+   case of RTP, the mapping from a particular dynamic payload type
+   number to a particular codec within that media stream MUST NOT change
+   for the duration of a session.  For example, if A generates an offer
+   with G.711 assigned to dynamic payload type number 46, payload type
+   number 46 MUST refer to G.711 from that point forward in any offers
+   or answers for that media stream within the session.  However, it is
+   acceptable for multiple payload type numbers to be mapped to the same
+   codec, so that an updated offer could also use payload type number 72
+   for G.711.
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 15]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+      The mappings need to remain fixed for the duration of the session
+      because of the loose synchronization between signaling exchanges
+      of SDP and the media stream.
+
+   The corresponding media stream in the answer is formulated as
+   described in Section 6, and may result in a change in media formats
+   as well.  Similarly, as described in Section 6, as soon as it sends
+   its answer, the answerer MUST begin sending media using any formats
+   in the offer that were also present in the answer, and SHOULD use the
+   most preferred format in the offer that was also listed in the answer
+   (assuming the stream allows for sending), and MUST NOT send using any
+   formats that are not in the offer, even if they were present in a
+   previous SDP from the peer.  Similarly, when the offerer receives the
+   answer, it MUST begin sending media using any formats in the answer,
+   and SHOULD use the most preferred one (assuming the stream allows for
+   sending), and MUST NOT send using any formats that are not in the
+   answer, even if they were present in a previous SDP from the peer.
+
+   When an agent ceases using a media format (by not listing that format
+   in an offer or answer, even though it was in a previous SDP) the
+   agent will still need to be prepared to receive media with that
+   format for a brief time.  How does it know when it can be prepared to
+   stop receiving with that format? If it needs to know, there are three
+   techniques that can be applied.  First, the agent can change ports in
+   addition to changing formats.  When media arrives on the new port, it
+   knows that the peer has ceased sending with the old format, and it
+   can cease being prepared to receive with it.  This approach has the
+   benefit of being media format independent.  However, changes in ports
+   may require changes in resource reservation or rekeying of security
+   protocols.  The second approach is to use a totally new set of
+   dynamic payload types for all codecs when one is discarded.  When
+   media is received with one of the new payload types, the agent knows
+   that the peer has ceased sending with the old format.  This approach
+   doesn't affect reservations or security contexts, but it is RTP
+   specific and wasteful of a very small payload type space.  A third
+   approach is to use a timer.  When the SDP from the peer is received,
+   the timer is set.  When it fires, the agent can cease being prepared
+   to receive with the old format.  A value of one minute would
+   typically be more than sufficient.  In some cases, an agent may not
+   care, and thus continually be prepared to receive with the old
+   formats.  Nothing need be done in this case.
+
+   Of course, if the offered stream is rejected, the offer can cease
+   being prepared to receive using any new formats as soon as the
+   rejection is received.
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 16]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+8.3.3 Changing Media Types
+
+   The media type (audio, video, etc.) for a stream MAY be changed.  It
+   is RECOMMENDED that the media type be changed (as opposed to adding a
+   new stream), when the same logical data is being conveyed, but just
+   in a different media format.  This is particularly useful for
+   changing between voiceband fax and fax in a single stream, which are
+   both separate media types.  To do this, the offerer creates a new
+   media description, with a new media type, in place of the description
+   in the previous SDP which is to be changed.
+
+   The corresponding media stream in the answer is formulated as
+   described in Section 6.  Assuming the stream is acceptable, the
+   answerer SHOULD begin sending with the new media type and formats as
+   soon as it receives the offer. The offerer MUST be prepared to
+   receive media with both the old and new types until the answer is
+   received, and media with the new type is received and reaches the top
+   of the playout buffer.
+
+8.3.4 Changing Attributes
+
+   Any other attributes in a media description MAY be updated in an
+   offer or answer.  Generally, an agent MUST send media (if the
+   directionality of the stream allows) using the new parameters once
+   the SDP with the change is received.
+
+8.4 Putting a Unicast Media Stream on Hold
+
+   If a party in a call wants to put the other party "on hold", i.e.,
+   request that it temporarily stops sending one or more unicast media
+   streams, a party offers the other an updated SDP.
+
+   If the stream to be placed on hold was previously a sendrecv media
+   stream, it is placed on hold by marking it as sendonly.  If the
+   stream to be placed on hold was previously a recvonly media stream,
+   it is placed on hold by marking it inactive.
+
+   This means that a stream is placed "on hold" separately in each
+   direction.  Each stream is placed "on hold" independently.  The
+   recipient of an offer for a stream on-hold SHOULD NOT automatically
+   return an answer with the corresponding stream on hold.  An SDP with
+   all streams "on hold" is referred to as held SDP.
+
+      Certain third party call control scenarios do not work when an
+      answerer responds to held SDP with held SDP.
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 17]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Typically, when a user "presses" hold, the agent will generate an
+   offer with all streams in the SDP indicating a direction of sendonly,
+   and it will also locally mute, so that no media is sent to the far
+   end, and no media is played out.
+
+   RFC 2543 [10] specified that placing a user on hold was accomplished
+   by setting the connection address to 0.0.0.0.  Its usage for putting
+   a call on hold is no longer recommended, since it doesn't allow for
+   RTCP to be used with held streams, doesn't work with IPv6, and breaks
+   with connection oriented media.  However, it can be useful in an
+   initial offer when the offerer knows it wants to use a particular set
+   of media streams and formats, but doesn't know the addresses and
+   ports at the time of the offer.  Of course, when used, the port
+   number MUST NOT be zero, which would specify that the stream has been
+   disabled.  An agent MUST be capable of receiving SDP with a
+   connection address of 0.0.0.0, in which case it means that neither
+   RTP nor RTCP should be sent to the peer.
+
+9 Indicating Capabilities
+
+   Before an agent sends an offer, it is helpful to know if the media
+   formats in that offer would be acceptable to the answerer.  Certain
+   protocols, like SIP, provide a means to query for such capabilities.
+   SDP can be used in responses to such queries to indicate
+   capabilities.  This section describes how such an SDP message is
+   formatted.  Since SDP has no way to indicate that the message is for
+   the purpose of capability indication, this is determined from the
+   context of the higher layer protocol.  The ability of baseline SDP to
+   indicate capabilities is very limited.  It cannot express allowed
+   parameter ranges or values, and can not be done in parallel with an
+   offer/answer itself.  Extensions might address such limitations in
+   the future.
+
+   An SDP constructed to indicate media capabilities is structured as
+   follows.  It MUST be a valid SDP, except that it MAY omit both "e="
+   and "p=" lines.  The "t=" line MUST be equal to "0 0".  For each
+   media type supported by the agent, there MUST be a corresponding
+   media description of that type.  The session ID in the origin field
+   MUST be unique for each SDP constructed to indicate media
+   capabilities.  The port MUST be set to zero, but the connection
+   address is arbitrary.  The usage of port zero makes sure that an SDP
+   formatted for capabilities does not cause media streams to be
+   established if it is interpreted as an offer or answer.
+
+   The transport component of the "m=" line indicates the transport for
+   that media type.  For each media format of that type supported by the
+   agent, there SHOULD be a media format listed in the "m=" line.  In
+   the case of RTP, if dynamic payload types are used, an rtpmap
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 18]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   attribute MUST be present to bind the type to a specific format.
+   There is no way to indicate constraints, such as how many
+   simultaneous streams can be supported for a particular codec, and so
+   on.
+
+   v=0
+   o=carol 28908764872 28908764872 IN IP4 100.3.6.6
+   s=-
+   t=0 0
+   c=IN IP4 192.0.2.4
+   m=audio 0 RTP/AVP 0 1 3
+   a=rtpmap:0 PCMU/8000
+   a=rtpmap:1 1016/8000
+   a=rtpmap:3 GSM/8000
+   m=video 0 RTP/AVP 31 34
+   a=rtpmap:31 H261/90000
+   a=rtpmap:34 H263/90000
+
+   Figure 1: SDP Indicating Capabilities
+
+   The SDP of Figure 1 indicates that the agent can support three audio
+   codecs (PCMU, 1016, and GSM) and two video codecs (H.261 and H.263).
+
+10 Example Offer/Answer Exchanges
+
+   This section provides example offer/answer exchanges.
+
+10.1 Basic Exchange
+
+   Assume that the caller, Alice, has included the following description
+   in her offer.  It includes a bidirectional audio stream and two
+   bidirectional video streams, using H.261 (payload type 31) and MPEG
+   (payload type 32).  The offered SDP is:
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 host.anywhere.com
+   s=
+   c=IN IP4 host.anywhere.com
+   t=0 0
+   m=audio 49170 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+   m=video 51372 RTP/AVP 31
+   a=rtpmap:31 H261/90000
+   m=video 53000 RTP/AVP 32
+   a=rtpmap:32 MPV/90000
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 19]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   The callee, Bob, does not want to receive or send the first video
+   stream, so he returns the SDP below as the answer:
+
+   v=0
+   o=bob 2890844730 2890844730 IN IP4 host.example.com
+   s=
+   c=IN IP4 host.example.com
+   t=0 0
+   m=audio 49920 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+   m=video 0 RTP/AVP 31
+   m=video 53000 RTP/AVP 32
+   a=rtpmap:32 MPV/90000
+
+   At some point later, Bob decides to change the port where he will
+   receive the audio stream (from 49920 to 65422), and at the same time,
+   add an additional audio stream as receive only, using the RTP payload
+   format for events [9].  Bob offers the following SDP in the offer:
+
+   v=0
+   o=bob 2890844730 2890844731 IN IP4 host.example.com
+   s=
+   c=IN IP4 host.example.com
+   t=0 0
+   m=audio 65422 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+   m=video 0 RTP/AVP 31
+   m=video 53000 RTP/AVP 32
+   a=rtpmap:32 MPV/90000
+   m=audio 51434 RTP/AVP 110
+   a=rtpmap:110 telephone-events/8000
+   a=recvonly
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 20]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Alice accepts the additional media stream, and so generates the
+   following answer:
+
+   v=0
+   o=alice 2890844526 2890844527 IN IP4 host.anywhere.com
+   s=
+   c=IN IP4 host.anywhere.com
+   t=0 0
+   m=audio 49170 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+   m=video 0 RTP/AVP 31
+   a=rtpmap:31 H261/90000
+   m=video 53000 RTP/AVP 32
+   a=rtpmap:32 MPV/90000
+   m=audio 53122 RTP/AVP 110
+   a=rtpmap:110 telephone-events/8000
+   a=sendonly
+
+10.2 One of N Codec Selection
+
+   A common occurrence in embedded phones is that the Digital Signal
+   Processor (DSP) used for compression can support multiple codecs at a
+   time, but once that codec is selected, it cannot be readily changed
+   on the fly.  This example shows how a session can be set up using an
+   initial offer/answer exchange, followed immediately by a second one
+   to lock down the set of codecs.
+
+   The initial offer from Alice to Bob indicates a single audio stream
+   with the three audio codecs that are available in the DSP.  The
+   stream is marked as inactive, since media cannot be received until a
+   codec is locked down:
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 host.anywhere.com
+   s=
+   c=IN IP4 host.anywhere.com
+   t=0 0
+   m=audio 62986 RTP/AVP 0 4 18
+   a=rtpmap:0 PCMU/8000
+   a=rtpmap:4 G723/8000
+   a=rtpmap:18 G729/8000
+   a=inactive
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 21]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   Bob can support dynamic switching between PCMU and G.723.  So, he
+   sends the following answer:
+
+   v=0
+   o=bob 2890844730 2890844731 IN IP4 host.example.com
+   s=
+   c=IN IP4 host.example.com
+   t=0 0
+   m=audio 54344 RTP/AVP 0 4
+   a=rtpmap:0 PCMU/8000
+   a=rtpmap:4 G723/8000
+   a=inactive
+
+   Alice can then select any one of these two codecs.  So, she sends an
+   updated offer with a sendrecv stream:
+
+   v=0
+   o=alice 2890844526 2890844527 IN IP4 host.anywhere.com
+   s=
+   c=IN IP4 host.anywhere.com
+   t=0 0
+   m=audio 62986 RTP/AVP 4
+   a=rtpmap:4 G723/8000
+   a=sendrecv
+
+   Bob accepts the single codec:
+
+   v=0
+   o=bob 2890844730 2890844732 IN IP4 host.example.com
+   s=
+   c=IN IP4 host.example.com
+   t=0 0
+   m=audio 54344 RTP/AVP 4
+   a=rtpmap:4 G723/8000
+   a=sendrecv
+
+   If the answerer (Bob), was only capable of supporting one-of-N
+   codecs, Bob would select one of the codecs from the offer, and place
+   that in his answer. In this case, Alice would do a re-INVITE to
+   activate that stream with that codec.
+
+   As an alternative to using "a=inactive" in the first exchange, Alice
+   can list all codecs, and as soon as she receives media from Bob,
+   generate an updated offer locking down the codec to the one just
+   received. Of course, if Bob only supports one-of-N codecs, there
+   would only be one codec in his answer, and in this case, there is no
+   need for a re-INVITE to lock down to a single codec.
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 22]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+11 Security Considerations
+
+   There are numerous attacks possible if an attacker can modify offers
+   or answers in transit.  Generally, these include diversion of media
+   streams (enabling eavesdropping), disabling of calls, and injection
+   of unwanted media streams.  If a passive listener can construct fake
+   offers, and inject those into an exchange, similar attacks are
+   possible.  Even if an attacker can simply observe offers and answers,
+   they can inject media streams into an existing conversation.
+
+   Offer/answer relies on transport within an application signaling
+   protocol, such as SIP.  It also relies on that protocol for security
+   capabilities.  Because of the attacks described above, that protocol
+   MUST provide a means for end-to-end authentication and integrity
+   protection of offers and answers.  It SHOULD offer encryption of
+   bodies to prevent eavesdropping.  However, media injection attacks
+   can alternatively be resolved through authenticated media exchange,
+   and therefore the encryption requirement is a SHOULD instead of a
+   MUST.
+
+   Replay attacks are also problematic.  An attacker can replay an old
+   offer, perhaps one that had put media on hold, and thus disable media
+   streams in a conversation.  Therefore, the application protocol MUST
+   provide a secure way to sequence offers and answers, and to detect
+   and reject old offers or answers.
+
+   SIP [7] meets all of these requirements.
+
+12 IANA Considerations
+
+   There are no IANA considerations with this specification.
+
+13 Acknowledgements
+
+   The authors would like to thank Allison Mankin, Rohan Mahy, Joerg
+   Ott, and Flemming Andreasen for their detailed comments.
+
+14 Normative References
+
+   [1]   Handley, M. and V. Jacobson, "SDP: Session Description
+         Protocol", RFC 2327, April 1998.
+
+   [2]   Bradner, S., "Key Words for Use in RFCs to Indicate Requirement
+         Levels", BCP 14, RFC 2119, March 1997.
+
+   [3]   Kumar, R. and M. Mostafa, "Conventions For the Use of The
+         Session Description Protocol (SDP) for ATM Bearer Connections",
+         RFC 3108, May 2001.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 23]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+   [4]   Schulzrinne, H., Casner, S, Frederick, R. and V. Jacobson,
+         "RTP: A Transport Protocol for Real-Time Applications", RFC
+         1889, January 1996.
+
+   [5]   Schulzrinne, H., "RTP Profile for Audio and Video Conferences
+         with Minimal Control", RFC 1890, January 1996.
+
+15 Informative References
+
+   [6]   Handley, M., Perkins, C. and E. Whelan, "Session Announcement
+         Protocol", RFC 2974, October 2000.
+
+   [7]   Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston, A.,
+         Peterson, J., Sparks, R., Handley, M. and E. Schooler, "SIP:
+         Session Initiation Protocol", RFC 3261, June 2002.
+
+   [8]   Schulzrinne, H., Rao, A. and R. Lanphier, "Real Time Streaming
+         Protocol (RTSP)", RFC 2326, April 1998.
+
+   [9]   Schulzrinne, H. and S. Petrack, "RTP Payload for DTMF Digits,
+         Telephony Tones and Telephony Signals", RFC 2833, May 2000.
+
+   [10]  Handley, M., Schulzrinne, H., Schooler, E. and J. Rosenberg,
+         "SIP: Session Initiation Protocol", RFC 2543, March 1999.
+
+16 Authors' Addresses
+
+   Jonathan Rosenberg
+   dynamicsoft
+   72 Eagle Rock Avenue
+   First Floor
+   East Hanover, NJ 07936
+
+   EMail: jdrosen@dynamicsoft.com
+
+
+   Henning Schulzrinne
+   Dept. of Computer Science
+   Columbia University
+   1214 Amsterdam Avenue
+   New York, NY 10027
+   USA
+
+   EMail: schulzrinne@cs.columbia.edu
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 24]
+
+RFC 3264  An Offer/Answer Model Session Description Protocol   June 2002
+
+
+17.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 25]
+

--- a/rfcs/rfc3550.txt
+++ b/rfcs/rfc3550.txt
@@ -1,0 +1,5827 @@
+
+
+
+
+
+
+Network Working Group                                     H. Schulzrinne
+Request for Comments: 3550                           Columbia University
+Obsoletes: 1889                                               S.  Casner
+Category: Standards Track                                  Packet Design
+                                                            R. Frederick
+                                                  Blue Coat Systems Inc.
+                                                             V. Jacobson
+                                                           Packet Design
+                                                               July 2003
+
+
+          RTP: A Transport Protocol for Real-Time Applications
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This memorandum describes RTP, the real-time transport protocol.  RTP
+   provides end-to-end network transport functions suitable for
+   applications transmitting real-time data, such as audio, video or
+   simulation data, over multicast or unicast network services.  RTP
+   does not address resource reservation and does not guarantee
+   quality-of-service for real-time services.  The data transport is
+   augmented by a control protocol (RTCP) to allow monitoring of the
+   data delivery in a manner scalable to large multicast networks, and
+   to provide minimal control and identification functionality.  RTP and
+   RTCP are designed to be independent of the underlying transport and
+   network layers.  The protocol supports the use of RTP-level
+   translators and mixers.
+
+   Most of the text in this memorandum is identical to RFC 1889 which it
+   obsoletes.  There are no changes in the packet formats on the wire,
+   only changes to the rules and algorithms governing how the protocol
+   is used.  The biggest change is an enhancement to the scalable timer
+   algorithm for calculating when to send RTCP packets in order to
+   minimize transmission in excess of the intended rate when many
+   participants join a session simultaneously.
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 1]
+
+RFC 3550                          RTP                          July 2003
+
+
+Table of Contents
+
+   1.  Introduction ................................................   4
+       1.1  Terminology ............................................   5
+   2.  RTP Use Scenarios ...........................................   5
+       2.1  Simple Multicast Audio Conference ......................   6
+       2.2  Audio and Video Conference .............................   7
+       2.3  Mixers and Translators .................................   7
+       2.4  Layered Encodings ......................................   8
+   3.  Definitions .................................................   8
+   4.  Byte Order, Alignment, and Time Format ......................  12
+   5.  RTP Data Transfer Protocol ..................................  13
+       5.1  RTP Fixed Header Fields ................................  13
+       5.2  Multiplexing RTP Sessions ..............................  16
+       5.3  Profile-Specific Modifications to the RTP Header .......  18
+            5.3.1  RTP Header Extension ............................  18
+   6.  RTP Control Protocol -- RTCP ................................  19
+       6.1  RTCP Packet Format .....................................  21
+       6.2  RTCP Transmission Interval .............................  24
+            6.2.1  Maintaining the Number of Session Members .......  28
+       6.3  RTCP Packet Send and Receive Rules .....................  28
+            6.3.1  Computing the RTCP Transmission Interval ........  29
+            6.3.2  Initialization ..................................  30
+            6.3.3  Receiving an RTP or Non-BYE RTCP Packet .........  31
+            6.3.4  Receiving an RTCP BYE Packet ....................  31
+            6.3.5  Timing Out an SSRC ..............................  32
+            6.3.6  Expiration of Transmission Timer ................  32
+            6.3.7  Transmitting a BYE Packet .......................  33
+            6.3.8  Updating we_sent ................................  34
+            6.3.9  Allocation of Source Description Bandwidth ......  34
+       6.4  Sender and Receiver Reports ............................  35
+            6.4.1  SR: Sender Report RTCP Packet ...................  36
+            6.4.2  RR: Receiver Report RTCP Packet .................  42
+            6.4.3  Extending the Sender and Receiver Reports .......  42
+            6.4.4  Analyzing Sender and Receiver Reports ...........  43
+       6.5  SDES: Source Description RTCP Packet ...................  45
+            6.5.1  CNAME: Canonical End-Point Identifier SDES Item .  46
+            6.5.2  NAME: User Name SDES Item .......................  48
+            6.5.3  EMAIL: Electronic Mail Address SDES Item ........  48
+            6.5.4  PHONE: Phone Number SDES Item ...................  49
+            6.5.5  LOC: Geographic User Location SDES Item .........  49
+            6.5.6  TOOL: Application or Tool Name SDES Item ........  49
+            6.5.7  NOTE: Notice/Status SDES Item ...................  50
+            6.5.8  PRIV: Private Extensions SDES Item ..............  50
+       6.6  BYE: Goodbye RTCP Packet ...............................  51
+       6.7  APP: Application-Defined RTCP Packet ...................  52
+   7.  RTP Translators and Mixers ..................................  53
+       7.1  General Description ....................................  53
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 2]
+
+RFC 3550                          RTP                          July 2003
+
+
+       7.2  RTCP Processing in Translators .........................  55
+       7.3  RTCP Processing in Mixers ..............................  57
+       7.4  Cascaded Mixers ........................................  58
+   8.  SSRC Identifier Allocation and Use ..........................  59
+       8.1  Probability of Collision ...............................  59
+       8.2  Collision Resolution and Loop Detection ................  60
+       8.3  Use with Layered Encodings .............................  64
+   9.  Security ....................................................  65
+       9.1  Confidentiality ........................................  65
+       9.2  Authentication and Message Integrity ...................  67
+   10. Congestion Control ..........................................  67
+   11. RTP over Network and Transport Protocols ....................  68
+   12. Summary of Protocol Constants ...............................  69
+       12.1 RTCP Packet Types ......................................  70
+       12.2 SDES Types .............................................  70
+   13. RTP Profiles and Payload Format Specifications ..............  71
+   14. Security Considerations .....................................  73
+   15. IANA Considerations .........................................  73
+   16. Intellectual Property Rights Statement ......................  74
+   17. Acknowledgments .............................................  74
+   Appendix A.   Algorithms ........................................  75
+   Appendix A.1  RTP Data Header Validity Checks ...................  78
+   Appendix A.2  RTCP Header Validity Checks .......................  82
+   Appendix A.3  Determining Number of Packets Expected and Lost ...  83
+   Appendix A.4  Generating RTCP SDES Packets ......................  84
+   Appendix A.5  Parsing RTCP SDES Packets .........................  85
+   Appendix A.6  Generating a Random 32-bit Identifier .............  85
+   Appendix A.7  Computing the RTCP Transmission Interval ..........  87
+   Appendix A.8  Estimating the Interarrival Jitter ................  94
+   Appendix B.   Changes from RFC 1889 .............................  95
+   References ...................................................... 100
+   Normative References ............................................ 100
+   Informative References .......................................... 100
+   Authors' Addresses .............................................. 103
+   Full Copyright Statement ........................................ 104
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 3]
+
+RFC 3550                          RTP                          July 2003
+
+
+1. Introduction
+
+   This memorandum specifies the real-time transport protocol (RTP),
+   which provides end-to-end delivery services for data with real-time
+   characteristics, such as interactive audio and video.  Those services
+   include payload type identification, sequence numbering, timestamping
+   and delivery monitoring.  Applications typically run RTP on top of
+   UDP to make use of its multiplexing and checksum services; both
+   protocols contribute parts of the transport protocol functionality.
+   However, RTP may be used with other suitable underlying network or
+   transport protocols (see Section 11).  RTP supports data transfer to
+   multiple destinations using multicast distribution if provided by the
+   underlying network.
+
+   Note that RTP itself does not provide any mechanism to ensure timely
+   delivery or provide other quality-of-service guarantees, but relies
+   on lower-layer services to do so.  It does not guarantee delivery or
+   prevent out-of-order delivery, nor does it assume that the underlying
+   network is reliable and delivers packets in sequence.  The sequence
+   numbers included in RTP allow the receiver to reconstruct the
+   sender's packet sequence, but sequence numbers might also be used to
+   determine the proper location of a packet, for example in video
+   decoding, without necessarily decoding packets in sequence.
+
+   While RTP is primarily designed to satisfy the needs of multi-
+   participant multimedia conferences, it is not limited to that
+   particular application.  Storage of continuous data, interactive
+   distributed simulation, active badge, and control and measurement
+   applications may also find RTP applicable.
+
+   This document defines RTP, consisting of two closely-linked parts:
+
+   o  the real-time transport protocol (RTP), to carry data that has
+      real-time properties.
+
+   o  the RTP control protocol (RTCP), to monitor the quality of service
+      and to convey information about the participants in an on-going
+      session.  The latter aspect of RTCP may be sufficient for "loosely
+      controlled" sessions, i.e., where there is no explicit membership
+      control and set-up, but it is not necessarily intended to support
+      all of an application's control communication requirements.  This
+      functionality may be fully or partially subsumed by a separate
+      session control protocol, which is beyond the scope of this
+      document.
+
+   RTP represents a new style of protocol following the principles of
+   application level framing and integrated layer processing proposed by
+   Clark and Tennenhouse [10].  That is, RTP is intended to be malleable
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 4]
+
+RFC 3550                          RTP                          July 2003
+
+
+   to provide the information required by a particular application and
+   will often be integrated into the application processing rather than
+   being implemented as a separate layer.  RTP is a protocol framework
+   that is deliberately not complete.  This document specifies those
+   functions expected to be common across all the applications for which
+   RTP would be appropriate.  Unlike conventional protocols in which
+   additional functions might be accommodated by making the protocol
+   more general or by adding an option mechanism that would require
+   parsing, RTP is intended to be tailored through modifications and/or
+   additions to the headers as needed.  Examples are given in Sections
+   5.3 and 6.4.3.
+
+   Therefore, in addition to this document, a complete specification of
+   RTP for a particular application will require one or more companion
+   documents (see Section 13):
+
+   o  a profile specification document, which defines a set of payload
+      type codes and their mapping to payload formats (e.g., media
+      encodings).  A profile may also define extensions or modifications
+      to RTP that are specific to a particular class of applications.
+      Typically an application will operate under only one profile.  A
+      profile for audio and video data may be found in the companion RFC
+      3551 [1].
+
+   o  payload format specification documents, which define how a
+      particular payload, such as an audio or video encoding, is to be
+      carried in RTP.
+
+   A discussion of real-time services and algorithms for their
+   implementation as well as background discussion on some of the RTP
+   design decisions can be found in [11].
+
+1.1 Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119 [2]
+   and indicate requirement levels for compliant RTP implementations.
+
+2. RTP Use Scenarios
+
+   The following sections describe some aspects of the use of RTP.  The
+   examples were chosen to illustrate the basic operation of
+   applications using RTP, not to limit what RTP may be used for.  In
+   these examples, RTP is carried on top of IP and UDP, and follows the
+   conventions established by the profile for audio and video specified
+   in the companion RFC 3551.
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 5]
+
+RFC 3550                          RTP                          July 2003
+
+
+2.1 Simple Multicast Audio Conference
+
+   A working group of the IETF meets to discuss the latest protocol
+   document, using the IP multicast services of the Internet for voice
+   communications.  Through some allocation mechanism the working group
+   chair obtains a multicast group address and pair of ports.  One port
+   is used for audio data, and the other is used for control (RTCP)
+   packets.  This address and port information is distributed to the
+   intended participants.  If privacy is desired, the data and control
+   packets may be encrypted as specified in Section 9.1, in which case
+   an encryption key must also be generated and distributed.  The exact
+   details of these allocation and distribution mechanisms are beyond
+   the scope of RTP.
+
+   The audio conferencing application used by each conference
+   participant sends audio data in small chunks of, say, 20 ms duration.
+   Each chunk of audio data is preceded by an RTP header; RTP header and
+   data are in turn contained in a UDP packet.  The RTP header indicates
+   what type of audio encoding (such as PCM, ADPCM or LPC) is contained
+   in each packet so that senders can change the encoding during a
+   conference, for example, to accommodate a new participant that is
+   connected through a low-bandwidth link or react to indications of
+   network congestion.
+
+   The Internet, like other packet networks, occasionally loses and
+   reorders packets and delays them by variable amounts of time.  To
+   cope with these impairments, the RTP header contains timing
+   information and a sequence number that allow the receivers to
+   reconstruct the timing produced by the source, so that in this
+   example, chunks of audio are contiguously played out the speaker
+   every 20 ms.  This timing reconstruction is performed separately for
+   each source of RTP packets in the conference.  The sequence number
+   can also be used by the receiver to estimate how many packets are
+   being lost.
+
+   Since members of the working group join and leave during the
+   conference, it is useful to know who is participating at any moment
+   and how well they are receiving the audio data.  For that purpose,
+   each instance of the audio application in the conference periodically
+   multicasts a reception report plus the name of its user on the RTCP
+   (control) port.  The reception report indicates how well the current
+   speaker is being received and may be used to control adaptive
+   encodings.  In addition to the user name, other identifying
+   information may also be included subject to control bandwidth limits.
+   A site sends the RTCP BYE packet (Section 6.6) when it leaves the
+   conference.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 6]
+
+RFC 3550                          RTP                          July 2003
+
+
+2.2 Audio and Video Conference
+
+   If both audio and video media are used in a conference, they are
+   transmitted as separate RTP sessions.  That is, separate RTP and RTCP
+   packets are transmitted for each medium using two different UDP port
+   pairs and/or multicast addresses.  There is no direct coupling at the
+   RTP level between the audio and video sessions, except that a user
+   participating in both sessions should use the same distinguished
+   (canonical) name in the RTCP packets for both so that the sessions
+   can be associated.
+
+   One motivation for this separation is to allow some participants in
+   the conference to receive only one medium if they choose.  Further
+   explanation is given in Section 5.2.  Despite the separation,
+   synchronized playback of a source's audio and video can be achieved
+   using timing information carried in the RTCP packets for both
+   sessions.
+
+2.3 Mixers and Translators
+
+   So far, we have assumed that all sites want to receive media data in
+   the same format.  However, this may not always be appropriate.
+   Consider the case where participants in one area are connected
+   through a low-speed link to the majority of the conference
+   participants who enjoy high-speed network access.  Instead of forcing
+   everyone to use a lower-bandwidth, reduced-quality audio encoding, an
+   RTP-level relay called a mixer may be placed near the low-bandwidth
+   area.  This mixer resynchronizes incoming audio packets to
+   reconstruct the constant 20 ms spacing generated by the sender, mixes
+   these reconstructed audio streams into a single stream, translates
+   the audio encoding to a lower-bandwidth one and forwards the lower-
+   bandwidth packet stream across the low-speed link.  These packets
+   might be unicast to a single recipient or multicast on a different
+   address to multiple recipients.  The RTP header includes a means for
+   mixers to identify the sources that contributed to a mixed packet so
+   that correct talker indication can be provided at the receivers.
+
+   Some of the intended participants in the audio conference may be
+   connected with high bandwidth links but might not be directly
+   reachable via IP multicast.  For example, they might be behind an
+   application-level firewall that will not let any IP packets pass.
+   For these sites, mixing may not be necessary, in which case another
+   type of RTP-level relay called a translator may be used.  Two
+   translators are installed, one on either side of the firewall, with
+   the outside one funneling all multicast packets received through a
+   secure connection to the translator inside the firewall.  The
+   translator inside the firewall sends them again as multicast packets
+   to a multicast group restricted to the site's internal network.
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 7]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Mixers and translators may be designed for a variety of purposes.  An
+   example is a video mixer that scales the images of individual people
+   in separate video streams and composites them into one video stream
+   to simulate a group scene.  Other examples of translation include the
+   connection of a group of hosts speaking only IP/UDP to a group of
+   hosts that understand only ST-II, or the packet-by-packet encoding
+   translation of video streams from individual sources without
+   resynchronization or mixing.  Details of the operation of mixers and
+   translators are given in Section 7.
+
+2.4 Layered Encodings
+
+   Multimedia applications should be able to adjust the transmission
+   rate to match the capacity of the receiver or to adapt to network
+   congestion.  Many implementations place the responsibility of rate-
+   adaptivity at the source.  This does not work well with multicast
+   transmission because of the conflicting bandwidth requirements of
+   heterogeneous receivers.  The result is often a least-common
+   denominator scenario, where the smallest pipe in the network mesh
+   dictates the quality and fidelity of the overall live multimedia
+   "broadcast".
+
+   Instead, responsibility for rate-adaptation can be placed at the
+   receivers by combining a layered encoding with a layered transmission
+   system.  In the context of RTP over IP multicast, the source can
+   stripe the progressive layers of a hierarchically represented signal
+   across multiple RTP sessions each carried on its own multicast group.
+   Receivers can then adapt to network heterogeneity and control their
+   reception bandwidth by joining only the appropriate subset of the
+   multicast groups.
+
+   Details of the use of RTP with layered encodings are given in
+   Sections 6.3.9, 8.3 and 11.
+
+3. Definitions
+
+   RTP payload: The data transported by RTP in a packet, for
+      example audio samples or compressed video data.  The payload
+      format and interpretation are beyond the scope of this document.
+
+   RTP packet: A data packet consisting of the fixed RTP header, a
+      possibly empty list of contributing sources (see below), and the
+      payload data.  Some underlying protocols may require an
+      encapsulation of the RTP packet to be defined.  Typically one
+      packet of the underlying protocol contains a single RTP packet,
+      but several RTP packets MAY be contained if permitted by the
+      encapsulation method (see Section 11).
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 8]
+
+RFC 3550                          RTP                          July 2003
+
+
+   RTCP packet: A control packet consisting of a fixed header part
+      similar to that of RTP data packets, followed by structured
+      elements that vary depending upon the RTCP packet type.  The
+      formats are defined in Section 6.  Typically, multiple RTCP
+      packets are sent together as a compound RTCP packet in a single
+      packet of the underlying protocol; this is enabled by the length
+      field in the fixed header of each RTCP packet.
+
+   Port: The "abstraction that transport protocols use to
+      distinguish among multiple destinations within a given host
+      computer.  TCP/IP protocols identify ports using small positive
+      integers." [12] The transport selectors (TSEL) used by the OSI
+      transport layer are equivalent to ports.  RTP depends upon the
+      lower-layer protocol to provide some mechanism such as ports to
+      multiplex the RTP and RTCP packets of a session.
+
+   Transport address: The combination of a network address and port
+      that identifies a transport-level endpoint, for example an IP
+      address and a UDP port.  Packets are transmitted from a source
+      transport address to a destination transport address.
+
+   RTP media type: An RTP media type is the collection of payload
+      types which can be carried within a single RTP session.  The RTP
+      Profile assigns RTP media types to RTP payload types.
+
+   Multimedia session: A set of concurrent RTP sessions among a
+      common group of participants.  For example, a videoconference
+      (which is a multimedia session) may contain an audio RTP session
+      and a video RTP session.
+
+   RTP session: An association among a set of participants
+      communicating with RTP.  A participant may be involved in multiple
+      RTP sessions at the same time.  In a multimedia session, each
+      medium is typically carried in a separate RTP session with its own
+      RTCP packets unless the the encoding itself multiplexes multiple
+      media into a single data stream.  A participant distinguishes
+      multiple RTP sessions by reception of different sessions using
+      different pairs of destination transport addresses, where a pair
+      of transport addresses comprises one network address plus a pair
+      of ports for RTP and RTCP.  All participants in an RTP session may
+      share a common destination transport address pair, as in the case
+      of IP multicast, or the pairs may be different for each
+      participant, as in the case of individual unicast network
+      addresses and port pairs.  In the unicast case, a participant may
+      receive from all other participants in the session using the same
+      pair of ports, or may use a distinct pair of ports for each.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                     [Page 9]
+
+RFC 3550                          RTP                          July 2003
+
+
+      The distinguishing feature of an RTP session is that each
+      maintains a full, separate space of SSRC identifiers (defined
+      next).  The set of participants included in one RTP session
+      consists of those that can receive an SSRC identifier transmitted
+      by any one of the participants either in RTP as the SSRC or a CSRC
+      (also defined below) or in RTCP.  For example, consider a three-
+      party conference implemented using unicast UDP with each
+      participant receiving from the other two on separate port pairs.
+      If each participant sends RTCP feedback about data received from
+      one other participant only back to that participant, then the
+      conference is composed of three separate point-to-point RTP
+      sessions.  If each participant provides RTCP feedback about its
+      reception of one other participant to both of the other
+      participants, then the conference is composed of one multi-party
+      RTP session.  The latter case simulates the behavior that would
+      occur with IP multicast communication among the three
+      participants.
+
+      The RTP framework allows the variations defined here, but a
+      particular control protocol or application design will usually
+      impose constraints on these variations.
+
+   Synchronization source (SSRC): The source of a stream of RTP
+      packets, identified by a 32-bit numeric SSRC identifier carried in
+      the RTP header so as not to be dependent upon the network address.
+      All packets from a synchronization source form part of the same
+      timing and sequence number space, so a receiver groups packets by
+      synchronization source for playback.  Examples of synchronization
+      sources include the sender of a stream of packets derived from a
+      signal source such as a microphone or a camera, or an RTP mixer
+      (see below).  A synchronization source may change its data format,
+      e.g., audio encoding, over time.  The SSRC identifier is a
+      randomly chosen value meant to be globally unique within a
+      particular RTP session (see Section 8).  A participant need not
+      use the same SSRC identifier for all the RTP sessions in a
+      multimedia session; the binding of the SSRC identifiers is
+      provided through RTCP (see Section 6.5.1).  If a participant
+      generates multiple streams in one RTP session, for example from
+      separate video cameras, each MUST be identified as a different
+      SSRC.
+
+   Contributing source (CSRC): A source of a stream of RTP packets
+      that has contributed to the combined stream produced by an RTP
+      mixer (see below).  The mixer inserts a list of the SSRC
+      identifiers of the sources that contributed to the generation of a
+      particular packet into the RTP header of that packet.  This list
+      is called the CSRC list.  An example application is audio
+      conferencing where a mixer indicates all the talkers whose speech
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 10]
+
+RFC 3550                          RTP                          July 2003
+
+
+      was combined to produce the outgoing packet, allowing the receiver
+      to indicate the current talker, even though all the audio packets
+      contain the same SSRC identifier (that of the mixer).
+
+   End system: An application that generates the content to be sent
+      in RTP packets and/or consumes the content of received RTP
+      packets.  An end system can act as one or more synchronization
+      sources in a particular RTP session, but typically only one.
+
+   Mixer: An intermediate system that receives RTP packets from one
+      or more sources, possibly changes the data format, combines the
+      packets in some manner and then forwards a new RTP packet.  Since
+      the timing among multiple input sources will not generally be
+      synchronized, the mixer will make timing adjustments among the
+      streams and generate its own timing for the combined stream.
+      Thus, all data packets originating from a mixer will be identified
+      as having the mixer as their synchronization source.
+
+   Translator: An intermediate system that forwards RTP packets
+      with their synchronization source identifier intact.  Examples of
+      translators include devices that convert encodings without mixing,
+      replicators from multicast to unicast, and application-level
+      filters in firewalls.
+
+   Monitor: An application that receives RTCP packets sent by
+      participants in an RTP session, in particular the reception
+      reports, and estimates the current quality of service for
+      distribution monitoring, fault diagnosis and long-term statistics.
+      The monitor function is likely to be built into the application(s)
+      participating in the session, but may also be a separate
+      application that does not otherwise participate and does not send
+      or receive the RTP data packets (since they are on a separate
+      port).  These are called third-party monitors.  It is also
+      acceptable for a third-party monitor to receive the RTP data
+      packets but not send RTCP packets or otherwise be counted in the
+      session.
+
+   Non-RTP means: Protocols and mechanisms that may be needed in
+      addition to RTP to provide a usable service.  In particular, for
+      multimedia conferences, a control protocol may distribute
+      multicast addresses and keys for encryption, negotiate the
+      encryption algorithm to be used, and define dynamic mappings
+      between RTP payload type values and the payload formats they
+      represent for formats that do not have a predefined payload type
+      value.  Examples of such protocols include the Session Initiation
+      Protocol (SIP) (RFC 3261 [13]), ITU Recommendation H.323 [14] and
+      applications using SDP (RFC 2327 [15]), such as RTSP (RFC 2326
+      [16]).  For simple
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 11]
+
+RFC 3550                          RTP                          July 2003
+
+
+      applications, electronic mail or a conference database may also be
+      used.  The specification of such protocols and mechanisms is
+      outside the scope of this document.
+
+4. Byte Order, Alignment, and Time Format
+
+   All integer fields are carried in network byte order, that is, most
+   significant byte (octet) first.  This byte order is commonly known as
+   big-endian.  The transmission order is described in detail in [3].
+   Unless otherwise noted, numeric constants are in decimal (base 10).
+
+   All header data is aligned to its natural length, i.e., 16-bit fields
+   are aligned on even offsets, 32-bit fields are aligned at offsets
+   divisible by four, etc.  Octets designated as padding have the value
+   zero.
+
+   Wallclock time (absolute date and time) is represented using the
+   timestamp format of the Network Time Protocol (NTP), which is in
+   seconds relative to 0h UTC on 1 January 1900 [4].  The full
+   resolution NTP timestamp is a 64-bit unsigned fixed-point number with
+   the integer part in the first 32 bits and the fractional part in the
+   last 32 bits.  In some fields where a more compact representation is
+   appropriate, only the middle 32 bits are used; that is, the low 16
+   bits of the integer part and the high 16 bits of the fractional part.
+   The high 16 bits of the integer part must be determined
+   independently.
+
+   An implementation is not required to run the Network Time Protocol in
+   order to use RTP.  Other time sources, or none at all, may be used
+   (see the description of the NTP timestamp field in Section 6.4.1).
+   However, running NTP may be useful for synchronizing streams
+   transmitted from separate hosts.
+
+   The NTP timestamp will wrap around to zero some time in the year
+   2036, but for RTP purposes, only differences between pairs of NTP
+   timestamps are used.  So long as the pairs of timestamps can be
+   assumed to be within 68 years of each other, using modular arithmetic
+   for subtractions and comparisons makes the wraparound irrelevant.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 12]
+
+RFC 3550                          RTP                          July 2003
+
+
+5. RTP Data Transfer Protocol
+
+5.1 RTP Fixed Header Fields
+
+   The RTP header has the following format:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           timestamp                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |           synchronization source (SSRC) identifier            |
+   +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+   |            contributing source (CSRC) identifiers             |
+   |                             ....                              |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The first twelve octets are present in every RTP packet, while the
+   list of CSRC identifiers is present only when inserted by a mixer.
+   The fields have the following meaning:
+
+   version (V): 2 bits
+      This field identifies the version of RTP.  The version defined by
+      this specification is two (2).  (The value 1 is used by the first
+      draft version of RTP and the value 0 is used by the protocol
+      initially implemented in the "vat" audio tool.)
+
+   padding (P): 1 bit
+      If the padding bit is set, the packet contains one or more
+      additional padding octets at the end which are not part of the
+      payload.  The last octet of the padding contains a count of how
+      many padding octets should be ignored, including itself.  Padding
+      may be needed by some encryption algorithms with fixed block sizes
+      or for carrying several RTP packets in a lower-layer protocol data
+      unit.
+
+   extension (X): 1 bit
+      If the extension bit is set, the fixed header MUST be followed by
+      exactly one header extension, with a format defined in Section
+      5.3.1.
+
+   CSRC count (CC): 4 bits
+      The CSRC count contains the number of CSRC identifiers that follow
+      the fixed header.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 13]
+
+RFC 3550                          RTP                          July 2003
+
+
+   marker (M): 1 bit
+      The interpretation of the marker is defined by a profile.  It is
+      intended to allow significant events such as frame boundaries to
+      be marked in the packet stream.  A profile MAY define additional
+      marker bits or specify that there is no marker bit by changing the
+      number of bits in the payload type field (see Section 5.3).
+
+   payload type (PT): 7 bits
+      This field identifies the format of the RTP payload and determines
+      its interpretation by the application.  A profile MAY specify a
+      default static mapping of payload type codes to payload formats.
+      Additional payload type codes MAY be defined dynamically through
+      non-RTP means (see Section 3).  A set of default mappings for
+      audio and video is specified in the companion RFC 3551 [1].  An
+      RTP source MAY change the payload type during a session, but this
+      field SHOULD NOT be used for multiplexing separate media streams
+      (see Section 5.2).
+
+      A receiver MUST ignore packets with payload types that it does not
+      understand.
+
+   sequence number: 16 bits
+      The sequence number increments by one for each RTP data packet
+      sent, and may be used by the receiver to detect packet loss and to
+      restore packet sequence.  The initial value of the sequence number
+      SHOULD be random (unpredictable) to make known-plaintext attacks
+      on encryption more difficult, even if the source itself does not
+      encrypt according to the method in Section 9.1, because the
+      packets may flow through a translator that does.  Techniques for
+      choosing unpredictable numbers are discussed in [17].
+
+   timestamp: 32 bits
+      The timestamp reflects the sampling instant of the first octet in
+      the RTP data packet.  The sampling instant MUST be derived from a
+      clock that increments monotonically and linearly in time to allow
+      synchronization and jitter calculations (see Section 6.4.1).  The
+      resolution of the clock MUST be sufficient for the desired
+      synchronization accuracy and for measuring packet arrival jitter
+      (one tick per video frame is typically not sufficient).  The clock
+      frequency is dependent on the format of data carried as payload
+      and is specified statically in the profile or payload format
+      specification that defines the format, or MAY be specified
+      dynamically for payload formats defined through non-RTP means.  If
+      RTP packets are generated periodically, the nominal sampling
+      instant as determined from the sampling clock is to be used, not a
+      reading of the system clock.  As an example, for fixed-rate audio
+      the timestamp clock would likely increment by one for each
+      sampling period.  If an audio application reads blocks covering
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 14]
+
+RFC 3550                          RTP                          July 2003
+
+
+      160 sampling periods from the input device, the timestamp would be
+      increased by 160 for each such block, regardless of whether the
+      block is transmitted in a packet or dropped as silent.
+
+      The initial value of the timestamp SHOULD be random, as for the
+      sequence number.  Several consecutive RTP packets will have equal
+      timestamps if they are (logically) generated at once, e.g., belong
+      to the same video frame.  Consecutive RTP packets MAY contain
+      timestamps that are not monotonic if the data is not transmitted
+      in the order it was sampled, as in the case of MPEG interpolated
+      video frames.  (The sequence numbers of the packets as transmitted
+      will still be monotonic.)
+
+      RTP timestamps from different media streams may advance at
+      different rates and usually have independent, random offsets.
+      Therefore, although these timestamps are sufficient to reconstruct
+      the timing of a single stream, directly comparing RTP timestamps
+      from different media is not effective for synchronization.
+      Instead, for each medium the RTP timestamp is related to the
+      sampling instant by pairing it with a timestamp from a reference
+      clock (wallclock) that represents the time when the data
+      corresponding to the RTP timestamp was sampled.  The reference
+      clock is shared by all media to be synchronized.  The timestamp
+      pairs are not transmitted in every data packet, but at a lower
+      rate in RTCP SR packets as described in Section 6.4.
+
+      The sampling instant is chosen as the point of reference for the
+      RTP timestamp because it is known to the transmitting endpoint and
+      has a common definition for all media, independent of encoding
+      delays or other processing.  The purpose is to allow synchronized
+      presentation of all media sampled at the same time.
+
+      Applications transmitting stored data rather than data sampled in
+      real time typically use a virtual presentation timeline derived
+      from wallclock time to determine when the next frame or other unit
+      of each medium in the stored data should be presented.  In this
+      case, the RTP timestamp would reflect the presentation time for
+      each unit.  That is, the RTP timestamp for each unit would be
+      related to the wallclock time at which the unit becomes current on
+      the virtual presentation timeline.  Actual presentation occurs
+      some time later as determined by the receiver.
+
+      An example describing live audio narration of prerecorded video
+      illustrates the significance of choosing the sampling instant as
+      the reference point.  In this scenario, the video would be
+      presented locally for the narrator to view and would be
+      simultaneously transmitted using RTP.  The "sampling instant" of a
+      video frame transmitted in RTP would be established by referencing
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 15]
+
+RFC 3550                          RTP                          July 2003
+
+
+      its timestamp to the wallclock time when that video frame was
+      presented to the narrator.  The sampling instant for the audio RTP
+      packets containing the narrator's speech would be established by
+      referencing the same wallclock time when the audio was sampled.
+      The audio and video may even be transmitted by different hosts if
+      the reference clocks on the two hosts are synchronized by some
+      means such as NTP.  A receiver can then synchronize presentation
+      of the audio and video packets by relating their RTP timestamps
+      using the timestamp pairs in RTCP SR packets.
+
+   SSRC: 32 bits
+      The SSRC field identifies the synchronization source.  This
+      identifier SHOULD be chosen randomly, with the intent that no two
+      synchronization sources within the same RTP session will have the
+      same SSRC identifier.  An example algorithm for generating a
+      random identifier is presented in Appendix A.6.  Although the
+      probability of multiple sources choosing the same identifier is
+      low, all RTP implementations must be prepared to detect and
+      resolve collisions.  Section 8 describes the probability of
+      collision along with a mechanism for resolving collisions and
+      detecting RTP-level forwarding loops based on the uniqueness of
+      the SSRC identifier.  If a source changes its source transport
+      address, it must also choose a new SSRC identifier to avoid being
+      interpreted as a looped source (see Section 8.2).
+
+   CSRC list: 0 to 15 items, 32 bits each
+      The CSRC list identifies the contributing sources for the payload
+      contained in this packet.  The number of identifiers is given by
+      the CC field.  If there are more than 15 contributing sources,
+      only 15 can be identified.  CSRC identifiers are inserted by
+      mixers (see Section 7.1), using the SSRC identifiers of
+      contributing sources.  For example, for audio packets the SSRC
+      identifiers of all sources that were mixed together to create a
+      packet are listed, allowing correct talker indication at the
+      receiver.
+
+5.2 Multiplexing RTP Sessions
+
+   For efficient protocol processing, the number of multiplexing points
+   should be minimized, as described in the integrated layer processing
+   design principle [10].  In RTP, multiplexing is provided by the
+   destination transport address (network address and port number) which
+   is different for each RTP session.  For example, in a teleconference
+   composed of audio and video media encoded separately, each medium
+   SHOULD be carried in a separate RTP session with its own destination
+   transport address.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 16]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Separate audio and video streams SHOULD NOT be carried in a single
+   RTP session and demultiplexed based on the payload type or SSRC
+   fields.  Interleaving packets with different RTP media types but
+   using the same SSRC would introduce several problems:
+
+   1. If, say, two audio streams shared the same RTP session and the
+      same SSRC value, and one were to change encodings and thus acquire
+      a different RTP payload type, there would be no general way of
+      identifying which stream had changed encodings.
+
+   2. An SSRC is defined to identify a single timing and sequence number
+      space.  Interleaving multiple payload types would require
+      different timing spaces if the media clock rates differ and would
+      require different sequence number spaces to tell which payload
+      type suffered packet loss.
+
+   3. The RTCP sender and receiver reports (see Section 6.4) can only
+      describe one timing and sequence number space per SSRC and do not
+      carry a payload type field.
+
+   4. An RTP mixer would not be able to combine interleaved streams of
+      incompatible media into one stream.
+
+   5. Carrying multiple media in one RTP session precludes: the use of
+      different network paths or network resource allocations if
+      appropriate; reception of a subset of the media if desired, for
+      example just audio if video would exceed the available bandwidth;
+      and receiver implementations that use separate processes for the
+      different media, whereas using separate RTP sessions permits
+      either single- or multiple-process implementations.
+
+   Using a different SSRC for each medium but sending them in the same
+   RTP session would avoid the first three problems but not the last
+   two.
+
+   On the other hand, multiplexing multiple related sources of the same
+   medium in one RTP session using different SSRC values is the norm for
+   multicast sessions.  The problems listed above don't apply: an RTP
+   mixer can combine multiple audio sources, for example, and the same
+   treatment is applicable for all of them.  It may also be appropriate
+   to multiplex streams of the same medium using different SSRC values
+   in other scenarios where the last two problems do not apply.
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 17]
+
+RFC 3550                          RTP                          July 2003
+
+
+5.3 Profile-Specific Modifications to the RTP Header
+
+   The existing RTP data packet header is believed to be complete for
+   the set of functions required in common across all the application
+   classes that RTP might support.  However, in keeping with the ALF
+   design principle, the header MAY be tailored through modifications or
+   additions defined in a profile specification while still allowing
+   profile-independent monitoring and recording tools to function.
+
+   o  The marker bit and payload type field carry profile-specific
+      information, but they are allocated in the fixed header since many
+      applications are expected to need them and might otherwise have to
+      add another 32-bit word just to hold them.  The octet containing
+      these fields MAY be redefined by a profile to suit different
+      requirements, for example with more or fewer marker bits.  If
+      there are any marker bits, one SHOULD be located in the most
+      significant bit of the octet since profile-independent monitors
+      may be able to observe a correlation between packet loss patterns
+      and the marker bit.
+
+   o  Additional information that is required for a particular payload
+      format, such as a video encoding, SHOULD be carried in the payload
+      section of the packet.  This might be in a header that is always
+      present at the start of the payload section, or might be indicated
+      by a reserved value in the data pattern.
+
+   o  If a particular class of applications needs additional
+      functionality independent of payload format, the profile under
+      which those applications operate SHOULD define additional fixed
+      fields to follow immediately after the SSRC field of the existing
+      fixed header.  Those applications will be able to quickly and
+      directly access the additional fields while profile-independent
+      monitors or recorders can still process the RTP packets by
+      interpreting only the first twelve octets.
+
+   If it turns out that additional functionality is needed in common
+   across all profiles, then a new version of RTP should be defined to
+   make a permanent change to the fixed header.
+
+5.3.1 RTP Header Extension
+
+   An extension mechanism is provided to allow individual
+   implementations to experiment with new payload-format-independent
+   functions that require additional information to be carried in the
+   RTP data packet header.  This mechanism is designed so that the
+   header extension may be ignored by other interoperating
+   implementations that have not been extended.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 18]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Note that this header extension is intended only for limited use.
+   Most potential uses of this mechanism would be better done another
+   way, using the methods described in the previous section.  For
+   example, a profile-specific extension to the fixed header is less
+   expensive to process because it is not conditional nor in a variable
+   location.  Additional information required for a particular payload
+   format SHOULD NOT use this header extension, but SHOULD be carried in
+   the payload section of the packet.
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |      defined by profile       |           length              |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                        header extension                       |
+   |                             ....                              |
+
+   If the X bit in the RTP header is one, a variable-length header
+   extension MUST be appended to the RTP header, following the CSRC list
+   if present.  The header extension contains a 16-bit length field that
+   counts the number of 32-bit words in the extension, excluding the
+   four-octet extension header (therefore zero is a valid length).  Only
+   a single extension can be appended to the RTP data header.  To allow
+   multiple interoperating implementations to each experiment
+   independently with different header extensions, or to allow a
+   particular implementation to experiment with more than one type of
+   header extension, the first 16 bits of the header extension are left
+   open for distinguishing identifiers or parameters.  The format of
+   these 16 bits is to be defined by the profile specification under
+   which the implementations are operating.  This RTP specification does
+   not define any header extensions itself.
+
+6. RTP Control Protocol -- RTCP
+
+   The RTP control protocol (RTCP) is based on the periodic transmission
+   of control packets to all participants in the session, using the same
+   distribution mechanism as the data packets.  The underlying protocol
+   MUST provide multiplexing of the data and control packets, for
+   example using separate port numbers with UDP.  RTCP performs four
+   functions:
+
+   1. The primary function is to provide feedback on the quality of the
+      data distribution.  This is an integral part of the RTP's role as
+      a transport protocol and is related to the flow and congestion
+      control functions of other transport protocols (see Section 10 on
+      the requirement for congestion control).  The feedback may be
+      directly useful for control of adaptive encodings [18,19], but
+      experiments with IP multicasting have shown that it is also
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 19]
+
+RFC 3550                          RTP                          July 2003
+
+
+      critical to get feedback from the receivers to diagnose faults in
+      the distribution.  Sending reception feedback reports to all
+      participants allows one who is observing problems to evaluate
+      whether those problems are local or global.  With a distribution
+      mechanism like IP multicast, it is also possible for an entity
+      such as a network service provider who is not otherwise involved
+      in the session to receive the feedback information and act as a
+      third-party monitor to diagnose network problems.  This feedback
+      function is performed by the RTCP sender and receiver reports,
+      described below in Section 6.4.
+
+   2. RTCP carries a persistent transport-level identifier for an RTP
+      source called the canonical name or CNAME, Section 6.5.1.  Since
+      the SSRC identifier may change if a conflict is discovered or a
+      program is restarted, receivers require the CNAME to keep track of
+      each participant.  Receivers may also require the CNAME to
+      associate multiple data streams from a given participant in a set
+      of related RTP sessions, for example to synchronize audio and
+      video.  Inter-media synchronization also requires the NTP and RTP
+      timestamps included in RTCP packets by data senders.
+
+   3. The first two functions require that all participants send RTCP
+      packets, therefore the rate must be controlled in order for RTP to
+      scale up to a large number of participants.  By having each
+      participant send its control packets to all the others, each can
+      independently observe the number of participants.  This number is
+      used to calculate the rate at which the packets are sent, as
+      explained in Section 6.2.
+
+   4. A fourth, OPTIONAL function is to convey minimal session control
+      information, for example participant identification to be
+      displayed in the user interface.  This is most likely to be useful
+      in "loosely controlled" sessions where participants enter and
+      leave without membership control or parameter negotiation.  RTCP
+      serves as a convenient channel to reach all the participants, but
+      it is not necessarily expected to support all the control
+      communication requirements of an application.  A higher-level
+      session control protocol, which is beyond the scope of this
+      document, may be needed.
+
+   Functions 1-3 SHOULD be used in all environments, but particularly in
+   the IP multicast environment.  RTP application designers SHOULD avoid
+   mechanisms that can only work in unicast mode and will not scale to
+   larger numbers.  Transmission of RTCP MAY be controlled separately
+   for senders and receivers, as described in Section 6.2, for cases
+   such as unidirectional links where feedback from receivers is not
+   possible.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 20]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Non-normative note:  In the multicast routing approach
+      called Source-Specific Multicast (SSM), there is only one sender
+      per "channel" (a source address, group address pair), and
+      receivers (except for the channel source) cannot use multicast to
+      communicate directly with other channel members.  The
+      recommendations here accommodate SSM only through Section 6.2's
+      option of turning off receivers' RTCP entirely.  Future work will
+      specify adaptation of RTCP for SSM so that feedback from receivers
+      can be maintained.
+
+6.1 RTCP Packet Format
+
+   This specification defines several RTCP packet types to carry a
+   variety of control information:
+
+   SR:   Sender report, for transmission and reception statistics from
+         participants that are active senders
+
+   RR:   Receiver report, for reception statistics from participants
+         that are not active senders and in combination with SR for
+         active senders reporting on more than 31 sources
+
+   SDES: Source description items, including CNAME
+
+   BYE:  Indicates end of participation
+
+   APP:  Application-specific functions
+
+   Each RTCP packet begins with a fixed part similar to that of RTP data
+   packets, followed by structured elements that MAY be of variable
+   length according to the packet type but MUST end on a 32-bit
+   boundary.  The alignment requirement and a length field in the fixed
+   part of each packet are included to make RTCP packets "stackable".
+   Multiple RTCP packets can be concatenated without any intervening
+   separators to form a compound RTCP packet that is sent in a single
+   packet of the lower layer protocol, for example UDP.  There is no
+   explicit count of individual RTCP packets in the compound packet
+   since the lower layer protocols are expected to provide an overall
+   length to determine the end of the compound packet.
+
+   Each individual RTCP packet in the compound packet may be processed
+   independently with no requirements upon the order or combination of
+   packets.  However, in order to perform the functions of the protocol,
+   the following constraints are imposed:
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 21]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  Reception statistics (in SR or RR) should be sent as often as
+      bandwidth constraints will allow to maximize the resolution of the
+      statistics, therefore each periodically transmitted compound RTCP
+      packet MUST include a report packet.
+
+   o  New receivers need to receive the CNAME for a source as soon as
+      possible to identify the source and to begin associating media for
+      purposes such as lip-sync, so each compound RTCP packet MUST also
+      include the SDES CNAME except when the compound RTCP packet is
+      split for partial encryption as described in Section 9.1.
+
+   o  The number of packet types that may appear first in the compound
+      packet needs to be limited to increase the number of constant bits
+      in the first word and the probability of successfully validating
+      RTCP packets against misaddressed RTP data packets or other
+      unrelated packets.
+
+   Thus, all RTCP packets MUST be sent in a compound packet of at least
+   two individual packets, with the following format:
+
+   Encryption prefix:  If and only if the compound packet is to be
+      encrypted according to the method in Section 9.1, it MUST be
+      prefixed by a random 32-bit quantity redrawn for every compound
+      packet transmitted.  If padding is required for the encryption, it
+      MUST be added to the last packet of the compound packet.
+
+   SR or RR:  The first RTCP packet in the compound packet MUST
+      always be a report packet to facilitate header validation as
+      described in Appendix A.2.  This is true even if no data has been
+      sent or received, in which case an empty RR MUST be sent, and even
+      if the only other RTCP packet in the compound packet is a BYE.
+
+   Additional RRs:  If the number of sources for which reception
+      statistics are being reported exceeds 31, the number that will fit
+      into one SR or RR packet, then additional RR packets SHOULD follow
+      the initial report packet.
+
+   SDES:  An SDES packet containing a CNAME item MUST be included
+      in each compound RTCP packet, except as noted in Section 9.1.
+      Other source description items MAY optionally be included if
+      required by a particular application, subject to bandwidth
+      constraints (see Section 6.3.9).
+
+   BYE or APP:  Other RTCP packet types, including those yet to be
+      defined, MAY follow in any order, except that BYE SHOULD be the
+      last packet sent with a given SSRC/CSRC.  Packet types MAY appear
+      more than once.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 22]
+
+RFC 3550                          RTP                          July 2003
+
+
+   An individual RTP participant SHOULD send only one compound RTCP
+   packet per report interval in order for the RTCP bandwidth per
+   participant to be estimated correctly (see Section 6.2), except when
+   the compound RTCP packet is split for partial encryption as described
+   in Section 9.1.  If there are too many sources to fit all the
+   necessary RR packets into one compound RTCP packet without exceeding
+   the maximum transmission unit (MTU) of the network path, then only
+   the subset that will fit into one MTU SHOULD be included in each
+   interval.  The subsets SHOULD be selected round-robin across multiple
+   intervals so that all sources are reported.
+
+   It is RECOMMENDED that translators and mixers combine individual RTCP
+   packets from the multiple sources they are forwarding into one
+   compound packet whenever feasible in order to amortize the packet
+   overhead (see Section 7).  An example RTCP compound packet as might
+   be produced by a mixer is shown in Fig. 1.  If the overall length of
+   a compound packet would exceed the MTU of the network path, it SHOULD
+   be segmented into multiple shorter compound packets to be transmitted
+   in separate packets of the underlying protocol.  This does not impair
+   the RTCP bandwidth estimation because each compound packet represents
+   at least one distinct participant.  Note that each of the compound
+   packets MUST begin with an SR or RR packet.
+
+   An implementation SHOULD ignore incoming RTCP packets with types
+   unknown to it.  Additional RTCP packet types may be registered with
+   the Internet Assigned Numbers Authority (IANA) as described in
+   Section 15.
+
+   if encrypted: random 32-bit integer
+   |
+   |[--------- packet --------][---------- packet ----------][-packet-]
+   |
+   |                receiver            chunk        chunk
+   V                reports           item  item   item  item
+   --------------------------------------------------------------------
+   R[SR #sendinfo #site1#site2][SDES #CNAME PHONE #CNAME LOC][BYE##why]
+   --------------------------------------------------------------------
+   |                                                                  |
+   |<-----------------------  compound packet ----------------------->|
+   |<--------------------------  UDP packet ------------------------->|
+
+   #: SSRC/CSRC identifier
+
+              Figure 1: Example of an RTCP compound packet
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 23]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.2 RTCP Transmission Interval
+
+   RTP is designed to allow an application to scale automatically over
+   session sizes ranging from a few participants to thousands.  For
+   example, in an audio conference the data traffic is inherently self-
+   limiting because only one or two people will speak at a time, so with
+   multicast distribution the data rate on any given link remains
+   relatively constant independent of the number of participants.
+   However, the control traffic is not self-limiting.  If the reception
+   reports from each participant were sent at a constant rate, the
+   control traffic would grow linearly with the number of participants.
+   Therefore, the rate must be scaled down by dynamically calculating
+   the interval between RTCP packet transmissions.
+
+   For each session, it is assumed that the data traffic is subject to
+   an aggregate limit called the "session bandwidth" to be divided among
+   the participants.  This bandwidth might be reserved and the limit
+   enforced by the network.  If there is no reservation, there may be
+   other constraints, depending on the environment, that establish the
+   "reasonable" maximum for the session to use, and that would be the
+   session bandwidth.  The session bandwidth may be chosen based on some
+   cost or a priori knowledge of the available network bandwidth for the
+   session.  It is somewhat independent of the media encoding, but the
+   encoding choice may be limited by the session bandwidth.  Often, the
+   session bandwidth is the sum of the nominal bandwidths of the senders
+   expected to be concurrently active.  For teleconference audio, this
+   number would typically be one sender's bandwidth.  For layered
+   encodings, each layer is a separate RTP session with its own session
+   bandwidth parameter.
+
+   The session bandwidth parameter is expected to be supplied by a
+   session management application when it invokes a media application,
+   but media applications MAY set a default based on the single-sender
+   data bandwidth for the encoding selected for the session.  The
+   application MAY also enforce bandwidth limits based on multicast
+   scope rules or other criteria.  All participants MUST use the same
+   value for the session bandwidth so that the same RTCP interval will
+   be calculated.
+
+   Bandwidth calculations for control and data traffic include lower-
+   layer transport and network protocols (e.g., UDP and IP) since that
+   is what the resource reservation system would need to know.  The
+   application can also be expected to know which of these protocols are
+   in use.  Link level headers are not included in the calculation since
+   the packet will be encapsulated with different link level headers as
+   it travels.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 24]
+
+RFC 3550                          RTP                          July 2003
+
+
+   The control traffic should be limited to a small and known fraction
+   of the session bandwidth: small so that the primary function of the
+   transport protocol to carry data is not impaired; known so that the
+   control traffic can be included in the bandwidth specification given
+   to a resource reservation protocol, and so that each participant can
+   independently calculate its share.  The control traffic bandwidth is
+   in addition to the session bandwidth for the data traffic.  It is
+   RECOMMENDED that the fraction of the session bandwidth added for RTCP
+   be fixed at 5%.  It is also RECOMMENDED that 1/4 of the RTCP
+   bandwidth be dedicated to participants that are sending data so that
+   in sessions with a large number of receivers but a small number of
+   senders, newly joining participants will more quickly receive the
+   CNAME for the sending sites.  When the proportion of senders is
+   greater than 1/4 of the participants, the senders get their
+   proportion of the full RTCP bandwidth.  While the values of these and
+   other constants in the interval calculation are not critical, all
+   participants in the session MUST use the same values so the same
+   interval will be calculated.  Therefore, these constants SHOULD be
+   fixed for a particular profile.
+
+   A profile MAY specify that the control traffic bandwidth may be a
+   separate parameter of the session rather than a strict percentage of
+   the session bandwidth.  Using a separate parameter allows rate-
+   adaptive applications to set an RTCP bandwidth consistent with a
+   "typical" data bandwidth that is lower than the maximum bandwidth
+   specified by the session bandwidth parameter.
+
+   The profile MAY further specify that the control traffic bandwidth
+   may be divided into two separate session parameters for those
+   participants which are active data senders and those which are not;
+   let us call the parameters S and R.  Following the recommendation
+   that 1/4 of the RTCP bandwidth be dedicated to data senders, the
+   RECOMMENDED default values for these two parameters would be 1.25%
+   and 3.75%, respectively.  When the proportion of senders is greater
+   than S/(S+R) of the participants, the senders get their proportion of
+   the sum of these parameters.  Using two parameters allows RTCP
+   reception reports to be turned off entirely for a particular session
+   by setting the RTCP bandwidth for non-data-senders to zero while
+   keeping the RTCP bandwidth for data senders non-zero so that sender
+   reports can still be sent for inter-media synchronization.  Turning
+   off RTCP reception reports is NOT RECOMMENDED because they are needed
+   for the functions listed at the beginning of Section 6, particularly
+   reception quality feedback and congestion control.  However, doing so
+   may be appropriate for systems operating on unidirectional links or
+   for sessions that don't require feedback on the quality of reception
+   or liveness of receivers and that have other means to avoid
+   congestion.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 25]
+
+RFC 3550                          RTP                          July 2003
+
+
+   The calculated interval between transmissions of compound RTCP
+   packets SHOULD also have a lower bound to avoid having bursts of
+   packets exceed the allowed bandwidth when the number of participants
+   is small and the traffic isn't smoothed according to the law of large
+   numbers.  It also keeps the report interval from becoming too small
+   during transient outages like a network partition such that
+   adaptation is delayed when the partition heals.  At application
+   startup, a delay SHOULD be imposed before the first compound RTCP
+   packet is sent to allow time for RTCP packets to be received from
+   other participants so the report interval will converge to the
+   correct value more quickly.  This delay MAY be set to half the
+   minimum interval to allow quicker notification that the new
+   participant is present.  The RECOMMENDED value for a fixed minimum
+   interval is 5 seconds.
+
+   An implementation MAY scale the minimum RTCP interval to a smaller
+   value inversely proportional to the session bandwidth parameter with
+   the following limitations:
+
+   o  For multicast sessions, only active data senders MAY use the
+      reduced minimum value to calculate the interval for transmission
+      of compound RTCP packets.
+
+   o  For unicast sessions, the reduced value MAY be used by
+      participants that are not active data senders as well, and the
+      delay before sending the initial compound RTCP packet MAY be zero.
+
+   o  For all sessions, the fixed minimum SHOULD be used when
+      calculating the participant timeout interval (see Section 6.3.5)
+      so that implementations which do not use the reduced value for
+      transmitting RTCP packets are not timed out by other participants
+      prematurely.
+
+   o  The RECOMMENDED value for the reduced minimum in seconds is 360
+      divided by the session bandwidth in kilobits/second.  This minimum
+      is smaller than 5 seconds for bandwidths greater than 72 kb/s.
+
+   The algorithm described in Section 6.3 and Appendix A.7 was designed
+   to meet the goals outlined in this section.  It calculates the
+   interval between sending compound RTCP packets to divide the allowed
+   control traffic bandwidth among the participants.  This allows an
+   application to provide fast response for small sessions where, for
+   example, identification of all participants is important, yet
+   automatically adapt to large sessions.  The algorithm incorporates
+   the following characteristics:
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 26]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  The calculated interval between RTCP packets scales linearly with
+      the number of members in the group.  It is this linear factor
+      which allows for a constant amount of control traffic when summed
+      across all members.
+
+   o  The interval between RTCP packets is varied randomly over the
+      range [0.5,1.5] times the calculated interval to avoid unintended
+      synchronization of all participants [20].  The first RTCP packet
+      sent after joining a session is also delayed by a random variation
+      of half the minimum RTCP interval.
+
+   o  A dynamic estimate of the average compound RTCP packet size is
+      calculated, including all those packets received and sent, to
+      automatically adapt to changes in the amount of control
+      information carried.
+
+   o  Since the calculated interval is dependent on the number of
+      observed group members, there may be undesirable startup effects
+      when a new user joins an existing session, or many users
+      simultaneously join a new session.  These new users will initially
+      have incorrect estimates of the group membership, and thus their
+      RTCP transmission interval will be too short.  This problem can be
+      significant if many users join the session simultaneously.  To
+      deal with this, an algorithm called "timer reconsideration" is
+      employed.  This algorithm implements a simple back-off mechanism
+      which causes users to hold back RTCP packet transmission if the
+      group sizes are increasing.
+
+   o  When users leave a session, either with a BYE or by timeout, the
+      group membership decreases, and thus the calculated interval
+      should decrease.  A "reverse reconsideration" algorithm is used to
+      allow members to more quickly reduce their intervals in response
+      to group membership decreases.
+
+   o  BYE packets are given different treatment than other RTCP packets.
+      When a user leaves a group, and wishes to send a BYE packet, it
+      may do so before its next scheduled RTCP packet.  However,
+      transmission of BYEs follows a back-off algorithm which avoids
+      floods of BYE packets should a large number of members
+      simultaneously leave the session.
+
+   This algorithm may be used for sessions in which all participants are
+   allowed to send.  In that case, the session bandwidth parameter is
+   the product of the individual sender's bandwidth times the number of
+   participants, and the RTCP bandwidth is 5% of that.
+
+   Details of the algorithm's operation are given in the sections that
+   follow.  Appendix A.7 gives an example implementation.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 27]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.2.1 Maintaining the Number of Session Members
+
+   Calculation of the RTCP packet interval depends upon an estimate of
+   the number of sites participating in the session.  New sites are
+   added to the count when they are heard, and an entry for each SHOULD
+   be created in a table indexed by the SSRC or CSRC identifier (see
+   Section 8.2) to keep track of them.  New entries MAY be considered
+   not valid until multiple packets carrying the new SSRC have been
+   received (see Appendix A.1), or until an SDES RTCP packet containing
+   a CNAME for that SSRC has been received.  Entries MAY be deleted from
+   the table when an RTCP BYE packet with the corresponding SSRC
+   identifier is received, except that some straggler data packets might
+   arrive after the BYE and cause the entry to be recreated.  Instead,
+   the entry SHOULD be marked as having received a BYE and then deleted
+   after an appropriate delay.
+
+   A participant MAY mark another site inactive, or delete it if not yet
+   valid, if no RTP or RTCP packet has been received for a small number
+   of RTCP report intervals (5 is RECOMMENDED).  This provides some
+   robustness against packet loss.  All sites must have the same value
+   for this multiplier and must calculate roughly the same value for the
+   RTCP report interval in order for this timeout to work properly.
+   Therefore, this multiplier SHOULD be fixed for a particular profile.
+
+   For sessions with a very large number of participants, it may be
+   impractical to maintain a table to store the SSRC identifier and
+   state information for all of them.  An implementation MAY use SSRC
+   sampling, as described in [21], to reduce the storage requirements.
+   An implementation MAY use any other algorithm with similar
+   performance.  A key requirement is that any algorithm considered
+   SHOULD NOT substantially underestimate the group size, although it
+   MAY overestimate.
+
+6.3 RTCP Packet Send and Receive Rules
+
+   The rules for how to send, and what to do when receiving an RTCP
+   packet are outlined here.  An implementation that allows operation in
+   a multicast environment or a multipoint unicast environment MUST meet
+   the requirements in Section 6.2.  Such an implementation MAY use the
+   algorithm defined in this section to meet those requirements, or MAY
+   use some other algorithm so long as it provides equivalent or better
+   performance.  An implementation which is constrained to two-party
+   unicast operation SHOULD still use randomization of the RTCP
+   transmission interval to avoid unintended synchronization of multiple
+   instances operating in the same environment, but MAY omit the "timer
+   reconsideration" and "reverse reconsideration" algorithms in Sections
+   6.3.3, 6.3.6 and 6.3.7.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 28]
+
+RFC 3550                          RTP                          July 2003
+
+
+   To execute these rules, a session participant must maintain several
+   pieces of state:
+
+   tp: the last time an RTCP packet was transmitted;
+
+   tc: the current time;
+
+   tn: the next scheduled transmission time of an RTCP packet;
+
+   pmembers: the estimated number of session members at the time tn
+      was last recomputed;
+
+   members: the most current estimate for the number of session
+      members;
+
+   senders: the most current estimate for the number of senders in
+      the session;
+
+   rtcp_bw: The target RTCP bandwidth, i.e., the total bandwidth
+      that will be used for RTCP packets by all members of this session,
+      in octets per second.  This will be a specified fraction of the
+      "session bandwidth" parameter supplied to the application at
+      startup.
+
+   we_sent: Flag that is true if the application has sent data
+      since the 2nd previous RTCP report was transmitted.
+
+   avg_rtcp_size: The average compound RTCP packet size, in octets,
+      over all RTCP packets sent and received by this participant.  The
+      size includes lower-layer transport and network protocol headers
+      (e.g., UDP and IP) as explained in Section 6.2.
+
+   initial: Flag that is true if the application has not yet sent
+      an RTCP packet.
+
+   Many of these rules make use of the "calculated interval" between
+   packet transmissions.  This interval is described in the following
+   section.
+
+6.3.1 Computing the RTCP Transmission Interval
+
+   To maintain scalability, the average interval between packets from a
+   session participant should scale with the group size.  This interval
+   is called the calculated interval.  It is obtained by combining a
+   number of the pieces of state described above.  The calculated
+   interval T is then determined as follows:
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 29]
+
+RFC 3550                          RTP                          July 2003
+
+
+   1. If the number of senders is less than or equal to 25% of the
+      membership (members), the interval depends on whether the
+      participant is a sender or not (based on the value of we_sent).
+      If the participant is a sender (we_sent true), the constant C is
+      set to the average RTCP packet size (avg_rtcp_size) divided by 25%
+      of the RTCP bandwidth (rtcp_bw), and the constant n is set to the
+      number of senders.  If we_sent is not true, the constant C is set
+      to the average RTCP packet size divided by 75% of the RTCP
+      bandwidth.  The constant n is set to the number of receivers
+      (members - senders).  If the number of senders is greater than
+      25%, senders and receivers are treated together.  The constant C
+      is set to the average RTCP packet size divided by the total RTCP
+      bandwidth and n is set to the total number of members.  As stated
+      in Section 6.2, an RTP profile MAY specify that the RTCP bandwidth
+      may be explicitly defined by two separate parameters (call them S
+      and R) for those participants which are senders and those which
+      are not.  In that case, the 25% fraction becomes S/(S+R) and the
+      75% fraction becomes R/(S+R).  Note that if R is zero, the
+      percentage of senders is never greater than S/(S+R), and the
+      implementation must avoid division by zero.
+
+   2. If the participant has not yet sent an RTCP packet (the variable
+      initial is true), the constant Tmin is set to 2.5 seconds, else it
+      is set to 5 seconds.
+
+   3. The deterministic calculated interval Td is set to max(Tmin, n*C).
+
+   4. The calculated interval T is set to a number uniformly distributed
+      between 0.5 and 1.5 times the deterministic calculated interval.
+
+   5. The resulting value of T is divided by e-3/2=1.21828 to compensate
+      for the fact that the timer reconsideration algorithm converges to
+      a value of the RTCP bandwidth below the intended average.
+
+   This procedure results in an interval which is random, but which, on
+   average, gives at least 25% of the RTCP bandwidth to senders and the
+   rest to receivers.  If the senders constitute more than one quarter
+   of the membership, this procedure splits the bandwidth equally among
+   all participants, on average.
+
+6.3.2 Initialization
+
+   Upon joining the session, the participant initializes tp to 0, tc to
+   0, senders to 0, pmembers to 1, members to 1, we_sent to false,
+   rtcp_bw to the specified fraction of the session bandwidth, initial
+   to true, and avg_rtcp_size to the probable size of the first RTCP
+   packet that the application will later construct.  The calculated
+   interval T is then computed, and the first packet is scheduled for
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 30]
+
+RFC 3550                          RTP                          July 2003
+
+
+   time tn = T.  This means that a transmission timer is set which
+   expires at time T.  Note that an application MAY use any desired
+   approach for implementing this timer.
+
+   The participant adds its own SSRC to the member table.
+
+6.3.3 Receiving an RTP or Non-BYE RTCP Packet
+
+   When an RTP or RTCP packet is received from a participant whose SSRC
+   is not in the member table, the SSRC is added to the table, and the
+   value for members is updated once the participant has been validated
+   as described in Section 6.2.1.  The same processing occurs for each
+   CSRC in a validated RTP packet.
+
+   When an RTP packet is received from a participant whose SSRC is not
+   in the sender table, the SSRC is added to the table, and the value
+   for senders is updated.
+
+   For each compound RTCP packet received, the value of avg_rtcp_size is
+   updated:
+
+      avg_rtcp_size = (1/16) * packet_size + (15/16) * avg_rtcp_size
+
+   where packet_size is the size of the RTCP packet just received.
+
+6.3.4 Receiving an RTCP BYE Packet
+
+   Except as described in Section 6.3.7 for the case when an RTCP BYE is
+   to be transmitted, if the received packet is an RTCP BYE packet, the
+   SSRC is checked against the member table.  If present, the entry is
+   removed from the table, and the value for members is updated.  The
+   SSRC is then checked against the sender table.  If present, the entry
+   is removed from the table, and the value for senders is updated.
+
+   Furthermore, to make the transmission rate of RTCP packets more
+   adaptive to changes in group membership, the following "reverse
+   reconsideration" algorithm SHOULD be executed when a BYE packet is
+   received that reduces members to a value less than pmembers:
+
+   o  The value for tn is updated according to the following formula:
+
+         tn = tc + (members/pmembers) * (tn - tc)
+
+   o  The value for tp is updated according the following formula:
+
+         tp = tc - (members/pmembers) * (tc - tp).
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 31]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  The next RTCP packet is rescheduled for transmission at time tn,
+      which is now earlier.
+
+   o  The value of pmembers is set equal to members.
+
+   This algorithm does not prevent the group size estimate from
+   incorrectly dropping to zero for a short time due to premature
+   timeouts when most participants of a large session leave at once but
+   some remain.  The algorithm does make the estimate return to the
+   correct value more rapidly.  This situation is unusual enough and the
+   consequences are sufficiently harmless that this problem is deemed
+   only a secondary concern.
+
+6.3.5 Timing Out an SSRC
+
+   At occasional intervals, the participant MUST check to see if any of
+   the other participants time out.  To do this, the participant
+   computes the deterministic (without the randomization factor)
+   calculated interval Td for a receiver, that is, with we_sent false.
+   Any other session member who has not sent an RTP or RTCP packet since
+   time tc - MTd (M is the timeout multiplier, and defaults to 5) is
+   timed out.  This means that its SSRC is removed from the member list,
+   and members is updated.  A similar check is performed on the sender
+   list.  Any member on the sender list who has not sent an RTP packet
+   since time tc - 2T (within the last two RTCP report intervals) is
+   removed from the sender list, and senders is updated.
+
+   If any members time out, the reverse reconsideration algorithm
+   described in Section 6.3.4 SHOULD be performed.
+
+   The participant MUST perform this check at least once per RTCP
+   transmission interval.
+
+6.3.6 Expiration of Transmission Timer
+
+   When the packet transmission timer expires, the participant performs
+   the following operations:
+
+   o  The transmission interval T is computed as described in Section
+      6.3.1, including the randomization factor.
+
+   o  If tp + T is less than or equal to tc, an RTCP packet is
+      transmitted.  tp is set to tc, then another value for T is
+      calculated as in the previous step and tn is set to tc + T.  The
+      transmission timer is set to expire again at time tn.  If tp + T
+      is greater than tc, tn is set to tp + T.  No RTCP packet is
+      transmitted.  The transmission timer is set to expire at time tn.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 32]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  pmembers is set to members.
+
+   If an RTCP packet is transmitted, the value of initial is set to
+   FALSE.  Furthermore, the value of avg_rtcp_size is updated:
+
+      avg_rtcp_size = (1/16) * packet_size + (15/16) * avg_rtcp_size
+
+   where packet_size is the size of the RTCP packet just transmitted.
+
+6.3.7 Transmitting a BYE Packet
+
+   When a participant wishes to leave a session, a BYE packet is
+   transmitted to inform the other participants of the event.  In order
+   to avoid a flood of BYE packets when many participants leave the
+   system, a participant MUST execute the following algorithm if the
+   number of members is more than 50 when the participant chooses to
+   leave.  This algorithm usurps the normal role of the members variable
+   to count BYE packets instead:
+
+   o  When the participant decides to leave the system, tp is reset to
+      tc, the current time, members and pmembers are initialized to 1,
+      initial is set to 1, we_sent is set to false, senders is set to 0,
+      and avg_rtcp_size is set to the size of the compound BYE packet.
+      The calculated interval T is computed.  The BYE packet is then
+      scheduled for time tn = tc + T.
+
+   o  Every time a BYE packet from another participant is received,
+      members is incremented by 1 regardless of whether that participant
+      exists in the member table or not, and when SSRC sampling is in
+      use, regardless of whether or not the BYE SSRC would be included
+      in the sample.  members is NOT incremented when other RTCP packets
+      or RTP packets are received, but only for BYE packets.  Similarly,
+      avg_rtcp_size is updated only for received BYE packets.  senders
+      is NOT updated when RTP packets arrive; it remains 0.
+
+   o  Transmission of the BYE packet then follows the rules for
+      transmitting a regular RTCP packet, as above.
+
+   This allows BYE packets to be sent right away, yet controls their
+   total bandwidth usage.  In the worst case, this could cause RTCP
+   control packets to use twice the bandwidth as normal (10%) -- 5% for
+   non-BYE RTCP packets and 5% for BYE.
+
+   A participant that does not want to wait for the above mechanism to
+   allow transmission of a BYE packet MAY leave the group without
+   sending a BYE at all.  That participant will eventually be timed out
+   by the other group members.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 33]
+
+RFC 3550                          RTP                          July 2003
+
+
+   If the group size estimate members is less than 50 when the
+   participant decides to leave, the participant MAY send a BYE packet
+   immediately.  Alternatively, the participant MAY choose to execute
+   the above BYE backoff algorithm.
+
+   In either case, a participant which never sent an RTP or RTCP packet
+   MUST NOT send a BYE packet when they leave the group.
+
+6.3.8 Updating we_sent
+
+   The variable we_sent contains true if the participant has sent an RTP
+   packet recently, false otherwise.  This determination is made by
+   using the same mechanisms as for managing the set of other
+   participants listed in the senders table.  If the participant sends
+   an RTP packet when we_sent is false, it adds itself to the sender
+   table and sets we_sent to true.  The reverse reconsideration
+   algorithm described in Section 6.3.4 SHOULD be performed to possibly
+   reduce the delay before sending an SR packet.  Every time another RTP
+   packet is sent, the time of transmission of that packet is maintained
+   in the table.  The normal sender timeout algorithm is then applied to
+   the participant -- if an RTP packet has not been transmitted since
+   time tc - 2T, the participant removes itself from the sender table,
+   decrements the sender count, and sets we_sent to false.
+
+6.3.9 Allocation of Source Description Bandwidth
+
+   This specification defines several source description (SDES) items in
+   addition to the mandatory CNAME item, such as NAME (personal name)
+   and EMAIL (email address).  It also provides a means to define new
+   application-specific RTCP packet types.  Applications should exercise
+   caution in allocating control bandwidth to this additional
+   information because it will slow down the rate at which reception
+   reports and CNAME are sent, thus impairing the performance of the
+   protocol.  It is RECOMMENDED that no more than 20% of the RTCP
+   bandwidth allocated to a single participant be used to carry the
+   additional information.  Furthermore, it is not intended that all
+   SDES items will be included in every application.  Those that are
+   included SHOULD be assigned a fraction of the bandwidth according to
+   their utility.  Rather than estimate these fractions dynamically, it
+   is recommended that the percentages be translated statically into
+   report interval counts based on the typical length of an item.
+
+   For example, an application may be designed to send only CNAME, NAME
+   and EMAIL and not any others.  NAME might be given much higher
+   priority than EMAIL because the NAME would be displayed continuously
+   in the application's user interface, whereas EMAIL would be displayed
+   only when requested.  At every RTCP interval, an RR packet and an
+   SDES packet with the CNAME item would be sent.  For a small session
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 34]
+
+RFC 3550                          RTP                          July 2003
+
+
+   operating at the minimum interval, that would be every 5 seconds on
+   the average.  Every third interval (15 seconds), one extra item would
+   be included in the SDES packet.  Seven out of eight times this would
+   be the NAME item, and every eighth time (2 minutes) it would be the
+   EMAIL item.
+
+   When multiple applications operate in concert using cross-application
+   binding through a common CNAME for each participant, for example in a
+   multimedia conference composed of an RTP session for each medium, the
+   additional SDES information MAY be sent in only one RTP session.  The
+   other sessions would carry only the CNAME item.  In particular, this
+   approach should be applied to the multiple sessions of a layered
+   encoding scheme (see Section 2.4).
+
+6.4 Sender and Receiver Reports
+
+   RTP receivers provide reception quality feedback using RTCP report
+   packets which may take one of two forms depending upon whether or not
+   the receiver is also a sender.  The only difference between the
+   sender report (SR) and receiver report (RR) forms, besides the packet
+   type code, is that the sender report includes a 20-byte sender
+   information section for use by active senders.  The SR is issued if a
+   site has sent any data packets during the interval since issuing the
+   last report or the previous one, otherwise the RR is issued.
+
+   Both the SR and RR forms include zero or more reception report
+   blocks, one for each of the synchronization sources from which this
+   receiver has received RTP data packets since the last report.
+   Reports are not issued for contributing sources listed in the CSRC
+   list.  Each reception report block provides statistics about the data
+   received from the particular source indicated in that block.  Since a
+   maximum of 31 reception report blocks will fit in an SR or RR packet,
+   additional RR packets SHOULD be stacked after the initial SR or RR
+   packet as needed to contain the reception reports for all sources
+   heard during the interval since the last report.  If there are too
+   many sources to fit all the necessary RR packets into one compound
+   RTCP packet without exceeding the MTU of the network path, then only
+   the subset that will fit into one MTU SHOULD be included in each
+   interval.  The subsets SHOULD be selected round-robin across multiple
+   intervals so that all sources are reported.
+
+   The next sections define the formats of the two reports, how they may
+   be extended in a profile-specific manner if an application requires
+   additional feedback information, and how the reports may be used.
+   Details of reception reporting by translators and mixers is given in
+   Section 7.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 35]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.4.1 SR: Sender Report RTCP Packet
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    RC   |   PT=SR=200   |             length            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         SSRC of sender                        |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+sender |              NTP timestamp, most significant word             |
+info   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |             NTP timestamp, least significant word             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         RTP timestamp                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                     sender's packet count                     |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      sender's octet count                     |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_1 (SSRC of first source)                 |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  1    | fraction lost |       cumulative number of packets lost       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |           extended highest sequence number received           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      interarrival jitter                      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         last SR (LSR)                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   delay since last SR (DLSR)                  |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_2 (SSRC of second source)                |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  2    :                               ...                             :
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+       |                  profile-specific extensions                  |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The sender report packet consists of three sections, possibly
+   followed by a fourth profile-specific extension section if defined.
+   The first section, the header, is 8 octets long.  The fields have the
+   following meaning:
+
+   version (V): 2 bits
+      Identifies the version of RTP, which is the same in RTCP packets
+      as in RTP data packets.  The version defined by this specification
+      is two (2).
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 36]
+
+RFC 3550                          RTP                          July 2003
+
+
+   padding (P): 1 bit
+      If the padding bit is set, this individual RTCP packet contains
+      some additional padding octets at the end which are not part of
+      the control information but are included in the length field.  The
+      last octet of the padding is a count of how many padding octets
+      should be ignored, including itself (it will be a multiple of
+      four).  Padding may be needed by some encryption algorithms with
+      fixed block sizes.  In a compound RTCP packet, padding is only
+      required on one individual packet because the compound packet is
+      encrypted as a whole for the method in Section 9.1.  Thus, padding
+      MUST only be added to the last individual packet, and if padding
+      is added to that packet, the padding bit MUST be set only on that
+      packet.  This convention aids the header validity checks described
+      in Appendix A.2 and allows detection of packets from some early
+      implementations that incorrectly set the padding bit on the first
+      individual packet and add padding to the last individual packet.
+
+   reception report count (RC): 5 bits
+      The number of reception report blocks contained in this packet.  A
+      value of zero is valid.
+
+   packet type (PT): 8 bits
+      Contains the constant 200 to identify this as an RTCP SR packet.
+
+   length: 16 bits
+      The length of this RTCP packet in 32-bit words minus one,
+      including the header and any padding.  (The offset of one makes
+      zero a valid length and avoids a possible infinite loop in
+      scanning a compound RTCP packet, while counting 32-bit words
+      avoids a validity check for a multiple of 4.)
+
+   SSRC: 32 bits
+      The synchronization source identifier for the originator of this
+      SR packet.
+
+   The second section, the sender information, is 20 octets long and is
+   present in every sender report packet.  It summarizes the data
+   transmissions from this sender.  The fields have the following
+   meaning:
+
+   NTP timestamp: 64 bits
+      Indicates the wallclock time (see Section 4) when this report was
+      sent so that it may be used in combination with timestamps
+      returned in reception reports from other receivers to measure
+      round-trip propagation to those receivers.  Receivers should
+      expect that the measurement accuracy of the timestamp may be
+      limited to far less than the resolution of the NTP timestamp.  The
+      measurement uncertainty of the timestamp is not indicated as it
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 37]
+
+RFC 3550                          RTP                          July 2003
+
+
+      may not be known.  On a system that has no notion of wallclock
+      time but does have some system-specific clock such as "system
+      uptime", a sender MAY use that clock as a reference to calculate
+      relative NTP timestamps.  It is important to choose a commonly
+      used clock so that if separate implementations are used to produce
+      the individual streams of a multimedia session, all
+      implementations will use the same clock.  Until the year 2036,
+      relative and absolute timestamps will differ in the high bit so
+      (invalid) comparisons will show a large difference; by then one
+      hopes relative timestamps will no longer be needed.  A sender that
+      has no notion of wallclock or elapsed time MAY set the NTP
+      timestamp to zero.
+
+   RTP timestamp: 32 bits
+      Corresponds to the same time as the NTP timestamp (above), but in
+      the same units and with the same random offset as the RTP
+      timestamps in data packets.  This correspondence may be used for
+      intra- and inter-media synchronization for sources whose NTP
+      timestamps are synchronized, and may be used by media-independent
+      receivers to estimate the nominal RTP clock frequency.  Note that
+      in most cases this timestamp will not be equal to the RTP
+      timestamp in any adjacent data packet.  Rather, it MUST be
+      calculated from the corresponding NTP timestamp using the
+      relationship between the RTP timestamp counter and real time as
+      maintained by periodically checking the wallclock time at a
+      sampling instant.
+
+   sender's packet count: 32 bits
+      The total number of RTP data packets transmitted by the sender
+      since starting transmission up until the time this SR packet was
+      generated.  The count SHOULD be reset if the sender changes its
+      SSRC identifier.
+
+   sender's octet count: 32 bits
+      The total number of payload octets (i.e., not including header or
+      padding) transmitted in RTP data packets by the sender since
+      starting transmission up until the time this SR packet was
+      generated.  The count SHOULD be reset if the sender changes its
+      SSRC identifier.  This field can be used to estimate the average
+      payload data rate.
+
+   The third section contains zero or more reception report blocks
+   depending on the number of other sources heard by this sender since
+   the last report.  Each reception report block conveys statistics on
+   the reception of RTP packets from a single synchronization source.
+   Receivers SHOULD NOT carry over statistics when a source changes its
+   SSRC identifier due to a collision.  These statistics are:
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 38]
+
+RFC 3550                          RTP                          July 2003
+
+
+   SSRC_n (source identifier): 32 bits
+      The SSRC identifier of the source to which the information in this
+      reception report block pertains.
+
+   fraction lost: 8 bits
+      The fraction of RTP data packets from source SSRC_n lost since the
+      previous SR or RR packet was sent, expressed as a fixed point
+      number with the binary point at the left edge of the field.  (That
+      is equivalent to taking the integer part after multiplying the
+      loss fraction by 256.)  This fraction is defined to be the number
+      of packets lost divided by the number of packets expected, as
+      defined in the next paragraph.  An implementation is shown in
+      Appendix A.3.  If the loss is negative due to duplicates, the
+      fraction lost is set to zero.  Note that a receiver cannot tell
+      whether any packets were lost after the last one received, and
+      that there will be no reception report block issued for a source
+      if all packets from that source sent during the last reporting
+      interval have been lost.
+
+   cumulative number of packets lost: 24 bits
+      The total number of RTP data packets from source SSRC_n that have
+      been lost since the beginning of reception.  This number is
+      defined to be the number of packets expected less the number of
+      packets actually received, where the number of packets received
+      includes any which are late or duplicates.  Thus, packets that
+      arrive late are not counted as lost, and the loss may be negative
+      if there are duplicates.  The number of packets expected is
+      defined to be the extended last sequence number received, as
+      defined next, less the initial sequence number received.  This may
+      be calculated as shown in Appendix A.3.
+
+   extended highest sequence number received: 32 bits
+      The low 16 bits contain the highest sequence number received in an
+      RTP data packet from source SSRC_n, and the most significant 16
+      bits extend that sequence number with the corresponding count of
+      sequence number cycles, which may be maintained according to the
+      algorithm in Appendix A.1.  Note that different receivers within
+      the same session will generate different extensions to the
+      sequence number if their start times differ significantly.
+
+   interarrival jitter: 32 bits
+      An estimate of the statistical variance of the RTP data packet
+      interarrival time, measured in timestamp units and expressed as an
+      unsigned integer.  The interarrival jitter J is defined to be the
+      mean deviation (smoothed absolute value) of the difference D in
+      packet spacing at the receiver compared to the sender for a pair
+      of packets.  As shown in the equation below, this is equivalent to
+      the difference in the "relative transit time" for the two packets;
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 39]
+
+RFC 3550                          RTP                          July 2003
+
+
+      the relative transit time is the difference between a packet's RTP
+      timestamp and the receiver's clock at the time of arrival,
+      measured in the same units.
+
+      If Si is the RTP timestamp from packet i, and Ri is the time of
+      arrival in RTP timestamp units for packet i, then for two packets
+      i and j, D may be expressed as
+
+         D(i,j) = (Rj - Ri) - (Sj - Si) = (Rj - Sj) - (Ri - Si)
+
+      The interarrival jitter SHOULD be calculated continuously as each
+      data packet i is received from source SSRC_n, using this
+      difference D for that packet and the previous packet i-1 in order
+      of arrival (not necessarily in sequence), according to the formula
+
+         J(i) = J(i-1) + (|D(i-1,i)| - J(i-1))/16
+
+      Whenever a reception report is issued, the current value of J is
+      sampled.
+
+      The jitter calculation MUST conform to the formula specified here
+      in order to allow profile-independent monitors to make valid
+      interpretations of reports coming from different implementations.
+      This algorithm is the optimal first-order estimator and the gain
+      parameter 1/16 gives a good noise reduction ratio while
+      maintaining a reasonable rate of convergence [22].  A sample
+      implementation is shown in Appendix A.8.  See Section 6.4.4 for a
+      discussion of the effects of varying packet duration and delay
+      before transmission.
+
+   last SR timestamp (LSR): 32 bits
+      The middle 32 bits out of 64 in the NTP timestamp (as explained in
+      Section 4) received as part of the most recent RTCP sender report
+      (SR) packet from source SSRC_n.  If no SR has been received yet,
+      the field is set to zero.
+
+   delay since last SR (DLSR): 32 bits
+      The delay, expressed in units of 1/65536 seconds, between
+      receiving the last SR packet from source SSRC_n and sending this
+      reception report block.  If no SR packet has been received yet
+      from SSRC_n, the DLSR field is set to zero.
+
+      Let SSRC_r denote the receiver issuing this receiver report.
+      Source SSRC_n can compute the round-trip propagation delay to
+      SSRC_r by recording the time A when this reception report block is
+      received.  It calculates the total round-trip time A-LSR using the
+      last SR timestamp (LSR) field, and then subtracting this field to
+      leave the round-trip propagation delay as (A - LSR - DLSR).  This
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 40]
+
+RFC 3550                          RTP                          July 2003
+
+
+      is illustrated in Fig. 2.  Times are shown in both a hexadecimal
+      representation of the 32-bit fields and the equivalent floating-
+      point decimal representation.  Colons indicate a 32-bit field
+      divided into a 16-bit integer part and 16-bit fraction part.
+
+      This may be used as an approximate measure of distance to cluster
+      receivers, although some links have very asymmetric delays.
+
+   [10 Nov 1995 11:33:25.125 UTC]       [10 Nov 1995 11:33:36.5 UTC]
+   n                 SR(n)              A=b710:8000 (46864.500 s)
+   ---------------------------------------------------------------->
+                      v                 ^
+   ntp_sec =0xb44db705 v               ^ dlsr=0x0005:4000 (    5.250s)
+   ntp_frac=0x20000000  v             ^  lsr =0xb705:2000 (46853.125s)
+     (3024992005.125 s)  v           ^
+   r                      v         ^ RR(n)
+   ---------------------------------------------------------------->
+                          |<-DLSR->|
+                           (5.250 s)
+
+   A     0xb710:8000 (46864.500 s)
+   DLSR -0x0005:4000 (    5.250 s)
+   LSR  -0xb705:2000 (46853.125 s)
+   -------------------------------
+   delay 0x0006:2000 (    6.125 s)
+
+           Figure 2: Example for round-trip time computation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 41]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.4.2 RR: Receiver Report RTCP Packet
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    RC   |   PT=RR=201   |             length            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                     SSRC of packet sender                     |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_1 (SSRC of first source)                 |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  1    | fraction lost |       cumulative number of packets lost       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |           extended highest sequence number received           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      interarrival jitter                      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         last SR (LSR)                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   delay since last SR (DLSR)                  |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+report |                 SSRC_2 (SSRC of second source)                |
+block  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  2    :                               ...                             :
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+       |                  profile-specific extensions                  |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The format of the receiver report (RR) packet is the same as that of
+   the SR packet except that the packet type field contains the constant
+   201 and the five words of sender information are omitted (these are
+   the NTP and RTP timestamps and sender's packet and octet counts).
+   The remaining fields have the same meaning as for the SR packet.
+
+   An empty RR packet (RC = 0) MUST be put at the head of a compound
+   RTCP packet when there is no data transmission or reception to
+   report.
+
+6.4.3 Extending the Sender and Receiver Reports
+
+   A profile SHOULD define profile-specific extensions to the sender
+   report and receiver report if there is additional information that
+   needs to be reported regularly about the sender or receivers.  This
+   method SHOULD be used in preference to defining another RTCP packet
+   type because it requires less overhead:
+
+   o  fewer octets in the packet (no RTCP header or SSRC field);
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 42]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  simpler and faster parsing because applications running under that
+      profile would be programmed to always expect the extension fields
+      in the directly accessible location after the reception reports.
+
+   The extension is a fourth section in the sender- or receiver-report
+   packet which comes at the end after the reception report blocks, if
+   any.  If additional sender information is required, then for sender
+   reports it would be included first in the extension section, but for
+   receiver reports it would not be present.  If information about
+   receivers is to be included, that data SHOULD be structured as an
+   array of blocks parallel to the existing array of reception report
+   blocks; that is, the number of blocks would be indicated by the RC
+   field.
+
+6.4.4 Analyzing Sender and Receiver Reports
+
+   It is expected that reception quality feedback will be useful not
+   only for the sender but also for other receivers and third-party
+   monitors.  The sender may modify its transmissions based on the
+   feedback; receivers can determine whether problems are local,
+   regional or global; network managers may use profile-independent
+   monitors that receive only the RTCP packets and not the corresponding
+   RTP data packets to evaluate the performance of their networks for
+   multicast distribution.
+
+   Cumulative counts are used in both the sender information and
+   receiver report blocks so that differences may be calculated between
+   any two reports to make measurements over both short and long time
+   periods, and to provide resilience against the loss of a report.  The
+   difference between the last two reports received can be used to
+   estimate the recent quality of the distribution.  The NTP timestamp
+   is included so that rates may be calculated from these differences
+   over the interval between two reports.  Since that timestamp is
+   independent of the clock rate for the data encoding, it is possible
+   to implement encoding- and profile-independent quality monitors.
+
+   An example calculation is the packet loss rate over the interval
+   between two reception reports.  The difference in the cumulative
+   number of packets lost gives the number lost during that interval.
+   The difference in the extended last sequence numbers received gives
+   the number of packets expected during the interval.  The ratio of
+   these two is the packet loss fraction over the interval.  This ratio
+   should equal the fraction lost field if the two reports are
+   consecutive, but otherwise it may not.  The loss rate per second can
+   be obtained by dividing the loss fraction by the difference in NTP
+   timestamps, expressed in seconds.  The number of packets received is
+   the number of packets expected minus the number lost.  The number of
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 43]
+
+RFC 3550                          RTP                          July 2003
+
+
+   packets expected may also be used to judge the statistical validity
+   of any loss estimates.  For example, 1 out of 5 packets lost has a
+   lower significance than 200 out of 1000.
+
+   From the sender information, a third-party monitor can calculate the
+   average payload data rate and the average packet rate over an
+   interval without receiving the data.  Taking the ratio of the two
+   gives the average payload size.  If it can be assumed that packet
+   loss is independent of packet size, then the number of packets
+   received by a particular receiver times the average payload size (or
+   the corresponding packet size) gives the apparent throughput
+   available to that receiver.
+
+   In addition to the cumulative counts which allow long-term packet
+   loss measurements using differences between reports, the fraction
+   lost field provides a short-term measurement from a single report.
+   This becomes more important as the size of a session scales up enough
+   that reception state information might not be kept for all receivers
+   or the interval between reports becomes long enough that only one
+   report might have been received from a particular receiver.
+
+   The interarrival jitter field provides a second short-term measure of
+   network congestion.  Packet loss tracks persistent congestion while
+   the jitter measure tracks transient congestion.  The jitter measure
+   may indicate congestion before it leads to packet loss.  The
+   interarrival jitter field is only a snapshot of the jitter at the
+   time of a report and is not intended to be taken quantitatively.
+   Rather, it is intended for comparison across a number of reports from
+   one receiver over time or from multiple receivers, e.g., within a
+   single network, at the same time.  To allow comparison across
+   receivers, it is important the the jitter be calculated according to
+   the same formula by all receivers.
+
+   Because the jitter calculation is based on the RTP timestamp which
+   represents the instant when the first data in the packet was sampled,
+   any variation in the delay between that sampling instant and the time
+   the packet is transmitted will affect the resulting jitter that is
+   calculated.  Such a variation in delay would occur for audio packets
+   of varying duration.  It will also occur for video encodings because
+   the timestamp is the same for all the packets of one frame but those
+   packets are not all transmitted at the same time.  The variation in
+   delay until transmission does reduce the accuracy of the jitter
+   calculation as a measure of the behavior of the network by itself,
+   but it is appropriate to include considering that the receiver buffer
+   must accommodate it.  When the jitter calculation is used as a
+   comparative measure, the (constant) component due to variation in
+   delay until transmission subtracts out so that a change in the
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 44]
+
+RFC 3550                          RTP                          July 2003
+
+
+   network jitter component can then be observed unless it is relatively
+   small.  If the change is small, then it is likely to be
+   inconsequential.
+
+6.5 SDES: Source Description RTCP Packet
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+header |V=2|P|    SC   |  PT=SDES=202  |             length            |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+chunk  |                          SSRC/CSRC_1                          |
+  1    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                           SDES items                          |
+       |                              ...                              |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+chunk  |                          SSRC/CSRC_2                          |
+  2    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                           SDES items                          |
+       |                              ...                              |
+       +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+
+   The SDES packet is a three-level structure composed of a header and
+   zero or more chunks, each of which is composed of items describing
+   the source identified in that chunk.  The items are described
+   individually in subsequent sections.
+
+   version (V), padding (P), length:
+      As described for the SR packet (see Section 6.4.1).
+
+   packet type (PT): 8 bits
+      Contains the constant 202 to identify this as an RTCP SDES packet.
+
+   source count (SC): 5 bits
+      The number of SSRC/CSRC chunks contained in this SDES packet.  A
+      value of zero is valid but useless.
+
+   Each chunk consists of an SSRC/CSRC identifier followed by a list of
+   zero or more items, which carry information about the SSRC/CSRC.
+   Each chunk starts on a 32-bit boundary.  Each item consists of an 8-
+   bit type field, an 8-bit octet count describing the length of the
+   text (thus, not including this two-octet header), and the text
+   itself.  Note that the text can be no longer than 255 octets, but
+   this is consistent with the need to limit RTCP bandwidth consumption.
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 45]
+
+RFC 3550                          RTP                          July 2003
+
+
+   The text is encoded according to the UTF-8 encoding specified in RFC
+   2279 [5].  US-ASCII is a subset of this encoding and requires no
+   additional encoding.  The presence of multi-octet encodings is
+   indicated by setting the most significant bit of a character to a
+   value of one.
+
+   Items are contiguous, i.e., items are not individually padded to a
+   32-bit boundary.  Text is not null terminated because some multi-
+   octet encodings include null octets.  The list of items in each chunk
+   MUST be terminated by one or more null octets, the first of which is
+   interpreted as an item type of zero to denote the end of the list.
+   No length octet follows the null item type octet, but additional null
+   octets MUST be included if needed to pad until the next 32-bit
+   boundary.  Note that this padding is separate from that indicated by
+   the P bit in the RTCP header.  A chunk with zero items (four null
+   octets) is valid but useless.
+
+   End systems send one SDES packet containing their own source
+   identifier (the same as the SSRC in the fixed RTP header).  A mixer
+   sends one SDES packet containing a chunk for each contributing source
+   from which it is receiving SDES information, or multiple complete
+   SDES packets in the format above if there are more than 31 such
+   sources (see Section 7).
+
+   The SDES items currently defined are described in the next sections.
+   Only the CNAME item is mandatory.  Some items shown here may be
+   useful only for particular profiles, but the item types are all
+   assigned from one common space to promote shared use and to simplify
+   profile-independent applications.  Additional items may be defined in
+   a profile by registering the type numbers with IANA as described in
+   Section 15.
+
+6.5.1 CNAME: Canonical End-Point Identifier SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    CNAME=1    |     length    | user and domain name        ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The CNAME identifier has the following properties:
+
+   o  Because the randomly allocated SSRC identifier may change if a
+      conflict is discovered or if a program is restarted, the CNAME
+      item MUST be included to provide the binding from the SSRC
+      identifier to an identifier for the source (sender or receiver)
+      that remains constant.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 46]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  Like the SSRC identifier, the CNAME identifier SHOULD also be
+      unique among all participants within one RTP session.
+
+   o  To provide a binding across multiple media tools used by one
+      participant in a set of related RTP sessions, the CNAME SHOULD be
+      fixed for that participant.
+
+   o  To facilitate third-party monitoring, the CNAME SHOULD be suitable
+      for either a program or a person to locate the source.
+
+   Therefore, the CNAME SHOULD be derived algorithmically and not
+   entered manually, when possible.  To meet these requirements, the
+   following format SHOULD be used unless a profile specifies an
+   alternate syntax or semantics.  The CNAME item SHOULD have the format
+   "user@host", or "host" if a user name is not available as on single-
+   user systems.  For both formats, "host" is either the fully qualified
+   domain name of the host from which the real-time data originates,
+   formatted according to the rules specified in RFC 1034 [6], RFC 1035
+   [7] and Section 2.1 of RFC 1123 [8]; or the standard ASCII
+   representation of the host's numeric address on the interface used
+   for the RTP communication.  For example, the standard ASCII
+   representation of an IP Version 4 address is "dotted decimal", also
+   known as dotted quad, and for IP Version 6, addresses are textually
+   represented as groups of hexadecimal digits separated by colons (with
+   variations as detailed in RFC 3513 [23]).  Other address types are
+   expected to have ASCII representations that are mutually unique.  The
+   fully qualified domain name is more convenient for a human observer
+   and may avoid the need to send a NAME item in addition, but it may be
+   difficult or impossible to obtain reliably in some operating
+   environments.  Applications that may be run in such environments
+   SHOULD use the ASCII representation of the address instead.
+
+   Examples are "doe@sleepy.example.com", "doe@192.0.2.89" or
+   "doe@2201:056D::112E:144A:1E24" for a multi-user system.  On a system
+   with no user name, examples would be "sleepy.example.com",
+   "192.0.2.89" or "2201:056D::112E:144A:1E24".
+
+   The user name SHOULD be in a form that a program such as "finger" or
+   "talk" could use, i.e., it typically is the login name rather than
+   the personal name.  The host name is not necessarily identical to the
+   one in the participant's electronic mail address.
+
+   This syntax will not provide unique identifiers for each source if an
+   application permits a user to generate multiple sources from one
+   host.  Such an application would have to rely on the SSRC to further
+   identify the source, or the profile for that application would have
+   to specify additional syntax for the CNAME identifier.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 47]
+
+RFC 3550                          RTP                          July 2003
+
+
+   If each application creates its CNAME independently, the resulting
+   CNAMEs may not be identical as would be required to provide a binding
+   across multiple media tools belonging to one participant in a set of
+   related RTP sessions.  If cross-media binding is required, it may be
+   necessary for the CNAME of each tool to be externally configured with
+   the same value by a coordination tool.
+
+   Application writers should be aware that private network address
+   assignments such as the Net-10 assignment proposed in RFC 1918 [24]
+   may create network addresses that are not globally unique.  This
+   would lead to non-unique CNAMEs if hosts with private addresses and
+   no direct IP connectivity to the public Internet have their RTP
+   packets forwarded to the public Internet through an RTP-level
+   translator.  (See also RFC 1627 [25].)  To handle this case,
+   applications MAY provide a means to configure a unique CNAME, but the
+   burden is on the translator to translate CNAMEs from private
+   addresses to public addresses if necessary to keep private addresses
+   from being exposed.
+
+6.5.2 NAME: User Name SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     NAME=2    |     length    | common name of source       ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   This is the real name used to describe the source, e.g., "John Doe,
+   Bit Recycler".  It may be in any form desired by the user.  For
+   applications such as conferencing, this form of name may be the most
+   desirable for display in participant lists, and therefore might be
+   sent most frequently of those items other than CNAME.  Profiles MAY
+   establish such priorities.  The NAME value is expected to remain
+   constant at least for the duration of a session.  It SHOULD NOT be
+   relied upon to be unique among all participants in the session.
+
+6.5.3 EMAIL: Electronic Mail Address SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    EMAIL=3    |     length    | email address of source     ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The email address is formatted according to RFC 2822 [9], for
+   example, "John.Doe@example.com".  The EMAIL value is expected to
+   remain constant for the duration of a session.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 48]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.5.4 PHONE: Phone Number SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    PHONE=4    |     length    | phone number of source      ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The phone number SHOULD be formatted with the plus sign replacing the
+   international access code.  For example, "+1 908 555 1212" for a
+   number in the United States.
+
+6.5.5 LOC: Geographic User Location SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     LOC=5     |     length    | geographic location of site ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Depending on the application, different degrees of detail are
+   appropriate for this item.  For conference applications, a string
+   like "Murray Hill, New Jersey" may be sufficient, while, for an
+   active badge system, strings like "Room 2A244, AT&T BL MH" might be
+   appropriate.  The degree of detail is left to the implementation
+   and/or user, but format and content MAY be prescribed by a profile.
+   The LOC value is expected to remain constant for the duration of a
+   session, except for mobile hosts.
+
+6.5.6 TOOL: Application or Tool Name SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     TOOL=6    |     length    |name/version of source appl. ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   A string giving the name and possibly version of the application
+   generating the stream, e.g., "videotool 1.2".  This information may
+   be useful for debugging purposes and is similar to the Mailer or
+   Mail-System-Version SMTP headers.  The TOOL value is expected to
+   remain constant for the duration of the session.
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 49]
+
+RFC 3550                          RTP                          July 2003
+
+
+6.5.7 NOTE: Notice/Status SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     NOTE=7    |     length    | note about the source       ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The following semantics are suggested for this item, but these or
+   other semantics MAY be explicitly defined by a profile.  The NOTE
+   item is intended for transient messages describing the current state
+   of the source, e.g., "on the phone, can't talk".  Or, during a
+   seminar, this item might be used to convey the title of the talk.  It
+   should be used only to carry exceptional information and SHOULD NOT
+   be included routinely by all participants because this would slow
+   down the rate at which reception reports and CNAME are sent, thus
+   impairing the performance of the protocol.  In particular, it SHOULD
+   NOT be included as an item in a user's configuration file nor
+   automatically generated as in a quote-of-the-day.
+
+   Since the NOTE item may be important to display while it is active,
+   the rate at which other non-CNAME items such as NAME are transmitted
+   might be reduced so that the NOTE item can take that part of the RTCP
+   bandwidth.  When the transient message becomes inactive, the NOTE
+   item SHOULD continue to be transmitted a few times at the same
+   repetition rate but with a string of length zero to signal the
+   receivers.  However, receivers SHOULD also consider the NOTE item
+   inactive if it is not received for a small multiple of the repetition
+   rate, or perhaps 20-30 RTCP intervals.
+
+6.5.8 PRIV: Private Extensions SDES Item
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     PRIV=8    |     length    | prefix length |prefix string...
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    ...             |                  value string               ...
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   This item is used to define experimental or application-specific SDES
+   extensions.  The item contains a prefix consisting of a length-string
+   pair, followed by the value string filling the remainder of the item
+   and carrying the desired information.  The prefix length field is 8
+   bits long.  The prefix string is a name chosen by the person defining
+   the PRIV item to be unique with respect to other PRIV items this
+   application might receive.  The application creator might choose to
+   use the application name plus an additional subtype identification if
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 50]
+
+RFC 3550                          RTP                          July 2003
+
+
+   needed.  Alternatively, it is RECOMMENDED that others choose a name
+   based on the entity they represent, then coordinate the use of the
+   name within that entity.
+
+   Note that the prefix consumes some space within the item's total
+   length of 255 octets, so the prefix should be kept as short as
+   possible.  This facility and the constrained RTCP bandwidth SHOULD
+   NOT be overloaded; it is not intended to satisfy all the control
+   communication requirements of all applications.
+
+   SDES PRIV prefixes will not be registered by IANA.  If some form of
+   the PRIV item proves to be of general utility, it SHOULD instead be
+   assigned a regular SDES item type registered with IANA so that no
+   prefix is required.  This simplifies use and increases transmission
+   efficiency.
+
+6.6 BYE: Goodbye RTCP Packet
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |V=2|P|    SC   |   PT=BYE=203  |             length            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           SSRC/CSRC                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      :                              ...                              :
+      +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
+(opt) |     length    |               reason for leaving            ...
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The BYE packet indicates that one or more sources are no longer
+   active.
+
+   version (V), padding (P), length:
+      As described for the SR packet (see Section 6.4.1).
+
+   packet type (PT): 8 bits
+      Contains the constant 203 to identify this as an RTCP BYE packet.
+
+   source count (SC): 5 bits
+      The number of SSRC/CSRC identifiers included in this BYE packet.
+      A count value of zero is valid, but useless.
+
+   The rules for when a BYE packet should be sent are specified in
+   Sections 6.3.7 and 8.2.
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 51]
+
+RFC 3550                          RTP                          July 2003
+
+
+   If a BYE packet is received by a mixer, the mixer SHOULD forward the
+   BYE packet with the SSRC/CSRC identifier(s) unchanged.  If a mixer
+   shuts down, it SHOULD send a BYE packet listing all contributing
+   sources it handles, as well as its own SSRC identifier.  Optionally,
+   the BYE packet MAY include an 8-bit octet count followed by that many
+   octets of text indicating the reason for leaving, e.g., "camera
+   malfunction" or "RTP loop detected".  The string has the same
+   encoding as that described for SDES.  If the string fills the packet
+   to the next 32-bit boundary, the string is not null terminated.  If
+   not, the BYE packet MUST be padded with null octets to the next 32-
+   bit boundary.  This padding is separate from that indicated by the P
+   bit in the RTCP header.
+
+6.7 APP: Application-Defined RTCP Packet
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |V=2|P| subtype |   PT=APP=204  |             length            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           SSRC/CSRC                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                          name (ASCII)                         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                   application-dependent data                ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   The APP packet is intended for experimental use as new applications
+   and new features are developed, without requiring packet type value
+   registration.  APP packets with unrecognized names SHOULD be ignored.
+   After testing and if wider use is justified, it is RECOMMENDED that
+   each APP packet be redefined without the subtype and name fields and
+   registered with IANA using an RTCP packet type.
+
+   version (V), padding (P), length:
+      As described for the SR packet (see Section 6.4.1).
+
+   subtype: 5 bits
+      May be used as a subtype to allow a set of APP packets to be
+      defined under one unique name, or for any application-dependent
+      data.
+
+   packet type (PT): 8 bits
+      Contains the constant 204 to identify this as an RTCP APP packet.
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 52]
+
+RFC 3550                          RTP                          July 2003
+
+
+   name: 4 octets
+      A name chosen by the person defining the set of APP packets to be
+      unique with respect to other APP packets this application might
+      receive.  The application creator might choose to use the
+      application name, and then coordinate the allocation of subtype
+      values to others who want to define new packet types for the
+      application.  Alternatively, it is RECOMMENDED that others choose
+      a name based on the entity they represent, then coordinate the use
+      of the name within that entity.  The name is interpreted as a
+      sequence of four ASCII characters, with uppercase and lowercase
+      characters treated as distinct.
+
+   application-dependent data: variable length
+      Application-dependent data may or may not appear in an APP packet.
+      It is interpreted by the application and not RTP itself.  It MUST
+      be a multiple of 32 bits long.
+
+7. RTP Translators and Mixers
+
+   In addition to end systems, RTP supports the notion of "translators"
+   and "mixers", which could be considered as "intermediate systems" at
+   the RTP level.  Although this support adds some complexity to the
+   protocol, the need for these functions has been clearly established
+   by experiments with multicast audio and video applications in the
+   Internet.  Example uses of translators and mixers given in Section
+   2.3 stem from the presence of firewalls and low bandwidth
+   connections, both of which are likely to remain.
+
+7.1 General Description
+
+   An RTP translator/mixer connects two or more transport-level
+   "clouds".  Typically, each cloud is defined by a common network and
+   transport protocol (e.g., IP/UDP) plus a multicast address and
+   transport level destination port or a pair of unicast addresses and
+   ports.  (Network-level protocol translators, such as IP version 4 to
+   IP version 6, may be present within a cloud invisibly to RTP.)  One
+   system may serve as a translator or mixer for a number of RTP
+   sessions, but each is considered a logically separate entity.
+
+   In order to avoid creating a loop when a translator or mixer is
+   installed, the following rules MUST be observed:
+
+   o  Each of the clouds connected by translators and mixers
+      participating in one RTP session either MUST be distinct from all
+      the others in at least one of these parameters (protocol, address,
+      port), or MUST be isolated at the network level from the others.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 53]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  A derivative of the first rule is that there MUST NOT be multiple
+      translators or mixers connected in parallel unless by some
+      arrangement they partition the set of sources to be forwarded.
+
+   Similarly, all RTP end systems that can communicate through one or
+   more RTP translators or mixers share the same SSRC space, that is,
+   the SSRC identifiers MUST be unique among all these end systems.
+   Section 8.2 describes the collision resolution algorithm by which
+   SSRC identifiers are kept unique and loops are detected.
+
+   There may be many varieties of translators and mixers designed for
+   different purposes and applications.  Some examples are to add or
+   remove encryption, change the encoding of the data or the underlying
+   protocols, or replicate between a multicast address and one or more
+   unicast addresses.  The distinction between translators and mixers is
+   that a translator passes through the data streams from different
+   sources separately, whereas a mixer combines them to form one new
+   stream:
+
+   Translator: Forwards RTP packets with their SSRC identifier
+      intact; this makes it possible for receivers to identify
+      individual sources even though packets from all the sources pass
+      through the same translator and carry the translator's network
+      source address.  Some kinds of translators will pass through the
+      data untouched, but others MAY change the encoding of the data and
+      thus the RTP data payload type and timestamp.  If multiple data
+      packets are re-encoded into one, or vice versa, a translator MUST
+      assign new sequence numbers to the outgoing packets.  Losses in
+      the incoming packet stream may induce corresponding gaps in the
+      outgoing sequence numbers.  Receivers cannot detect the presence
+      of a translator unless they know by some other means what payload
+      type or transport address was used by the original source.
+
+   Mixer: Receives streams of RTP data packets from one or more
+      sources, possibly changes the data format, combines the streams in
+      some manner and then forwards the combined stream.  Since the
+      timing among multiple input sources will not generally be
+      synchronized, the mixer will make timing adjustments among the
+      streams and generate its own timing for the combined stream, so it
+      is the synchronization source.  Thus, all data packets forwarded
+      by a mixer MUST be marked with the mixer's own SSRC identifier.
+      In order to preserve the identity of the original sources
+      contributing to the mixed packet, the mixer SHOULD insert their
+      SSRC identifiers into the CSRC identifier list following the fixed
+      RTP header of the packet.  A mixer that is also itself a
+      contributing source for some packet SHOULD explicitly include its
+      own SSRC identifier in the CSRC list for that packet.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 54]
+
+RFC 3550                          RTP                          July 2003
+
+
+      For some applications, it MAY be acceptable for a mixer not to
+      identify sources in the CSRC list.  However, this introduces the
+      danger that loops involving those sources could not be detected.
+
+   The advantage of a mixer over a translator for applications like
+   audio is that the output bandwidth is limited to that of one source
+   even when multiple sources are active on the input side.  This may be
+   important for low-bandwidth links.  The disadvantage is that
+   receivers on the output side don't have any control over which
+   sources are passed through or muted, unless some mechanism is
+   implemented for remote control of the mixer.  The regeneration of
+   synchronization information by mixers also means that receivers can't
+   do inter-media synchronization of the original streams.  A multi-
+   media mixer could do it.
+
+         [E1]                                    [E6]
+          |                                       |
+    E1:17 |                                 E6:15 |
+          |                                       |   E6:15
+          V  M1:48 (1,17)         M1:48 (1,17)    V   M1:48 (1,17)
+         (M1)-------------><T1>-----------------><T2>-------------->[E7]
+          ^                 ^     E4:47           ^   E4:47
+     E2:1 |           E4:47 |                     |   M3:89 (64,45)
+          |                 |                     |
+         [E2]              [E4]     M3:89 (64,45) |
+                                                  |        legend:
+   [E3] --------->(M2)----------->(M3)------------|        [End system]
+          E3:64        M2:12 (64)  ^                       (Mixer)
+                                   | E5:45                 <Translator>
+                                   |
+                                  [E5]          source: SSRC (CSRCs)
+                                                ------------------->
+
+   Figure 3: Sample RTP network with end systems, mixers and translators
+
+   A collection of mixers and translators is shown in Fig. 3 to
+   illustrate their effect on SSRC and CSRC identifiers.  In the figure,
+   end systems are shown as rectangles (named E), translators as
+   triangles (named T) and mixers as ovals (named M).  The notation "M1:
+   48(1,17)" designates a packet originating a mixer M1, identified by
+   M1's (random) SSRC value of 48 and two CSRC identifiers, 1 and 17,
+   copied from the SSRC identifiers of packets from E1 and E2.
+
+7.2 RTCP Processing in Translators
+
+   In addition to forwarding data packets, perhaps modified, translators
+   and mixers MUST also process RTCP packets.  In many cases, they will
+   take apart the compound RTCP packets received from end systems to
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 55]
+
+RFC 3550                          RTP                          July 2003
+
+
+   aggregate SDES information and to modify the SR or RR packets.
+   Retransmission of this information may be triggered by the packet
+   arrival or by the RTCP interval timer of the translator or mixer
+   itself.
+
+   A translator that does not modify the data packets, for example one
+   that just replicates between a multicast address and a unicast
+   address, MAY simply forward RTCP packets unmodified as well.  A
+   translator that transforms the payload in some way MUST make
+   corresponding transformations in the SR and RR information so that it
+   still reflects the characteristics of the data and the reception
+   quality.  These translators MUST NOT simply forward RTCP packets.  In
+   general, a translator SHOULD NOT aggregate SR and RR packets from
+   different sources into one packet since that would reduce the
+   accuracy of the propagation delay measurements based on the LSR and
+   DLSR fields.
+
+   SR sender information:  A translator does not generate its own
+      sender information, but forwards the SR packets received from one
+      cloud to the others.  The SSRC is left intact but the sender
+      information MUST be modified if required by the translation.  If a
+      translator changes the data encoding, it MUST change the "sender's
+      byte count" field.  If it also combines several data packets into
+      one output packet, it MUST change the "sender's packet count"
+      field.  If it changes the timestamp frequency, it MUST change the
+      "RTP timestamp" field in the SR packet.
+
+   SR/RR reception report blocks:  A translator forwards reception
+      reports received from one cloud to the others.  Note that these
+      flow in the direction opposite to the data.  The SSRC is left
+      intact.  If a translator combines several data packets into one
+      output packet, and therefore changes the sequence numbers, it MUST
+      make the inverse manipulation for the packet loss fields and the
+      "extended last sequence number" field.  This may be complex.  In
+      the extreme case, there may be no meaningful way to translate the
+      reception reports, so the translator MAY pass on no reception
+      report at all or a synthetic report based on its own reception.
+      The general rule is to do what makes sense for a particular
+      translation.
+
+      A translator does not require an SSRC identifier of its own, but
+      MAY choose to allocate one for the purpose of sending reports
+      about what it has received.  These would be sent to all the
+      connected clouds, each corresponding to the translation of the
+      data stream as sent to that cloud, since reception reports are
+      normally multicast to all participants.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 56]
+
+RFC 3550                          RTP                          July 2003
+
+
+   SDES:  Translators typically forward without change the SDES
+      information they receive from one cloud to the others, but MAY,
+      for example, decide to filter non-CNAME SDES information if
+      bandwidth is limited.  The CNAMEs MUST be forwarded to allow SSRC
+      identifier collision detection to work.  A translator that
+      generates its own RR packets MUST send SDES CNAME information
+      about itself to the same clouds that it sends those RR packets.
+
+   BYE:  Translators forward BYE packets unchanged.  A translator
+      that is about to cease forwarding packets SHOULD send a BYE packet
+      to each connected cloud containing all the SSRC identifiers that
+      were previously being forwarded to that cloud, including the
+      translator's own SSRC identifier if it sent reports of its own.
+
+   APP:  Translators forward APP packets unchanged.
+
+7.3 RTCP Processing in Mixers
+
+   Since a mixer generates a new data stream of its own, it does not
+   pass through SR or RR packets at all and instead generates new
+   information for both sides.
+
+   SR sender information:  A mixer does not pass through sender
+      information from the sources it mixes because the characteristics
+      of the source streams are lost in the mix.  As a synchronization
+      source, the mixer SHOULD generate its own SR packets with sender
+      information about the mixed data stream and send them in the same
+      direction as the mixed stream.
+
+   SR/RR reception report blocks:  A mixer generates its own
+      reception reports for sources in each cloud and sends them out
+      only to the same cloud.  It MUST NOT send these reception reports
+      to the other clouds and MUST NOT forward reception reports from
+      one cloud to the others because the sources would not be SSRCs
+      there (only CSRCs).
+
+   SDES:  Mixers typically forward without change the SDES
+      information they receive from one cloud to the others, but MAY,
+      for example, decide to filter non-CNAME SDES information if
+      bandwidth is limited.  The CNAMEs MUST be forwarded to allow SSRC
+      identifier collision detection to work.  (An identifier in a CSRC
+      list generated by a mixer might collide with an SSRC identifier
+      generated by an end system.)  A mixer MUST send SDES CNAME
+      information about itself to the same clouds that it sends SR or RR
+      packets.
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 57]
+
+RFC 3550                          RTP                          July 2003
+
+
+      Since mixers do not forward SR or RR packets, they will typically
+      be extracting SDES packets from a compound RTCP packet.  To
+      minimize overhead, chunks from the SDES packets MAY be aggregated
+      into a single SDES packet which is then stacked on an SR or RR
+      packet originating from the mixer.  A mixer which aggregates SDES
+      packets will use more RTCP bandwidth than an individual source
+      because the compound packets will be longer, but that is
+      appropriate since the mixer represents multiple sources.
+      Similarly, a mixer which passes through SDES packets as they are
+      received will be transmitting RTCP packets at higher than the
+      single source rate, but again that is correct since the packets
+      come from multiple sources.  The RTCP packet rate may be different
+      on each side of the mixer.
+
+      A mixer that does not insert CSRC identifiers MAY also refrain
+      from forwarding SDES CNAMEs.  In this case, the SSRC identifier
+      spaces in the two clouds are independent.  As mentioned earlier,
+      this mode of operation creates a danger that loops can't be
+      detected.
+
+   BYE:  Mixers MUST forward BYE packets.  A mixer that is about to
+      cease forwarding packets SHOULD send a BYE packet to each
+      connected cloud containing all the SSRC identifiers that were
+      previously being forwarded to that cloud, including the mixer's
+      own SSRC identifier if it sent reports of its own.
+
+   APP:  The treatment of APP packets by mixers is application-specific.
+
+7.4 Cascaded Mixers
+
+   An RTP session may involve a collection of mixers and translators as
+   shown in Fig. 3.  If two mixers are cascaded, such as M2 and M3 in
+   the figure, packets received by a mixer may already have been mixed
+   and may include a CSRC list with multiple identifiers.  The second
+   mixer SHOULD build the CSRC list for the outgoing packet using the
+   CSRC identifiers from already-mixed input packets and the SSRC
+   identifiers from unmixed input packets.  This is shown in the output
+   arc from mixer M3 labeled M3:89(64,45) in the figure.  As in the case
+   of mixers that are not cascaded, if the resulting CSRC list has more
+   than 15 identifiers, the remainder cannot be included.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 58]
+
+RFC 3550                          RTP                          July 2003
+
+
+8.  SSRC Identifier Allocation and Use
+
+   The SSRC identifier carried in the RTP header and in various fields
+   of RTCP packets is a random 32-bit number that is required to be
+   globally unique within an RTP session.  It is crucial that the number
+   be chosen with care in order that participants on the same network or
+   starting at the same time are not likely to choose the same number.
+
+   It is not sufficient to use the local network address (such as an
+   IPv4 address) for the identifier because the address may not be
+   unique.  Since RTP translators and mixers enable interoperation among
+   multiple networks with different address spaces, the allocation
+   patterns for addresses within two spaces might result in a much
+   higher rate of collision than would occur with random allocation.
+
+   Multiple sources running on one host would also conflict.
+
+   It is also not sufficient to obtain an SSRC identifier simply by
+   calling random() without carefully initializing the state.  An
+   example of how to generate a random identifier is presented in
+   Appendix A.6.
+
+8.1 Probability of Collision
+
+   Since the identifiers are chosen randomly, it is possible that two or
+   more sources will choose the same number.  Collision occurs with the
+   highest probability when all sources are started simultaneously, for
+   example when triggered automatically by some session management
+   event.  If N is the number of sources and L the length of the
+   identifier (here, 32 bits), the probability that two sources
+   independently pick the same value can be approximated for large N
+   [26] as 1 - exp(-N**2 / 2**(L+1)).  For N=1000, the probability is
+   roughly 10**-4.
+
+   The typical collision probability is much lower than the worst-case
+   above.  When one new source joins an RTP session in which all the
+   other sources already have unique identifiers, the probability of
+   collision is just the fraction of numbers used out of the space.
+   Again, if N is the number of sources and L the length of the
+   identifier, the probability of collision is N / 2**L.  For N=1000,
+   the probability is roughly 2*10**-7.
+
+   The probability of collision is further reduced by the opportunity
+   for a new source to receive packets from other participants before
+   sending its first packet (either data or control).  If the new source
+   keeps track of the other participants (by SSRC identifier), then
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 59]
+
+RFC 3550                          RTP                          July 2003
+
+
+   before transmitting its first packet the new source can verify that
+   its identifier does not conflict with any that have been received, or
+   else choose again.
+
+8.2 Collision Resolution and Loop Detection
+
+   Although the probability of SSRC identifier collision is low, all RTP
+   implementations MUST be prepared to detect collisions and take the
+   appropriate actions to resolve them.  If a source discovers at any
+   time that another source is using the same SSRC identifier as its
+   own, it MUST send an RTCP BYE packet for the old identifier and
+   choose another random one.  (As explained below, this step is taken
+   only once in case of a loop.)  If a receiver discovers that two other
+   sources are colliding, it MAY keep the packets from one and discard
+   the packets from the other when this can be detected by different
+   source transport addresses or CNAMEs.  The two sources are expected
+   to resolve the collision so that the situation doesn't last.
+
+   Because the random SSRC identifiers are kept globally unique for each
+   RTP session, they can also be used to detect loops that may be
+   introduced by mixers or translators.  A loop causes duplication of
+   data and control information, either unmodified or possibly mixed, as
+   in the following examples:
+
+   o  A translator may incorrectly forward a packet to the same
+      multicast group from which it has received the packet, either
+      directly or through a chain of translators.  In that case, the
+      same packet appears several times, originating from different
+      network sources.
+
+   o  Two translators incorrectly set up in parallel, i.e., with the
+      same multicast groups on both sides, would both forward packets
+      from one multicast group to the other.  Unidirectional translators
+      would produce two copies; bidirectional translators would form a
+      loop.
+
+   o  A mixer can close a loop by sending to the same transport
+      destination upon which it receives packets, either directly or
+      through another mixer or translator.  In this case a source might
+      show up both as an SSRC on a data packet and a CSRC in a mixed
+      data packet.
+
+   A source may discover that its own packets are being looped, or that
+   packets from another source are being looped (a third-party loop).
+   Both loops and collisions in the random selection of a source
+   identifier result in packets arriving with the same SSRC identifier
+   but a different source transport address, which may be that of the
+   end system originating the packet or an intermediate system.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 60]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Therefore, if a source changes its source transport address, it MAY
+   also choose a new SSRC identifier to avoid being interpreted as a
+   looped source.  (This is not MUST because in some applications of RTP
+   sources may be expected to change addresses during a session.)  Note
+   that if a translator restarts and consequently changes the source
+   transport address (e.g., changes the UDP source port number) on which
+   it forwards packets, then all those packets will appear to receivers
+   to be looped because the SSRC identifiers are applied by the original
+   source and will not change.  This problem can be avoided by keeping
+   the source transport address fixed across restarts, but in any case
+   will be resolved after a timeout at the receivers.
+
+   Loops or collisions occurring on the far side of a translator or
+   mixer cannot be detected using the source transport address if all
+   copies of the packets go through the translator or mixer, however,
+   collisions may still be detected when chunks from two RTCP SDES
+   packets contain the same SSRC identifier but different CNAMEs.
+
+   To detect and resolve these conflicts, an RTP implementation MUST
+   include an algorithm similar to the one described below, though the
+   implementation MAY choose a different policy for which packets from
+   colliding third-party sources are kept.  The algorithm described
+   below ignores packets from a new source or loop that collide with an
+   established source.  It resolves collisions with the participant's
+   own SSRC identifier by sending an RTCP BYE for the old identifier and
+   choosing a new one.  However, when the collision was induced by a
+   loop of the participant's own packets, the algorithm will choose a
+   new identifier only once and thereafter ignore packets from the
+   looping source transport address.  This is required to avoid a flood
+   of BYE packets.
+
+   This algorithm requires keeping a table indexed by the source
+   identifier and containing the source transport addresses from the
+   first RTP packet and first RTCP packet received with that identifier,
+   along with other state for that source.  Two source transport
+   addresses are required since, for example, the UDP source port
+   numbers may be different on RTP and RTCP packets.  However, it may be
+   assumed that the network address is the same in both source transport
+   addresses.
+
+   Each SSRC or CSRC identifier received in an RTP or RTCP packet is
+   looked up in the source identifier table in order to process that
+   data or control information.  The source transport address from the
+   packet is compared to the corresponding source transport address in
+   the table to detect a loop or collision if they don't match.  For
+   control packets, each element with its own SSRC identifier, for
+   example an SDES chunk, requires a separate lookup.  (The SSRC
+   identifier in a reception report block is an exception because it
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 61]
+
+RFC 3550                          RTP                          July 2003
+
+
+   identifies a source heard by the reporter, and that SSRC identifier
+   is unrelated to the source transport address of the RTCP packet sent
+   by the reporter.)  If the SSRC or CSRC is not found, a new entry is
+   created.  These table entries are removed when an RTCP BYE packet is
+   received with the corresponding SSRC identifier and validated by a
+   matching source transport address, or after no packets have arrived
+   for a relatively long time (see Section 6.2.1).
+
+   Note that if two sources on the same host are transmitting with the
+   same source identifier at the time a receiver begins operation, it
+   would be possible that the first RTP packet received came from one of
+   the sources while the first RTCP packet received came from the other.
+   This would cause the wrong RTCP information to be associated with the
+   RTP data, but this situation should be sufficiently rare and harmless
+   that it may be disregarded.
+
+   In order to track loops of the participant's own data packets, the
+   implementation MUST also keep a separate list of source transport
+   addresses (not identifiers) that have been found to be conflicting.
+   As in the source identifier table, two source transport addresses
+   MUST be kept to separately track conflicting RTP and RTCP packets.
+   Note that the conflicting address list should be short, usually
+   empty.  Each element in this list stores the source addresses plus
+   the time when the most recent conflicting packet was received.  An
+   element MAY be removed from the list when no conflicting packet has
+   arrived from that source for a time on the order of 10 RTCP report
+   intervals (see Section 6.2).
+
+   For the algorithm as shown, it is assumed that the participant's own
+   source identifier and state are included in the source identifier
+   table.  The algorithm could be restructured to first make a separate
+   comparison against the participant's own source identifier.
+
+      if (SSRC or CSRC identifier is not found in the source
+          identifier table) {
+          create a new entry storing the data or control source
+              transport address, the SSRC or CSRC and other state;
+      }
+
+      /* Identifier is found in the table */
+
+      else if (table entry was created on receipt of a control packet
+               and this is the first data packet or vice versa) {
+          store the source transport address from this packet;
+      }
+      else if (source transport address from the packet does not match
+               the one saved in the table entry for this identifier) {
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 62]
+
+RFC 3550                          RTP                          July 2003
+
+
+          /* An identifier collision or a loop is indicated */
+
+          if (source identifier is not the participant's own) {
+              /* OPTIONAL error counter step */
+              if (source identifier is from an RTCP SDES chunk
+                  containing a CNAME item that differs from the CNAME
+                  in the table entry) {
+                  count a third-party collision;
+              } else {
+                  count a third-party loop;
+              }
+              abort processing of data packet or control element;
+              /* MAY choose a different policy to keep new source */
+          }
+
+          /* A collision or loop of the participant's own packets */
+
+          else if (source transport address is found in the list of
+                   conflicting data or control source transport
+                   addresses) {
+              /* OPTIONAL error counter step */
+              if (source identifier is not from an RTCP SDES chunk
+                  containing a CNAME item or CNAME is the
+                  participant's own) {
+                  count occurrence of own traffic looped;
+              }
+              mark current time in conflicting address list entry;
+              abort processing of data packet or control element;
+          }
+
+          /* New collision, change SSRC identifier */
+
+          else {
+              log occurrence of a collision;
+              create a new entry in the conflicting data or control
+                  source transport address list and mark current time;
+              send an RTCP BYE packet with the old SSRC identifier;
+              choose a new SSRC identifier;
+              create a new entry in the source identifier table with
+                  the old SSRC plus the source transport address from
+                  the data or control packet being processed;
+          }
+      }
+
+   In this algorithm, packets from a newly conflicting source address
+   will be ignored and packets from the original source address will be
+   kept.  If no packets arrive from the original source for an extended
+   period, the table entry will be timed out and the new source will be
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 63]
+
+RFC 3550                          RTP                          July 2003
+
+
+   able to take over.  This might occur if the original source detects
+   the collision and moves to a new source identifier, but in the usual
+   case an RTCP BYE packet will be received from the original source to
+   delete the state without having to wait for a timeout.
+
+   If the original source address was received through a mixer (i.e.,
+   learned as a CSRC) and later the same source is received directly,
+   the receiver may be well advised to switch to the new source address
+   unless other sources in the mix would be lost.  Furthermore, for
+   applications such as telephony in which some sources such as mobile
+   entities may change addresses during the course of an RTP session,
+   the RTP implementation SHOULD modify the collision detection
+   algorithm to accept packets from the new source transport address.
+   To guard against flip-flopping between addresses if a genuine
+   collision does occur, the algorithm SHOULD include some means to
+   detect this case and avoid switching.
+
+   When a new SSRC identifier is chosen due to a collision, the
+   candidate identifier SHOULD first be looked up in the source
+   identifier table to see if it was already in use by some other
+   source.  If so, another candidate MUST be generated and the process
+   repeated.
+
+   A loop of data packets to a multicast destination can cause severe
+   network flooding.  All mixers and translators MUST implement a loop
+   detection algorithm like the one here so that they can break loops.
+   This should limit the excess traffic to no more than one duplicate
+   copy of the original traffic, which may allow the session to continue
+   so that the cause of the loop can be found and fixed.  However, in
+   extreme cases where a mixer or translator does not properly break the
+   loop and high traffic levels result, it may be necessary for end
+   systems to cease transmitting data or control packets entirely.  This
+   decision may depend upon the application.  An error condition SHOULD
+   be indicated as appropriate.  Transmission MAY be attempted again
+   periodically after a long, random time (on the order of minutes).
+
+8.3 Use with Layered Encodings
+
+   For layered encodings transmitted on separate RTP sessions (see
+   Section 2.4), a single SSRC identifier space SHOULD be used across
+   the sessions of all layers and the core (base) layer SHOULD be used
+   for SSRC identifier allocation and collision resolution.  When a
+   source discovers that it has collided, it transmits an RTCP BYE
+   packet on only the base layer but changes the SSRC identifier to the
+   new value in all layers.
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 64]
+
+RFC 3550                          RTP                          July 2003
+
+
+9. Security
+
+   Lower layer protocols may eventually provide all the security
+   services that may be desired for applications of RTP, including
+   authentication, integrity, and confidentiality.  These services have
+   been specified for IP in [27].  Since the initial audio and video
+   applications using RTP needed a confidentiality service before such
+   services were available for the IP layer, the confidentiality service
+   described in the next section was defined for use with RTP and RTCP.
+   That description is included here to codify existing practice.  New
+   applications of RTP MAY implement this RTP-specific confidentiality
+   service for backward compatibility, and/or they MAY implement
+   alternative security services.  The overhead on the RTP protocol for
+   this confidentiality service is low, so the penalty will be minimal
+   if this service is obsoleted by other services in the future.
+
+   Alternatively, other services, other implementations of services and
+   other algorithms may be defined for RTP in the future.  In
+   particular, an RTP profile called Secure Real-time Transport Protocol
+   (SRTP) [28] is being developed to provide confidentiality of the RTP
+   payload while leaving the RTP header in the clear so that link-level
+   header compression algorithms can still operate.  It is expected that
+   SRTP will be the correct choice for many applications.  SRTP is based
+   on the Advanced Encryption Standard (AES) and provides stronger
+   security than the service described here.  No claim is made that the
+   methods presented here are appropriate for a particular security
+   need.  A profile may specify which services and algorithms should be
+   offered by applications, and may provide guidance as to their
+   appropriate use.
+
+   Key distribution and certificates are outside the scope of this
+   document.
+
+9.1 Confidentiality
+
+   Confidentiality means that only the intended receiver(s) can decode
+   the received packets; for others, the packet contains no useful
+   information.  Confidentiality of the content is achieved by
+   encryption.
+
+   When it is desired to encrypt RTP or RTCP according to the method
+   specified in this section, all the octets that will be encapsulated
+   for transmission in a single lower-layer packet are encrypted as a
+   unit.  For RTCP, a 32-bit random number redrawn for each unit MUST be
+   prepended to the unit before encryption.  For RTP, no prefix is
+   prepended; instead, the sequence number and timestamp fields are
+   initialized with random offsets.  This is considered to be a weak
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 65]
+
+RFC 3550                          RTP                          July 2003
+
+
+   initialization vector (IV) because of poor randomness properties.  In
+   addition, if the subsequent field, the SSRC, can be manipulated by an
+   enemy, there is further weakness of the encryption method.
+
+   For RTCP, an implementation MAY segregate the individual RTCP packets
+   in a compound RTCP packet into two separate compound RTCP packets,
+   one to be encrypted and one to be sent in the clear.  For example,
+   SDES information might be encrypted while reception reports were sent
+   in the clear to accommodate third-party monitors that are not privy
+   to the encryption key.  In this example, depicted in Fig. 4, the SDES
+   information MUST be appended to an RR packet with no reports (and the
+   random number) to satisfy the requirement that all compound RTCP
+   packets begin with an SR or RR packet.  The SDES CNAME item is
+   required in either the encrypted or unencrypted packet, but not both.
+   The same SDES information SHOULD NOT be carried in both packets as
+   this may compromise the encryption.
+
+             UDP packet                     UDP packet
+   -----------------------------  ------------------------------
+   [random][RR][SDES #CNAME ...]  [SR #senderinfo #site1 #site2]
+   -----------------------------  ------------------------------
+             encrypted                     not encrypted
+
+   #: SSRC identifier
+
+       Figure 4: Encrypted and non-encrypted RTCP packets
+
+   The presence of encryption and the use of the correct key are
+   confirmed by the receiver through header or payload validity checks.
+   Examples of such validity checks for RTP and RTCP headers are given
+   in Appendices A.1 and A.2.
+
+   To be consistent with existing implementations of the initial
+   specification of RTP in RFC 1889, the default encryption algorithm is
+   the Data Encryption Standard (DES) algorithm in cipher block chaining
+   (CBC) mode, as described in Section 1.1 of RFC 1423 [29], except that
+   padding to a multiple of 8 octets is indicated as described for the P
+   bit in Section 5.1.  The initialization vector is zero because random
+   values are supplied in the RTP header or by the random prefix for
+   compound RTCP packets.  For details on the use of CBC initialization
+   vectors, see [30].
+
+   Implementations that support the encryption method specified here
+   SHOULD always support the DES algorithm in CBC mode as the default
+   cipher for this method to maximize interoperability.  This method was
+   chosen because it has been demonstrated to be easy and practical to
+   use in experimental audio and video tools in operation on the
+   Internet.  However, DES has since been found to be too easily broken.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 66]
+
+RFC 3550                          RTP                          July 2003
+
+
+   It is RECOMMENDED that stronger encryption algorithms such as
+   Triple-DES be used in place of the default algorithm.  Furthermore,
+   secure CBC mode requires that the first block of each packet be XORed
+   with a random, independent IV of the same size as the cipher's block
+   size.  For RTCP, this is (partially) achieved by prepending each
+   packet with a 32-bit random number, independently chosen for each
+   packet.  For RTP, the timestamp and sequence number start from random
+   values, but consecutive packets will not be independently randomized.
+   It should be noted that the randomness in both cases (RTP and RTCP)
+   is limited.  High-security applications SHOULD consider other, more
+   conventional, protection means.  Other encryption algorithms MAY be
+   specified dynamically for a session by non-RTP means.  In particular,
+   the SRTP profile [28] based on AES is being developed to take into
+   account known plaintext and CBC plaintext manipulation concerns, and
+   will be the correct choice in the future.
+
+   As an alternative to encryption at the IP level or at the RTP level
+   as described above, profiles MAY define additional payload types for
+   encrypted encodings.  Those encodings MUST specify how padding and
+   other aspects of the encryption are to be handled.  This method
+   allows encrypting only the data while leaving the headers in the
+   clear for applications where that is desired.  It may be particularly
+   useful for hardware devices that will handle both decryption and
+   decoding.  It is also valuable for applications where link-level
+   compression of RTP and lower-layer headers is desired and
+   confidentiality of the payload (but not addresses) is sufficient
+   since encryption of the headers precludes compression.
+
+9.2 Authentication and Message Integrity
+
+   Authentication and message integrity services are not defined at the
+   RTP level since these services would not be directly feasible without
+   a key management infrastructure.  It is expected that authentication
+   and integrity services will be provided by lower layer protocols.
+
+10. Congestion Control
+
+   All transport protocols used on the Internet need to address
+   congestion control in some way [31].  RTP is not an exception, but
+   because the data transported over RTP is often inelastic (generated
+   at a fixed or controlled rate), the means to control congestion in
+   RTP may be quite different from those for other transport protocols
+   such as TCP.  In one sense, inelasticity reduces the risk of
+   congestion because the RTP stream will not expand to consume all
+   available bandwidth as a TCP stream can.  However, inelasticity also
+   means that the RTP stream cannot arbitrarily reduce its load on the
+   network to eliminate congestion when it occurs.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 67]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Since RTP may be used for a wide variety of applications in many
+   different contexts, there is no single congestion control mechanism
+   that will work for all.  Therefore, congestion control SHOULD be
+   defined in each RTP profile as appropriate.  For some profiles, it
+   may be sufficient to include an applicability statement restricting
+   the use of that profile to environments where congestion is avoided
+   by engineering.  For other profiles, specific methods such as data
+   rate adaptation based on RTCP feedback may be required.
+
+11. RTP over Network and Transport Protocols
+
+   This section describes issues specific to carrying RTP packets within
+   particular network and transport protocols.  The following rules
+   apply unless superseded by protocol-specific definitions outside this
+   specification.
+
+   RTP relies on the underlying protocol(s) to provide demultiplexing of
+   RTP data and RTCP control streams.  For UDP and similar protocols,
+   RTP SHOULD use an even destination port number and the corresponding
+   RTCP stream SHOULD use the next higher (odd) destination port number.
+   For applications that take a single port number as a parameter and
+   derive the RTP and RTCP port pair from that number, if an odd number
+   is supplied then the application SHOULD replace that number with the
+   next lower (even) number to use as the base of the port pair.  For
+   applications in which the RTP and RTCP destination port numbers are
+   specified via explicit, separate parameters (using a signaling
+   protocol or other means), the application MAY disregard the
+   restrictions that the port numbers be even/odd and consecutive
+   although the use of an even/odd port pair is still encouraged.  The
+   RTP and RTCP port numbers MUST NOT be the same since RTP relies on
+   the port numbers to demultiplex the RTP data and RTCP control
+   streams.
+
+   In a unicast session, both participants need to identify a port pair
+   for receiving RTP and RTCP packets.  Both participants MAY use the
+   same port pair.  A participant MUST NOT assume that the source port
+   of the incoming RTP or RTCP packet can be used as the destination
+   port for outgoing RTP or RTCP packets.  When RTP data packets are
+   being sent in both directions, each participant's RTCP SR packets
+   MUST be sent to the port that the other participant has specified for
+   reception of RTCP.  The RTCP SR packets combine sender information
+   for the outgoing data plus reception report information for the
+   incoming data.  If a side is not actively sending data (see Section
+   6.4), an RTCP RR packet is sent instead.
+
+   It is RECOMMENDED that layered encoding applications (see Section
+   2.4) use a set of contiguous port numbers.  The port numbers MUST be
+   distinct because of a widespread deficiency in existing operating
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 68]
+
+RFC 3550                          RTP                          July 2003
+
+
+   systems that prevents use of the same port with multiple multicast
+   addresses, and for unicast, there is only one permissible address.
+   Thus for layer n, the data port is P + 2n, and the control port is P
+   + 2n + 1.  When IP multicast is used, the addresses MUST also be
+   distinct because multicast routing and group membership are managed
+   on an address granularity.  However, allocation of contiguous IP
+   multicast addresses cannot be assumed because some groups may require
+   different scopes and may therefore be allocated from different
+   address ranges.
+
+   The previous paragraph conflicts with the SDP specification, RFC 2327
+   [15], which says that it is illegal for both multiple addresses and
+   multiple ports to be specified in the same session description
+   because the association of addresses with ports could be ambiguous.
+   It is intended that this restriction will be relaxed in a revision of
+   RFC 2327 to allow an equal number of addresses and ports to be
+   specified with a one-to-one mapping implied.
+
+   RTP data packets contain no length field or other delineation,
+   therefore RTP relies on the underlying protocol(s) to provide a
+   length indication.  The maximum length of RTP packets is limited only
+   by the underlying protocols.
+
+   If RTP packets are to be carried in an underlying protocol that
+   provides the abstraction of a continuous octet stream rather than
+   messages (packets), an encapsulation of the RTP packets MUST be
+   defined to provide a framing mechanism.  Framing is also needed if
+   the underlying protocol may contain padding so that the extent of the
+   RTP payload cannot be determined.  The framing mechanism is not
+   defined here.
+
+   A profile MAY specify a framing method to be used even when RTP is
+   carried in protocols that do provide framing in order to allow
+   carrying several RTP packets in one lower-layer protocol data unit,
+   such as a UDP packet.  Carrying several RTP packets in one network or
+   transport packet reduces header overhead and may simplify
+   synchronization between different streams.
+
+12. Summary of Protocol Constants
+
+   This section contains a summary listing of the constants defined in
+   this specification.
+
+   The RTP payload type (PT) constants are defined in profiles rather
+   than this document.  However, the octet of the RTP header which
+   contains the marker bit(s) and payload type MUST avoid the reserved
+   values 200 and 201 (decimal) to distinguish RTP packets from the RTCP
+   SR and RR packet types for the header validation procedure described
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 69]
+
+RFC 3550                          RTP                          July 2003
+
+
+   in Appendix A.1.  For the standard definition of one marker bit and a
+   7-bit payload type field as shown in this specification, this
+   restriction means that payload types 72 and 73 are reserved.
+
+12.1 RTCP Packet Types
+
+   abbrev.  name                 value
+   SR       sender report          200
+   RR       receiver report        201
+   SDES     source description     202
+   BYE      goodbye                203
+   APP      application-defined    204
+
+   These type values were chosen in the range 200-204 for improved
+   header validity checking of RTCP packets compared to RTP packets or
+   other unrelated packets.  When the RTCP packet type field is compared
+   to the corresponding octet of the RTP header, this range corresponds
+   to the marker bit being 1 (which it usually is not in data packets)
+   and to the high bit of the standard payload type field being 1 (since
+   the static payload types are typically defined in the low half).
+   This range was also chosen to be some distance numerically from 0 and
+   255 since all-zeros and all-ones are common data patterns.
+
+   Since all compound RTCP packets MUST begin with SR or RR, these codes
+   were chosen as an even/odd pair to allow the RTCP validity check to
+   test the maximum number of bits with mask and value.
+
+   Additional RTCP packet types may be registered through IANA (see
+   Section 15).
+
+12.2 SDES Types
+
+   abbrev.  name                            value
+   END      end of SDES list                    0
+   CNAME    canonical name                      1
+   NAME     user name                           2
+   EMAIL    user's electronic mail address      3
+   PHONE    user's phone number                 4
+   LOC      geographic user location            5
+   TOOL     name of application or tool         6
+   NOTE     notice about the source             7
+   PRIV     private extensions                  8
+
+   Additional SDES types may be registered through IANA (see Section
+   15).
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 70]
+
+RFC 3550                          RTP                          July 2003
+
+
+13.  RTP Profiles and Payload Format Specifications
+
+   A complete specification of RTP for a particular application will
+   require one or more companion documents of two types described here:
+   profiles, and payload format specifications.
+
+   RTP may be used for a variety of applications with somewhat differing
+   requirements.  The flexibility to adapt to those requirements is
+   provided by allowing multiple choices in the main protocol
+   specification, then selecting the appropriate choices or defining
+   extensions for a particular environment and class of applications in
+   a separate profile document.  Typically an application will operate
+   under only one profile in a particular RTP session, so there is no
+   explicit indication within the RTP protocol itself as to which
+   profile is in use.  A profile for audio and video applications may be
+   found in the companion RFC 3551.  Profiles are typically titled "RTP
+   Profile for ...".
+
+   The second type of companion document is a payload format
+   specification, which defines how a particular kind of payload data,
+   such as H.261 encoded video, should be carried in RTP.  These
+   documents are typically titled "RTP Payload Format for XYZ
+   Audio/Video Encoding".  Payload formats may be useful under multiple
+   profiles and may therefore be defined independently of any particular
+   profile.  The profile documents are then responsible for assigning a
+   default mapping of that format to a payload type value if needed.
+
+   Within this specification, the following items have been identified
+   for possible definition within a profile, but this list is not meant
+   to be exhaustive:
+
+   RTP data header: The octet in the RTP data header that contains
+      the marker bit and payload type field MAY be redefined by a
+      profile to suit different requirements, for example with more or
+      fewer marker bits (Section 5.3, p. 18).
+
+   Payload types: Assuming that a payload type field is included,
+      the profile will usually define a set of payload formats (e.g.,
+      media encodings) and a default static mapping of those formats to
+      payload type values.  Some of the payload formats may be defined
+      by reference to separate payload format specifications.  For each
+      payload type defined, the profile MUST specify the RTP timestamp
+      clock rate to be used (Section 5.1, p. 14).
+
+   RTP data header additions: Additional fields MAY be appended to
+      the fixed RTP data header if some additional functionality is
+      required across the profile's class of applications independent of
+      payload type (Section 5.3, p. 18).
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 71]
+
+RFC 3550                          RTP                          July 2003
+
+
+   RTP data header extensions: The contents of the first 16 bits of
+      the RTP data header extension structure MUST be defined if use of
+      that mechanism is to be allowed under the profile for
+      implementation-specific extensions (Section 5.3.1, p. 18).
+
+   RTCP packet types: New application-class-specific RTCP packet
+      types MAY be defined and registered with IANA.
+
+   RTCP report interval: A profile SHOULD specify that the values
+      suggested in Section 6.2 for the constants employed in the
+      calculation of the RTCP report interval will be used.  Those are
+      the RTCP fraction of session bandwidth, the minimum report
+      interval, and the bandwidth split between senders and receivers.
+      A profile MAY specify alternate values if they have been
+      demonstrated to work in a scalable manner.
+
+   SR/RR extension: An extension section MAY be defined for the
+      RTCP SR and RR packets if there is additional information that
+      should be reported regularly about the sender or receivers
+      (Section 6.4.3, p. 42 and 43).
+
+   SDES use: The profile MAY specify the relative priorities for
+      RTCP SDES items to be transmitted or excluded entirely (Section
+      6.3.9); an alternate syntax or semantics for the CNAME item
+      (Section 6.5.1); the format of the LOC item (Section 6.5.5); the
+      semantics and use of the NOTE item (Section 6.5.7); or new SDES
+      item types to be registered with IANA.
+
+   Security: A profile MAY specify which security services and
+      algorithms should be offered by applications, and MAY provide
+      guidance as to their appropriate use (Section 9, p. 65).
+
+   String-to-key mapping: A profile MAY specify how a user-provided
+      password or pass phrase is mapped into an encryption key.
+
+   Congestion: A profile SHOULD specify the congestion control
+      behavior appropriate for that profile.
+
+   Underlying protocol: Use of a particular underlying network or
+      transport layer protocol to carry RTP packets MAY be required.
+
+   Transport mapping: A mapping of RTP and RTCP to transport-level
+      addresses, e.g., UDP ports, other than the standard mapping
+      defined in Section 11, p. 68 may be specified.
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 72]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Encapsulation: An encapsulation of RTP packets may be defined to
+      allow multiple RTP data packets to be carried in one lower-layer
+      packet or to provide framing over underlying protocols that do not
+      already do so (Section 11, p. 69).
+
+   It is not expected that a new profile will be required for every
+   application.  Within one application class, it would be better to
+   extend an existing profile rather than make a new one in order to
+   facilitate interoperation among the applications since each will
+   typically run under only one profile.  Simple extensions such as the
+   definition of additional payload type values or RTCP packet types may
+   be accomplished by registering them through IANA and publishing their
+   descriptions in an addendum to the profile or in a payload format
+   specification.
+
+14. Security Considerations
+
+   RTP suffers from the same security liabilities as the underlying
+   protocols.  For example, an impostor can fake source or destination
+   network addresses, or change the header or payload.  Within RTCP, the
+   CNAME and NAME information may be used to impersonate another
+   participant.  In addition, RTP may be sent via IP multicast, which
+   provides no direct means for a sender to know all the receivers of
+   the data sent and therefore no measure of privacy.  Rightly or not,
+   users may be more sensitive to privacy concerns with audio and video
+   communication than they have been with more traditional forms of
+   network communication [33].  Therefore, the use of security
+   mechanisms with RTP is important.  These mechanisms are discussed in
+   Section 9.
+
+   RTP-level translators or mixers may be used to allow RTP traffic to
+   reach hosts behind firewalls.  Appropriate firewall security
+   principles and practices, which are beyond the scope of this
+   document, should be followed in the design and installation of these
+   devices and in the admission of RTP applications for use behind the
+   firewall.
+
+15. IANA Considerations
+
+   Additional RTCP packet types and SDES item types may be registered
+   through the Internet Assigned Numbers Authority (IANA).  Since these
+   number spaces are small, allowing unconstrained registration of new
+   values would not be prudent.  To facilitate review of requests and to
+   promote shared use of new types among multiple applications, requests
+   for registration of new values must be documented in an RFC or other
+   permanent and readily available reference such as the product of
+   another cooperative standards body (e.g., ITU-T).  Other requests may
+   also be accepted, under the advice of a "designated expert."
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 73]
+
+RFC 3550                          RTP                          July 2003
+
+
+   (Contact the IANA for the contact information of the current expert.)
+
+   RTP profile specifications SHOULD register with IANA a name for the
+   profile in the form "RTP/xxx", where xxx is a short abbreviation of
+   the profile title.  These names are for use by higher-level control
+   protocols, such as the Session Description Protocol (SDP), RFC 2327
+   [15], to refer to transport methods.
+
+16. Intellectual Property Rights Statement
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+17.  Acknowledgments
+
+   This memorandum is based on discussions within the IETF Audio/Video
+   Transport working group chaired by Stephen Casner and Colin Perkins.
+   The current protocol has its origins in the Network Voice Protocol
+   and the Packet Video Protocol (Danny Cohen and Randy Cole) and the
+   protocol implemented by the vat application (Van Jacobson and Steve
+   McCanne).  Christian Huitema provided ideas for the random identifier
+   generator.  Extensive analysis and simulation of the timer
+   reconsideration algorithm was done by Jonathan Rosenberg.  The
+   additions for layered encodings were specified by Michael Speer and
+   Steve McCanne.
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 74]
+
+RFC 3550                          RTP                          July 2003
+
+
+Appendix A - Algorithms
+
+   We provide examples of C code for aspects of RTP sender and receiver
+   algorithms.  There may be other implementation methods that are
+   faster in particular operating environments or have other advantages.
+   These implementation notes are for informational purposes only and
+   are meant to clarify the RTP specification.
+
+   The following definitions are used for all examples; for clarity and
+   brevity, the structure definitions are only valid for 32-bit big-
+   endian (most significant octet first) architectures.  Bit fields are
+   assumed to be packed tightly in big-endian bit order, with no
+   additional padding.  Modifications would be required to construct a
+   portable implementation.
+
+   /*
+    * rtp.h  --  RTP header file
+    */
+   #include <sys/types.h>
+
+   /*
+    * The type definitions below are valid for 32-bit architectures and
+    * may have to be adjusted for 16- or 64-bit architectures.
+    */
+   typedef unsigned char  u_int8;
+   typedef unsigned short u_int16;
+   typedef unsigned int   u_int32;
+   typedef          short int16;
+
+   /*
+    * Current protocol version.
+    */
+   #define RTP_VERSION    2
+
+   #define RTP_SEQ_MOD (1<<16)
+   #define RTP_MAX_SDES 255      /* maximum text length for SDES */
+
+   typedef enum {
+       RTCP_SR   = 200,
+       RTCP_RR   = 201,
+       RTCP_SDES = 202,
+       RTCP_BYE  = 203,
+       RTCP_APP  = 204
+   } rtcp_type_t;
+
+   typedef enum {
+       RTCP_SDES_END   = 0,
+       RTCP_SDES_CNAME = 1,
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 75]
+
+RFC 3550                          RTP                          July 2003
+
+
+       RTCP_SDES_NAME  = 2,
+       RTCP_SDES_EMAIL = 3,
+       RTCP_SDES_PHONE = 4,
+       RTCP_SDES_LOC   = 5,
+       RTCP_SDES_TOOL  = 6,
+       RTCP_SDES_NOTE  = 7,
+       RTCP_SDES_PRIV  = 8
+   } rtcp_sdes_type_t;
+
+   /*
+    * RTP data header
+    */
+   typedef struct {
+       unsigned int version:2;   /* protocol version */
+       unsigned int p:1;         /* padding flag */
+       unsigned int x:1;         /* header extension flag */
+       unsigned int cc:4;        /* CSRC count */
+       unsigned int m:1;         /* marker bit */
+       unsigned int pt:7;        /* payload type */
+       unsigned int seq:16;      /* sequence number */
+       u_int32 ts;               /* timestamp */
+       u_int32 ssrc;             /* synchronization source */
+       u_int32 csrc[1];          /* optional CSRC list */
+   } rtp_hdr_t;
+
+   /*
+    * RTCP common header word
+    */
+   typedef struct {
+       unsigned int version:2;   /* protocol version */
+       unsigned int p:1;         /* padding flag */
+       unsigned int count:5;     /* varies by packet type */
+       unsigned int pt:8;        /* RTCP packet type */
+       u_int16 length;           /* pkt len in words, w/o this word */
+   } rtcp_common_t;
+
+   /*
+    * Big-endian mask for version, padding bit and packet type pair
+    */
+   #define RTCP_VALID_MASK (0xc000 | 0x2000 | 0xfe)
+   #define RTCP_VALID_VALUE ((RTP_VERSION << 14) | RTCP_SR)
+
+   /*
+    * Reception report block
+    */
+   typedef struct {
+       u_int32 ssrc;             /* data source being reported */
+       unsigned int fraction:8;  /* fraction lost since last SR/RR */
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 76]
+
+RFC 3550                          RTP                          July 2003
+
+
+       int lost:24;              /* cumul. no. pkts lost (signed!) */
+       u_int32 last_seq;         /* extended last seq. no. received */
+       u_int32 jitter;           /* interarrival jitter */
+       u_int32 lsr;              /* last SR packet from this source */
+       u_int32 dlsr;             /* delay since last SR packet */
+   } rtcp_rr_t;
+
+   /*
+    * SDES item
+    */
+   typedef struct {
+       u_int8 type;              /* type of item (rtcp_sdes_type_t) */
+       u_int8 length;            /* length of item (in octets) */
+       char data[1];             /* text, not null-terminated */
+   } rtcp_sdes_item_t;
+
+   /*
+    * One RTCP packet
+    */
+   typedef struct {
+       rtcp_common_t common;     /* common header */
+       union {
+           /* sender report (SR) */
+           struct {
+               u_int32 ssrc;     /* sender generating this report */
+               u_int32 ntp_sec;  /* NTP timestamp */
+               u_int32 ntp_frac;
+               u_int32 rtp_ts;   /* RTP timestamp */
+               u_int32 psent;    /* packets sent */
+               u_int32 osent;    /* octets sent */
+               rtcp_rr_t rr[1];  /* variable-length list */
+           } sr;
+
+           /* reception report (RR) */
+           struct {
+               u_int32 ssrc;     /* receiver generating this report */
+               rtcp_rr_t rr[1];  /* variable-length list */
+           } rr;
+
+           /* source description (SDES) */
+           struct rtcp_sdes {
+               u_int32 src;      /* first SSRC/CSRC */
+               rtcp_sdes_item_t item[1]; /* list of SDES items */
+           } sdes;
+
+           /* BYE */
+           struct {
+               u_int32 src[1];   /* list of sources */
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 77]
+
+RFC 3550                          RTP                          July 2003
+
+
+               /* can't express trailing text for reason */
+           } bye;
+       } r;
+   } rtcp_t;
+
+   typedef struct rtcp_sdes rtcp_sdes_t;
+
+   /*
+    * Per-source state information
+    */
+   typedef struct {
+       u_int16 max_seq;        /* highest seq. number seen */
+       u_int32 cycles;         /* shifted count of seq. number cycles */
+       u_int32 base_seq;       /* base seq number */
+       u_int32 bad_seq;        /* last 'bad' seq number + 1 */
+       u_int32 probation;      /* sequ. packets till source is valid */
+       u_int32 received;       /* packets received */
+       u_int32 expected_prior; /* packet expected at last interval */
+       u_int32 received_prior; /* packet received at last interval */
+       u_int32 transit;        /* relative trans time for prev pkt */
+       u_int32 jitter;         /* estimated jitter */
+       /* ... */
+   } source;
+
+A.1 RTP Data Header Validity Checks
+
+   An RTP receiver should check the validity of the RTP header on
+   incoming packets since they might be encrypted or might be from a
+   different application that happens to be misaddressed.  Similarly, if
+   encryption according to the method described in Section 9 is enabled,
+   the header validity check is needed to verify that incoming packets
+   have been correctly decrypted, although a failure of the header
+   validity check (e.g., unknown payload type) may not necessarily
+   indicate decryption failure.
+
+   Only weak validity checks are possible on an RTP data packet from a
+   source that has not been heard before:
+
+   o  RTP version field must equal 2.
+
+   o  The payload type must be known, and in particular it must not be
+      equal to SR or RR.
+
+   o  If the P bit is set, then the last octet of the packet must
+      contain a valid octet count, in particular, less than the total
+      packet length minus the header size.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 78]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  The X bit must be zero if the profile does not specify that the
+      header extension mechanism may be used.  Otherwise, the extension
+      length field must be less than the total packet size minus the
+      fixed header length and padding.
+
+   o  The length of the packet must be consistent with CC and payload
+      type (if payloads have a known length).
+
+   The last three checks are somewhat complex and not always possible,
+   leaving only the first two which total just a few bits.  If the SSRC
+   identifier in the packet is one that has been received before, then
+   the packet is probably valid and checking if the sequence number is
+   in the expected range provides further validation.  If the SSRC
+   identifier has not been seen before, then data packets carrying that
+   identifier may be considered invalid until a small number of them
+   arrive with consecutive sequence numbers.  Those invalid packets MAY
+   be discarded or they MAY be stored and delivered once validation has
+   been achieved if the resulting delay is acceptable.
+
+   The routine update_seq shown below ensures that a source is declared
+   valid only after MIN_SEQUENTIAL packets have been received in
+   sequence.  It also validates the sequence number seq of a newly
+   received packet and updates the sequence state for the packet's
+   source in the structure to which s points.
+
+   When a new source is heard for the first time, that is, its SSRC
+   identifier is not in the table (see Section 8.2), and the per-source
+   state is allocated for it, s->probation is set to the number of
+   sequential packets required before declaring a source valid
+   (parameter MIN_SEQUENTIAL) and other variables are initialized:
+
+      init_seq(s, seq);
+      s->max_seq = seq - 1;
+      s->probation = MIN_SEQUENTIAL;
+
+   A non-zero s->probation marks the source as not yet valid so the
+   state may be discarded after a short timeout rather than a long one,
+   as discussed in Section 6.2.1.
+
+   After a source is considered valid, the sequence number is considered
+   valid if it is no more than MAX_DROPOUT ahead of s->max_seq nor more
+   than MAX_MISORDER behind.  If the new sequence number is ahead of
+   max_seq modulo the RTP sequence number range (16 bits), but is
+   smaller than max_seq, it has wrapped around and the (shifted) count
+   of sequence number cycles is incremented.  A value of one is returned
+   to indicate a valid sequence number.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 79]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Otherwise, the value zero is returned to indicate that the validation
+   failed, and the bad sequence number plus 1 is stored.  If the next
+   packet received carries the next higher sequence number, it is
+   considered the valid start of a new packet sequence presumably caused
+   by an extended dropout or a source restart.  Since multiple complete
+   sequence number cycles may have been missed, the packet loss
+   statistics are reset.
+
+   Typical values for the parameters are shown, based on a maximum
+   misordering time of 2 seconds at 50 packets/second and a maximum
+   dropout of 1 minute.  The dropout parameter MAX_DROPOUT should be a
+   small fraction of the 16-bit sequence number space to give a
+   reasonable probability that new sequence numbers after a restart will
+   not fall in the acceptable range for sequence numbers from before the
+   restart.
+
+   void init_seq(source *s, u_int16 seq)
+   {
+       s->base_seq = seq;
+       s->max_seq = seq;
+       s->bad_seq = RTP_SEQ_MOD + 1;   /* so seq == bad_seq is false */
+       s->cycles = 0;
+       s->received = 0;
+       s->received_prior = 0;
+       s->expected_prior = 0;
+       /* other initialization */
+   }
+
+   int update_seq(source *s, u_int16 seq)
+   {
+       u_int16 udelta = seq - s->max_seq;
+       const int MAX_DROPOUT = 3000;
+       const int MAX_MISORDER = 100;
+       const int MIN_SEQUENTIAL = 2;
+
+       /*
+        * Source is not valid until MIN_SEQUENTIAL packets with
+        * sequential sequence numbers have been received.
+        */
+       if (s->probation) {
+           /* packet is in sequence */
+           if (seq == s->max_seq + 1) {
+               s->probation--;
+               s->max_seq = seq;
+               if (s->probation == 0) {
+                   init_seq(s, seq);
+                   s->received++;
+                   return 1;
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 80]
+
+RFC 3550                          RTP                          July 2003
+
+
+               }
+           } else {
+               s->probation = MIN_SEQUENTIAL - 1;
+               s->max_seq = seq;
+           }
+           return 0;
+       } else if (udelta < MAX_DROPOUT) {
+           /* in order, with permissible gap */
+           if (seq < s->max_seq) {
+               /*
+                * Sequence number wrapped - count another 64K cycle.
+                */
+               s->cycles += RTP_SEQ_MOD;
+           }
+           s->max_seq = seq;
+       } else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER) {
+           /* the sequence number made a very large jump */
+           if (seq == s->bad_seq) {
+               /*
+                * Two sequential packets -- assume that the other side
+                * restarted without telling us so just re-sync
+                * (i.e., pretend this was the first packet).
+                */
+               init_seq(s, seq);
+           }
+           else {
+               s->bad_seq = (seq + 1) & (RTP_SEQ_MOD-1);
+               return 0;
+           }
+       } else {
+           /* duplicate or reordered packet */
+       }
+       s->received++;
+       return 1;
+   }
+
+   The validity check can be made stronger requiring more than two
+   packets in sequence.  The disadvantages are that a larger number of
+   initial packets will be discarded (or delayed in a queue) and that
+   high packet loss rates could prevent validation.  However, because
+   the RTCP header validation is relatively strong, if an RTCP packet is
+   received from a source before the data packets, the count could be
+   adjusted so that only two packets are required in sequence.  If
+   initial data loss for a few seconds can be tolerated, an application
+   MAY choose to discard all data packets from a source until a valid
+   RTCP packet has been received from that source.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 81]
+
+RFC 3550                          RTP                          July 2003
+
+
+   Depending on the application and encoding, algorithms may exploit
+   additional knowledge about the payload format for further validation.
+   For payload types where the timestamp increment is the same for all
+   packets, the timestamp values can be predicted from the previous
+   packet received from the same source using the sequence number
+   difference (assuming no change in payload type).
+
+   A strong "fast-path" check is possible since with high probability
+   the first four octets in the header of a newly received RTP data
+   packet will be just the same as that of the previous packet from the
+   same SSRC except that the sequence number will have increased by one.
+   Similarly, a single-entry cache may be used for faster SSRC lookups
+   in applications where data is typically received from one source at a
+   time.
+
+A.2 RTCP Header Validity Checks
+
+   The following checks should be applied to RTCP packets.
+
+   o  RTP version field must equal 2.
+
+   o  The payload type field of the first RTCP packet in a compound
+      packet must be equal to SR or RR.
+
+   o  The padding bit (P) should be zero for the first packet of a
+      compound RTCP packet because padding should only be applied, if it
+      is needed, to the last packet.
+
+   o  The length fields of the individual RTCP packets must add up to
+      the overall length of the compound RTCP packet as received.  This
+      is a fairly strong check.
+
+   The code fragment below performs all of these checks.  The packet
+   type is not checked for subsequent packets since unknown packet types
+   may be present and should be ignored.
+
+      u_int32 len;        /* length of compound RTCP packet in words */
+      rtcp_t *r;          /* RTCP header */
+      rtcp_t *end;        /* end of compound RTCP packet */
+
+      if ((*(u_int16 *)r & RTCP_VALID_MASK) != RTCP_VALID_VALUE) {
+          /* something wrong with packet format */
+      }
+      end = (rtcp_t *)((u_int32 *)r + len);
+
+      do r = (rtcp_t *)((u_int32 *)r + r->common.length + 1);
+      while (r < end && r->common.version == 2);
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 82]
+
+RFC 3550                          RTP                          July 2003
+
+
+      if (r != end) {
+          /* something wrong with packet format */
+      }
+
+A.3 Determining Number of Packets Expected and Lost
+
+   In order to compute packet loss rates, the number of RTP packets
+   expected and actually received from each source needs to be known,
+   using per-source state information defined in struct source
+   referenced via pointer s in the code below.  The number of packets
+   received is simply the count of packets as they arrive, including any
+   late or duplicate packets.  The number of packets expected can be
+   computed by the receiver as the difference between the highest
+   sequence number received (s->max_seq) and the first sequence number
+   received (s->base_seq).  Since the sequence number is only 16 bits
+   and will wrap around, it is necessary to extend the highest sequence
+   number with the (shifted) count of sequence number wraparounds
+   (s->cycles).  Both the received packet count and the count of cycles
+   are maintained the RTP header validity check routine in Appendix A.1.
+
+      extended_max = s->cycles + s->max_seq;
+      expected = extended_max - s->base_seq + 1;
+
+   The number of packets lost is defined to be the number of packets
+   expected less the number of packets actually received:
+
+      lost = expected - s->received;
+
+   Since this signed number is carried in 24 bits, it should be clamped
+   at 0x7fffff for positive loss or 0x800000 for negative loss rather
+   than wrapping around.
+
+   The fraction of packets lost during the last reporting interval
+   (since the previous SR or RR packet was sent) is calculated from
+   differences in the expected and received packet counts across the
+   interval, where expected_prior and received_prior are the values
+   saved when the previous reception report was generated:
+
+      expected_interval = expected - s->expected_prior;
+      s->expected_prior = expected;
+      received_interval = s->received - s->received_prior;
+      s->received_prior = s->received;
+      lost_interval = expected_interval - received_interval;
+      if (expected_interval == 0 || lost_interval <= 0) fraction = 0;
+      else fraction = (lost_interval << 8) / expected_interval;
+
+   The resulting fraction is an 8-bit fixed point number with the binary
+   point at the left edge.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 83]
+
+RFC 3550                          RTP                          July 2003
+
+
+A.4 Generating RTCP SDES Packets
+
+   This function builds one SDES chunk into buffer b composed of argc
+   items supplied in arrays type, value and length.  It returns a
+   pointer to the next available location within b.
+
+   char *rtp_write_sdes(char *b, u_int32 src, int argc,
+                        rtcp_sdes_type_t type[], char *value[],
+                        int length[])
+   {
+       rtcp_sdes_t *s = (rtcp_sdes_t *)b;
+       rtcp_sdes_item_t *rsp;
+       int i;
+       int len;
+       int pad;
+
+       /* SSRC header */
+       s->src = src;
+       rsp = &s->item[0];
+
+       /* SDES items */
+       for (i = 0; i < argc; i++) {
+           rsp->type = type[i];
+           len = length[i];
+           if (len > RTP_MAX_SDES) {
+               /* invalid length, may want to take other action */
+               len = RTP_MAX_SDES;
+           }
+           rsp->length = len;
+           memcpy(rsp->data, value[i], len);
+           rsp = (rtcp_sdes_item_t *)&rsp->data[len];
+       }
+
+       /* terminate with end marker and pad to next 4-octet boundary */
+       len = ((char *) rsp) - b;
+       pad = 4 - (len & 0x3);
+       b = (char *) rsp;
+       while (pad--) *b++ = RTCP_SDES_END;
+
+       return b;
+   }
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 84]
+
+RFC 3550                          RTP                          July 2003
+
+
+A.5 Parsing RTCP SDES Packets
+
+   This function parses an SDES packet, calling functions find_member()
+   to find a pointer to the information for a session member given the
+   SSRC identifier and member_sdes() to store the new SDES information
+   for that member.  This function expects a pointer to the header of
+   the RTCP packet.
+
+   void rtp_read_sdes(rtcp_t *r)
+   {
+       int count = r->common.count;
+       rtcp_sdes_t *sd = &r->r.sdes;
+       rtcp_sdes_item_t *rsp, *rspn;
+       rtcp_sdes_item_t *end = (rtcp_sdes_item_t *)
+                               ((u_int32 *)r + r->common.length + 1);
+       source *s;
+
+       while (--count >= 0) {
+           rsp = &sd->item[0];
+           if (rsp >= end) break;
+           s = find_member(sd->src);
+
+           for (; rsp->type; rsp = rspn ) {
+               rspn = (rtcp_sdes_item_t *)((char*)rsp+rsp->length+2);
+               if (rspn >= end) {
+                   rsp = rspn;
+                   break;
+               }
+               member_sdes(s, rsp->type, rsp->data, rsp->length);
+           }
+           sd = (rtcp_sdes_t *)
+                ((u_int32 *)sd + (((char *)rsp - (char *)sd) >> 2)+1);
+       }
+       if (count >= 0) {
+           /* invalid packet format */
+       }
+   }
+
+A.6 Generating a Random 32-bit Identifier
+
+   The following subroutine generates a random 32-bit identifier using
+   the MD5 routines published in RFC 1321 [32].  The system routines may
+   not be present on all operating systems, but they should serve as
+   hints as to what kinds of information may be used.  Other system
+   calls that may be appropriate include
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 85]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  getdomainname(),
+
+   o  getwd(), or
+
+   o  getrusage().
+
+   "Live" video or audio samples are also a good source of random
+   numbers, but care must be taken to avoid using a turned-off
+   microphone or blinded camera as a source [17].
+
+   Use of this or a similar routine is recommended to generate the
+   initial seed for the random number generator producing the RTCP
+   period (as shown in Appendix A.7), to generate the initial values for
+   the sequence number and timestamp, and to generate SSRC values.
+   Since this routine is likely to be CPU-intensive, its direct use to
+   generate RTCP periods is inappropriate because predictability is not
+   an issue.  Note that this routine produces the same result on
+   repeated calls until the value of the system clock changes unless
+   different values are supplied for the type argument.
+
+   /*
+    * Generate a random 32-bit quantity.
+    */
+   #include <sys/types.h>   /* u_long */
+   #include <sys/time.h>    /* gettimeofday() */
+   #include <unistd.h>      /* get..() */
+   #include <stdio.h>       /* printf() */
+   #include <time.h>        /* clock() */
+   #include <sys/utsname.h> /* uname() */
+   #include "global.h"      /* from RFC 1321 */
+   #include "md5.h"         /* from RFC 1321 */
+
+   #define MD_CTX MD5_CTX
+   #define MDInit MD5Init
+   #define MDUpdate MD5Update
+   #define MDFinal MD5Final
+
+   static u_long md_32(char *string, int length)
+   {
+       MD_CTX context;
+       union {
+           char   c[16];
+           u_long x[4];
+       } digest;
+       u_long r;
+       int i;
+
+       MDInit (&context);
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 86]
+
+RFC 3550                          RTP                          July 2003
+
+
+       MDUpdate (&context, string, length);
+       MDFinal ((unsigned char *)&digest, &context);
+       r = 0;
+       for (i = 0; i < 3; i++) {
+           r ^= digest.x[i];
+       }
+       return r;
+   }                               /* md_32 */
+
+   /*
+    * Return random unsigned 32-bit quantity.  Use 'type' argument if
+    * you need to generate several different values in close succession.
+    */
+   u_int32 random32(int type)
+   {
+       struct {
+           int     type;
+           struct  timeval tv;
+           clock_t cpu;
+           pid_t   pid;
+           u_long  hid;
+           uid_t   uid;
+           gid_t   gid;
+           struct  utsname name;
+       } s;
+
+       gettimeofday(&s.tv, 0);
+       uname(&s.name);
+       s.type = type;
+       s.cpu  = clock();
+       s.pid  = getpid();
+       s.hid  = gethostid();
+       s.uid  = getuid();
+       s.gid  = getgid();
+       /* also: system uptime */
+
+       return md_32((char *)&s, sizeof(s));
+   }                               /* random32 */
+
+A.7 Computing the RTCP Transmission Interval
+
+   The following functions implement the RTCP transmission and reception
+   rules described in Section 6.2.  These rules are coded in several
+   functions:
+
+   o  rtcp_interval() computes the deterministic calculated interval,
+      measured in seconds.  The parameters are defined in Section 6.3.
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 87]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  OnExpire() is called when the RTCP transmission timer expires.
+
+   o  OnReceive() is called whenever an RTCP packet is received.
+
+   Both OnExpire() and OnReceive() have event e as an argument.  This is
+   the next scheduled event for that participant, either an RTCP report
+   or a BYE packet.  It is assumed that the following functions are
+   available:
+
+   o  Schedule(time t, event e) schedules an event e to occur at time t.
+      When time t arrives, the function OnExpire is called with e as an
+      argument.
+
+   o  Reschedule(time t, event e) reschedules a previously scheduled
+      event e for time t.
+
+   o  SendRTCPReport(event e) sends an RTCP report.
+
+   o  SendBYEPacket(event e) sends a BYE packet.
+
+   o  TypeOfEvent(event e) returns EVENT_BYE if the event being
+      processed is for a BYE packet to be sent, else it returns
+      EVENT_REPORT.
+
+   o  PacketType(p) returns PACKET_RTCP_REPORT if packet p is an RTCP
+      report (not BYE), PACKET_BYE if its a BYE RTCP packet, and
+      PACKET_RTP if its a regular RTP data packet.
+
+   o  ReceivedPacketSize() and SentPacketSize() return the size of the
+      referenced packet in octets.
+
+   o  NewMember(p) returns a 1 if the participant who sent packet p is
+      not currently in the member list, 0 otherwise.  Note this function
+      is not sufficient for a complete implementation because each CSRC
+      identifier in an RTP packet and each SSRC in a BYE packet should
+      be processed.
+
+   o  NewSender(p) returns a 1 if the participant who sent packet p is
+      not currently in the sender sublist of the member list, 0
+      otherwise.
+
+   o  AddMember() and RemoveMember() to add and remove participants from
+      the member list.
+
+   o  AddSender() and RemoveSender() to add and remove participants from
+      the sender sublist of the member list.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 88]
+
+RFC 3550                          RTP                          July 2003
+
+
+   These functions would have to be extended for an implementation that
+   allows the RTCP bandwidth fractions for senders and non-senders to be
+   specified as explicit parameters rather than fixed values of 25% and
+   75%.  The extended implementation of rtcp_interval() would need to
+   avoid division by zero if one of the parameters was zero.
+
+   double rtcp_interval(int members,
+                        int senders,
+                        double rtcp_bw,
+                        int we_sent,
+                        double avg_rtcp_size,
+                        int initial)
+   {
+       /*
+        * Minimum average time between RTCP packets from this site (in
+        * seconds).  This time prevents the reports from `clumping' when
+        * sessions are small and the law of large numbers isn't helping
+        * to smooth out the traffic.  It also keeps the report interval
+        * from becoming ridiculously small during transient outages like
+        * a network partition.
+        */
+       double const RTCP_MIN_TIME = 5.;
+       /*
+        * Fraction of the RTCP bandwidth to be shared among active
+        * senders.  (This fraction was chosen so that in a typical
+        * session with one or two active senders, the computed report
+        * time would be roughly equal to the minimum report time so that
+        * we don't unnecessarily slow down receiver reports.)  The
+        * receiver fraction must be 1 - the sender fraction.
+        */
+       double const RTCP_SENDER_BW_FRACTION = 0.25;
+       double const RTCP_RCVR_BW_FRACTION = (1-RTCP_SENDER_BW_FRACTION);
+       /*
+       /* To compensate for "timer reconsideration" converging to a
+        * value below the intended average.
+        */
+       double const COMPENSATION = 2.71828 - 1.5;
+
+       double t;                   /* interval */
+       double rtcp_min_time = RTCP_MIN_TIME;
+       int n;                      /* no. of members for computation */
+
+       /*
+        * Very first call at application start-up uses half the min
+        * delay for quicker notification while still allowing some time
+        * before reporting for randomization and to learn about other
+        * sources so the report interval will converge to the correct
+        * interval more quickly.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 89]
+
+RFC 3550                          RTP                          July 2003
+
+
+        */
+       if (initial) {
+           rtcp_min_time /= 2;
+       }
+       /*
+        * Dedicate a fraction of the RTCP bandwidth to senders unless
+        * the number of senders is large enough that their share is
+        * more than that fraction.
+        */
+       n = members;
+       if (senders <= members * RTCP_SENDER_BW_FRACTION) {
+           if (we_sent) {
+               rtcp_bw *= RTCP_SENDER_BW_FRACTION;
+               n = senders;
+           } else {
+               rtcp_bw *= RTCP_RCVR_BW_FRACTION;
+               n -= senders;
+           }
+       }
+
+       /*
+        * The effective number of sites times the average packet size is
+        * the total number of octets sent when each site sends a report.
+        * Dividing this by the effective bandwidth gives the time
+        * interval over which those packets must be sent in order to
+        * meet the bandwidth target, with a minimum enforced.  In that
+        * time interval we send one report so this time is also our
+        * average time between reports.
+        */
+       t = avg_rtcp_size * n / rtcp_bw;
+       if (t < rtcp_min_time) t = rtcp_min_time;
+
+       /*
+        * To avoid traffic bursts from unintended synchronization with
+        * other sites, we then pick our actual next report interval as a
+        * random number uniformly distributed between 0.5*t and 1.5*t.
+        */
+       t = t * (drand48() + 0.5);
+       t = t / COMPENSATION;
+       return t;
+   }
+
+   void OnExpire(event e,
+                 int    members,
+                 int    senders,
+                 double rtcp_bw,
+                 int    we_sent,
+                 double *avg_rtcp_size,
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 90]
+
+RFC 3550                          RTP                          July 2003
+
+
+                 int    *initial,
+                 time_tp   tc,
+                 time_tp   *tp,
+                 int    *pmembers)
+   {
+       /* This function is responsible for deciding whether to send an
+        * RTCP report or BYE packet now, or to reschedule transmission.
+        * It is also responsible for updating the pmembers, initial, tp,
+        * and avg_rtcp_size state variables.  This function should be
+        * called upon expiration of the event timer used by Schedule().
+        */
+
+       double t;     /* Interval */
+       double tn;    /* Next transmit time */
+
+       /* In the case of a BYE, we use "timer reconsideration" to
+        * reschedule the transmission of the BYE if necessary */
+
+       if (TypeOfEvent(e) == EVENT_BYE) {
+           t = rtcp_interval(members,
+                             senders,
+                             rtcp_bw,
+                             we_sent,
+                             *avg_rtcp_size,
+                             *initial);
+           tn = *tp + t;
+           if (tn <= tc) {
+               SendBYEPacket(e);
+               exit(1);
+           } else {
+               Schedule(tn, e);
+           }
+
+       } else if (TypeOfEvent(e) == EVENT_REPORT) {
+           t = rtcp_interval(members,
+                             senders,
+                             rtcp_bw,
+                             we_sent,
+                             *avg_rtcp_size,
+                             *initial);
+           tn = *tp + t;
+           if (tn <= tc) {
+               SendRTCPReport(e);
+               *avg_rtcp_size = (1./16.)*SentPacketSize(e) +
+                   (15./16.)*(*avg_rtcp_size);
+               *tp = tc;
+
+               /* We must redraw the interval.  Don't reuse the
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 91]
+
+RFC 3550                          RTP                          July 2003
+
+
+                  one computed above, since its not actually
+                  distributed the same, as we are conditioned
+                  on it being small enough to cause a packet to
+                  be sent */
+
+               t = rtcp_interval(members,
+                                 senders,
+                                 rtcp_bw,
+                                 we_sent,
+                                 *avg_rtcp_size,
+                                 *initial);
+
+               Schedule(t+tc,e);
+               *initial = 0;
+           } else {
+               Schedule(tn, e);
+           }
+           *pmembers = members;
+       }
+   }
+
+   void OnReceive(packet p,
+                  event e,
+                  int *members,
+                  int *pmembers,
+                  int *senders,
+                  double *avg_rtcp_size,
+                  double *tp,
+                  double tc,
+                  double tn)
+   {
+       /* What we do depends on whether we have left the group, and are
+        * waiting to send a BYE (TypeOfEvent(e) == EVENT_BYE) or an RTCP
+        * report.  p represents the packet that was just received.  */
+
+       if (PacketType(p) == PACKET_RTCP_REPORT) {
+           if (NewMember(p) && (TypeOfEvent(e) == EVENT_REPORT)) {
+               AddMember(p);
+               *members += 1;
+           }
+           *avg_rtcp_size = (1./16.)*ReceivedPacketSize(p) +
+               (15./16.)*(*avg_rtcp_size);
+       } else if (PacketType(p) == PACKET_RTP) {
+           if (NewMember(p) && (TypeOfEvent(e) == EVENT_REPORT)) {
+               AddMember(p);
+               *members += 1;
+           }
+           if (NewSender(p) && (TypeOfEvent(e) == EVENT_REPORT)) {
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 92]
+
+RFC 3550                          RTP                          July 2003
+
+
+               AddSender(p);
+               *senders += 1;
+           }
+       } else if (PacketType(p) == PACKET_BYE) {
+           *avg_rtcp_size = (1./16.)*ReceivedPacketSize(p) +
+               (15./16.)*(*avg_rtcp_size);
+
+           if (TypeOfEvent(e) == EVENT_REPORT) {
+               if (NewSender(p) == FALSE) {
+                   RemoveSender(p);
+                   *senders -= 1;
+               }
+
+               if (NewMember(p) == FALSE) {
+                   RemoveMember(p);
+                   *members -= 1;
+               }
+
+               if (*members < *pmembers) {
+                   tn = tc +
+                       (((double) *members)/(*pmembers))*(tn - tc);
+                   *tp = tc -
+                       (((double) *members)/(*pmembers))*(tc - *tp);
+
+                   /* Reschedule the next report for time tn */
+
+                   Reschedule(tn, e);
+                   *pmembers = *members;
+               }
+
+           } else if (TypeOfEvent(e) == EVENT_BYE) {
+               *members += 1;
+           }
+       }
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 93]
+
+RFC 3550                          RTP                          July 2003
+
+
+A.8 Estimating the Interarrival Jitter
+
+   The code fragments below implement the algorithm given in Section
+   6.4.1 for calculating an estimate of the statistical variance of the
+   RTP data interarrival time to be inserted in the interarrival jitter
+   field of reception reports.  The inputs are r->ts, the timestamp from
+   the incoming packet, and arrival, the current time in the same units.
+   Here s points to state for the source; s->transit holds the relative
+   transit time for the previous packet, and s->jitter holds the
+   estimated jitter.  The jitter field of the reception report is
+   measured in timestamp units and expressed as an unsigned integer, but
+   the jitter estimate is kept in a floating point.  As each data packet
+   arrives, the jitter estimate is updated:
+
+      int transit = arrival - r->ts;
+      int d = transit - s->transit;
+      s->transit = transit;
+      if (d < 0) d = -d;
+      s->jitter += (1./16.) * ((double)d - s->jitter);
+
+   When a reception report block (to which rr points) is generated for
+   this member, the current jitter estimate is returned:
+
+      rr->jitter = (u_int32) s->jitter;
+
+   Alternatively, the jitter estimate can be kept as an integer, but
+   scaled to reduce round-off error.  The calculation is the same except
+   for the last line:
+
+      s->jitter += d - ((s->jitter + 8) >> 4);
+
+   In this case, the estimate is sampled for the reception report as:
+
+      rr->jitter = s->jitter >> 4;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 94]
+
+RFC 3550                          RTP                          July 2003
+
+
+Appendix B - Changes from RFC 1889
+
+   Most of this RFC is identical to RFC 1889.  There are no changes in
+   the packet formats on the wire, only changes to the rules and
+   algorithms governing how the protocol is used.  The biggest change is
+   an enhancement to the scalable timer algorithm for calculating when
+   to send RTCP packets:
+
+   o  The algorithm for calculating the RTCP transmission interval
+      specified in Sections 6.2 and 6.3 and illustrated in Appendix A.7
+      is augmented to include "reconsideration" to minimize transmission
+      in excess of the intended rate when many participants join a
+      session simultaneously, and "reverse reconsideration" to reduce
+      the incidence and duration of false participant timeouts when the
+      number of participants drops rapidly.  Reverse reconsideration is
+      also used to possibly shorten the delay before sending RTCP SR
+      when transitioning from passive receiver to active sender mode.
+
+   o  Section 6.3.7 specifies new rules controlling when an RTCP BYE
+      packet should be sent in order to avoid a flood of packets when
+      many participants leave a session simultaneously.
+
+   o  The requirement to retain state for inactive participants for a
+      period long enough to span typical network partitions was removed
+      from Section 6.2.1.  In a session where many participants join for
+      a brief time and fail to send BYE, this requirement would cause a
+      significant overestimate of the number of participants.  The
+      reconsideration algorithm added in this revision compensates for
+      the large number of new participants joining simultaneously when a
+      partition heals.
+
+   It should be noted that these enhancements only have a significant
+   effect when the number of session participants is large (thousands)
+   and most of the participants join or leave at the same time.  This
+   makes testing in a live network difficult.  However, the algorithm
+   was subjected to a thorough analysis and simulation to verify its
+   performance.  Furthermore, the enhanced algorithm was designed to
+   interoperate with the algorithm in RFC 1889 such that the degree of
+   reduction in excess RTCP bandwidth during a step join is proportional
+   to the fraction of participants that implement the enhanced
+   algorithm.  Interoperation of the two algorithms has been verified
+   experimentally on live networks.
+
+   Other functional changes were:
+
+   o  Section 6.2.1 specifies that implementations may store only a
+      sampling of the participants' SSRC identifiers to allow scaling to
+      very large sessions.  Algorithms are specified in RFC 2762 [21].
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 95]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  In Section 6.2 it is specified that RTCP sender and non-sender
+      bandwidths may be set as separate parameters of the session rather
+      than a strict percentage of the session bandwidth, and may be set
+      to zero.  The requirement that RTCP was mandatory for RTP sessions
+      using IP multicast was relaxed.  However, a clarification was also
+      added that turning off RTCP is NOT RECOMMENDED.
+
+   o  In Sections 6.2, 6.3.1 and Appendix A.7, it is specified that the
+      fraction of participants below which senders get dedicated RTCP
+      bandwidth changes from the fixed 1/4 to a ratio based on the RTCP
+      sender and non-sender bandwidth parameters when those are given.
+      The condition that no bandwidth is dedicated to senders when there
+      are no senders was removed since that is expected to be a
+      transitory state.  It also keeps non-senders from using sender
+      RTCP bandwidth when that is not intended.
+
+   o  Also in Section 6.2 it is specified that the minimum RTCP interval
+      may be scaled to smaller values for high bandwidth sessions, and
+      that the initial RTCP delay may be set to zero for unicast
+      sessions.
+
+   o  Timing out a participant is to be based on inactivity for a number
+      of RTCP report intervals calculated using the receiver RTCP
+      bandwidth fraction even for active senders.
+
+   o  Sections 7.2 and 7.3 specify that translators and mixers should
+      send BYE packets for the sources they are no longer forwarding.
+
+   o  Rule changes for layered encodings are defined in Sections 2.4,
+      6.3.9, 8.3 and 11.  In the last of these, it is noted that the
+      address and port assignment rule conflicts with the SDP
+      specification, RFC 2327 [15], but it is intended that this
+      restriction will be relaxed in a revision of RFC 2327.
+
+   o  The convention for using even/odd port pairs for RTP and RTCP in
+      Section 11 was clarified to refer to destination ports.  The
+      requirement to use an even/odd port pair was removed if the two
+      ports are specified explicitly.  For unicast RTP sessions,
+      distinct port pairs may be used for the two ends (Sections 3, 7.1
+      and 11).
+
+   o  A new Section 10 was added to explain the requirement for
+      congestion control in applications using RTP.
+
+   o  In Section 8.2, the requirement that a new SSRC identifier MUST be
+      chosen whenever the source transport address is changed has been
+      relaxed to say that a new SSRC identifier MAY be chosen.
+      Correspondingly, it was clarified that an implementation MAY
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 96]
+
+RFC 3550                          RTP                          July 2003
+
+
+      choose to keep packets from the new source address rather than the
+      existing source address when an SSRC collision occurs between two
+      other participants, and SHOULD do so for applications such as
+      telephony in which some sources such as mobile entities may change
+      addresses during the course of an RTP session.
+
+   o  An indentation bug in the RFC 1889 printing of the pseudo-code for
+      the collision detection and resolution algorithm in Section 8.2
+      has been corrected by translating the syntax to pseudo C language,
+      and the algorithm has been modified to remove the restriction that
+      both RTP and RTCP must be sent from the same source port number.
+
+   o  The description of the padding mechanism for RTCP packets was
+      clarified and it is specified that padding MUST only be applied to
+      the last packet of a compound RTCP packet.
+
+   o  In Section A.1, initialization of base_seq was corrected to be seq
+      rather than seq - 1, and the text was corrected to say the bad
+      sequence number plus 1 is stored.  The initialization of max_seq
+      and other variables for the algorithm was separated from the text
+      to make clear that this initialization must be done in addition to
+      calling the init_seq() function (and a few words lost in RFC 1889
+      when processing the document from source to output form were
+      restored).
+
+   o  Clamping of number of packets lost in Section A.3 was corrected to
+      use both positive and negative limits.
+
+   o  The specification of "relative" NTP timestamp in the RTCP SR
+      section now defines these timestamps to be based on the most
+      common system-specific clock, such as system uptime, rather than
+      on session elapsed time which would not be the same for multiple
+      applications started on the same machine at different times.
+
+   Non-functional changes:
+
+   o  It is specified that a receiver MUST ignore packets with payload
+      types it does not understand.
+
+   o  In Fig. 2, the floating point NTP timestamp value was corrected,
+      some missing leading zeros were added in a hex number, and the UTC
+      timezone was specified.
+
+   o  The inconsequence of NTP timestamps wrapping around in the year
+      2036 is explained.
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 97]
+
+RFC 3550                          RTP                          July 2003
+
+
+   o  The policy for registration of RTCP packet types and SDES types
+      was clarified in a new Section 15, IANA Considerations.  The
+      suggestion that experimenters register the numbers they need and
+      then unregister those which prove to be unneeded has been removed
+      in favor of using APP and PRIV.  Registration of profile names was
+      also specified.
+
+   o  The reference for the UTF-8 character set was changed from an
+      X/Open Preliminary Specification to be RFC 2279.
+
+   o  The reference for RFC 1597 was updated to RFC 1918 and the
+      reference for RFC 2543 was updated to RFC 3261.
+
+   o  The last paragraph of the introduction in RFC 1889, which
+      cautioned implementors to limit deployment in the Internet, was
+      removed because it was deemed no longer relevant.
+
+   o  A non-normative note regarding the use of RTP with Source-Specific
+      Multicast (SSM) was added in Section 6.
+
+   o  The definition of "RTP session" in Section 3 was expanded to
+      acknowledge that a single session may use multiple destination
+      transport addresses (as was always the case for a translator or
+      mixer) and to explain that the distinguishing feature of an RTP
+      session is that each corresponds to a separate SSRC identifier
+      space.  A new definition of "multimedia session" was added to
+      reduce confusion about the word "session".
+
+   o  The meaning of "sampling instant" was explained in more detail as
+      part of the definition of the timestamp field of the RTP header in
+      Section 5.1.
+
+   o  Small clarifications of the text have been made in several places,
+      some in response to questions from readers.  In particular:
+
+      -  In RFC 1889, the first five words of the second sentence of
+         Section 2.2 were lost in processing the document from source to
+         output form, but are now restored.
+
+      -  A definition for "RTP media type" was added in Section 3 to
+         allow the explanation of multiplexing RTP sessions in Section
+         5.2 to be more clear regarding the multiplexing of multiple
+         media.  That section also now explains that multiplexing
+         multiple sources of the same medium based on SSRC identifiers
+         may be appropriate and is the norm for multicast sessions.
+
+      -  The definition for "non-RTP means" was expanded to include
+         examples of other protocols constituting non-RTP means.
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 98]
+
+RFC 3550                          RTP                          July 2003
+
+
+      -  The description of the session bandwidth parameter is expanded
+         in Section 6.2, including a clarification that the control
+         traffic bandwidth is in addition to the session bandwidth for
+         the data traffic.
+
+      -  The effect of varying packet duration on the jitter calculation
+         was explained in Section 6.4.4.
+
+      -  The method for terminating and padding a sequence of SDES items
+         was clarified in Section 6.5.
+
+      -  IPv6 address examples were added in the description of SDES
+         CNAME in Section 6.5.1, and "example.com" was used in place of
+         other example domain names.
+
+      -  The Security section added a formal reference to IPSEC now that
+         it is available, and says that the confidentiality method
+         defined in this specification is primarily to codify existing
+         practice.  It is RECOMMENDED that stronger encryption
+         algorithms such as Triple-DES be used in place of the default
+         algorithm, and noted that the SRTP profile based on AES will be
+         the correct choice in the future.  A caution about the weakness
+         of the RTP header as an initialization vector was added.  It
+         was also noted that payload-only encryption is necessary to
+         allow for header compression.
+
+      -  The method for partial encryption of RTCP was clarified; in
+         particular, SDES CNAME is carried in only one part when the
+         compound RTCP packet is split.
+
+      -  It is clarified that only one compound RTCP packet should be
+         sent per reporting interval and that if there are too many
+         active sources for the reports to fit in the MTU, then a subset
+         of the sources should be selected round-robin over multiple
+         intervals.
+
+      -  A note was added in Appendix A.1 that packets may be saved
+         during RTP header validation and delivered upon success.
+
+      -  Section 7.3 now explains that a mixer aggregating SDES packets
+         uses more RTCP bandwidth due to longer packets, and a mixer
+         passing through RTCP naturally sends packets at higher than the
+         single source rate, but both behaviors are valid.
+
+      -  Section 13 clarifies that an RTP application may use multiple
+         profiles but typically only one in a given session.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                    [Page 99]
+
+RFC 3550                          RTP                          July 2003
+
+
+      -  The terms MUST, SHOULD, MAY, etc. are used as defined in RFC
+         2119.
+
+      -  The bibliography was divided into normative and informative
+         references.
+
+References
+
+Normative References
+
+   [1]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and Video
+        Conferences with Minimal Control", RFC 3551, July 2003.
+
+   [2]  Bradner, S., "Key Words for Use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [3]  Postel, J., "Internet Protocol", STD 5, RFC 791, September 1981.
+
+   [4]  Mills, D., "Network Time Protocol (Version 3) Specification,
+        Implementation and Analysis", RFC 1305, March 1992.
+
+   [5]  Yergeau, F., "UTF-8, a Transformation Format of ISO 10646", RFC
+        2279, January 1998.
+
+   [6]  Mockapetris, P., "Domain Names - Concepts and Facilities", STD
+        13, RFC 1034, November 1987.
+
+   [7]  Mockapetris, P., "Domain Names - Implementation and
+        Specification", STD 13, RFC 1035, November 1987.
+
+   [8]  Braden, R., "Requirements for Internet Hosts - Application and
+        Support", STD 3, RFC 1123, October 1989.
+
+   [9]  Resnick, P., "Internet Message Format", RFC 2822, April 2001.
+
+Informative References
+
+   [10] Clark, D. and D. Tennenhouse, "Architectural Considerations for
+        a New Generation of Protocols," in SIGCOMM Symposium on
+        Communications Architectures and Protocols , (Philadelphia,
+        Pennsylvania), pp. 200--208, IEEE Computer Communications
+        Review, Vol. 20(4), September 1990.
+
+   [11] Schulzrinne, H., "Issues in designing a transport protocol for
+        audio and video conferences and other multiparticipant real-time
+        applications." expired Internet Draft, October 1993.
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                   [Page 100]
+
+RFC 3550                          RTP                          July 2003
+
+
+   [12] Comer, D., Internetworking with TCP/IP , vol. 1.  Englewood
+        Cliffs, New Jersey: Prentice Hall, 1991.
+
+   [13] Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston, A.,
+        Peterson, J., Sparks, R., Handley, M. and E. Schooler, "SIP:
+        Session Initiation Protocol", RFC 3261, June 2002.
+
+   [14] International Telecommunication Union, "Visual telephone systems
+        and equipment for local area networks which provide a non-
+        guaranteed quality of service", Recommendation H.323,
+        Telecommunication Standardization Sector of ITU, Geneva,
+        Switzerland, July 2003.
+
+   [15] Handley, M. and V. Jacobson, "SDP: Session Description
+        Protocol", RFC 2327, April 1998.
+
+   [16] Schulzrinne, H., Rao, A. and R. Lanphier, "Real Time Streaming
+        Protocol (RTSP)", RFC 2326, April 1998.
+
+   [17] Eastlake 3rd, D., Crocker, S. and J. Schiller, "Randomness
+        Recommendations for Security", RFC 1750, December 1994.
+
+   [18] Bolot, J.-C., Turletti, T. and I. Wakeman, "Scalable Feedback
+        Control for Multicast Video Distribution in the Internet", in
+        SIGCOMM Symposium on Communications Architectures and Protocols,
+        (London, England), pp. 58--67, ACM, August 1994.
+
+   [19] Busse, I., Deffner, B. and H. Schulzrinne, "Dynamic QoS Control
+        of Multimedia Applications Based on RTP", Computer
+        Communications , vol. 19, pp. 49--58, January 1996.
+
+   [20] Floyd, S. and V. Jacobson, "The Synchronization of Periodic
+        Routing Messages", in SIGCOMM Symposium on Communications
+        Architectures and Protocols (D. P. Sidhu, ed.), (San Francisco,
+        California), pp. 33--44, ACM, September 1993.  Also in [34].
+
+   [21] Rosenberg, J. and H. Schulzrinne, "Sampling of the Group
+        Membership in RTP", RFC 2762, February 2000.
+
+   [22] Cadzow, J., Foundations of Digital Signal Processing and Data
+        Analysis New York, New York: Macmillan, 1987.
+
+   [23] Hinden, R. and S. Deering, "Internet Protocol Version 6 (IPv6)
+        Addressing Architecture", RFC 3513, April 2003.
+
+   [24] Rekhter, Y., Moskowitz, B., Karrenberg, D., de Groot, G. and E.
+        Lear, "Address Allocation for Private Internets", RFC 1918,
+        February 1996.
+
+
+
+Schulzrinne, et al.         Standards Track                   [Page 101]
+
+RFC 3550                          RTP                          July 2003
+
+
+   [25] Lear, E., Fair, E., Crocker, D. and T. Kessler, "Network 10
+        Considered Harmful (Some Practices Shouldn't be Codified)", RFC
+        1627, July 1994.
+
+   [26] Feller, W., An Introduction to Probability Theory and its
+        Applications, vol. 1.  New York, New York: John Wiley and Sons,
+        third ed., 1968.
+
+   [27] Kent, S. and R. Atkinson, "Security Architecture for the
+        Internet Protocol", RFC 2401, November 1998.
+
+   [28] Baugher, M., Blom, R., Carrara, E., McGrew, D., Naslund, M.,
+        Norrman, K. and D. Oran, "Secure Real-time Transport Protocol",
+        Work in Progress, April 2003.
+
+   [29] Balenson, D., "Privacy Enhancement for Internet Electronic Mail:
+        Part III", RFC 1423, February 1993.
+
+   [30] Voydock, V. and S. Kent, "Security Mechanisms in High-Level
+        Network Protocols", ACM Computing Surveys, vol. 15, pp. 135-171,
+        June 1983.
+
+   [31] Floyd, S., "Congestion Control Principles", BCP 41, RFC 2914,
+        September 2000.
+
+   [32] Rivest, R., "The MD5 Message-Digest Algorithm", RFC 1321, April
+        1992.
+
+   [33] Stubblebine, S., "Security Services for Multimedia
+        Conferencing", in 16th National Computer Security Conference,
+        (Baltimore, Maryland), pp. 391--395, September 1993.
+
+   [34] Floyd, S. and V. Jacobson, "The Synchronization of Periodic
+        Routing Messages", IEEE/ACM Transactions on Networking, vol. 2,
+        pp. 122--136, April 1994.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                   [Page 102]
+
+RFC 3550                          RTP                          July 2003
+
+
+Authors' Addresses
+
+   Henning Schulzrinne
+   Department of Computer Science
+   Columbia University
+   1214 Amsterdam Avenue
+   New York, NY 10027
+   United States
+
+   EMail: schulzrinne@cs.columbia.edu
+
+
+   Stephen L. Casner
+   Packet Design
+   3400 Hillview Avenue, Building 3
+   Palo Alto, CA 94304
+   United States
+
+   EMail: casner@acm.org
+
+
+   Ron Frederick
+   Blue Coat Systems Inc.
+   650 Almanor Avenue
+   Sunnyvale, CA 94085
+   United States
+
+   EMail: ronf@bluecoat.com
+
+
+   Van Jacobson
+   Packet Design
+   3400 Hillview Avenue, Building 3
+   Palo Alto, CA 94304
+   United States
+
+   EMail: van@packetdesign.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                   [Page 103]
+
+RFC 3550                          RTP                          July 2003
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne, et al.         Standards Track                   [Page 104]
+

--- a/rfcs/rfc3551.txt
+++ b/rfcs/rfc3551.txt
@@ -1,0 +1,2467 @@
+
+
+
+
+
+
+Network Working Group                                     H. Schulzrinne
+Request for Comments: 3551                           Columbia University
+Obsoletes: 1890                                                S. Casner
+Category: Standards Track                                  Packet Design
+                                                               July 2003
+
+
+              RTP Profile for Audio and Video Conferences
+                          with Minimal Control
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This document describes a profile called "RTP/AVP" for the use of the
+   real-time transport protocol (RTP), version 2, and the associated
+   control protocol, RTCP, within audio and video multiparticipant
+   conferences with minimal control.  It provides interpretations of
+   generic fields within the RTP specification suitable for audio and
+   video conferences.  In particular, this document defines a set of
+   default mappings from payload type numbers to encodings.
+
+   This document also describes how audio and video data may be carried
+   within RTP.  It defines a set of standard encodings and their names
+   when used within RTP.  The descriptions provide pointers to reference
+   implementations and the detailed standards.  This document is meant
+   as an aid for implementors of audio, video and other real-time
+   multimedia applications.
+
+   This memorandum obsoletes RFC 1890.  It is mostly backwards-
+   compatible except for functions removed because two interoperable
+   implementations were not found.  The additions to RFC 1890 codify
+   existing practice in the use of payload formats under this profile
+   and include new payload formats defined since RFC 1890 was published.
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 1]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+Table of Contents
+
+   1.  Introduction .................................................  3
+       1.1  Terminology .............................................  3
+   2.  RTP and RTCP Packet Forms and Protocol Behavior ..............  4
+   3.  Registering Additional Encodings .............................  6
+   4.  Audio ........................................................  8
+       4.1  Encoding-Independent Rules ..............................  8
+       4.2  Operating Recommendations ...............................  9
+       4.3  Guidelines for Sample-Based Audio Encodings ............. 10
+       4.4  Guidelines for Frame-Based Audio Encodings .............. 11
+       4.5  Audio Encodings ......................................... 12
+            4.5.1   DVI4 ............................................ 13
+            4.5.2   G722 ............................................ 14
+            4.5.3   G723 ............................................ 14
+            4.5.4   G726-40, G726-32, G726-24, and G726-16 .......... 18
+            4.5.5   G728 ............................................ 19
+            4.5.6   G729 ............................................ 20
+            4.5.7   G729D and G729E ................................. 22
+            4.5.8   GSM ............................................. 24
+            4.5.9   GSM-EFR ......................................... 27
+            4.5.10  L8 .............................................. 27
+            4.5.11  L16 ............................................. 27
+            4.5.12  LPC ............................................. 27
+            4.5.13  MPA ............................................. 28
+            4.5.14  PCMA and PCMU ................................... 28
+            4.5.15  QCELP ........................................... 28
+            4.5.16  RED ............................................. 29
+            4.5.17  VDVI ............................................ 29
+   5.  Video ........................................................ 30
+       5.1  CelB .................................................... 30
+       5.2  JPEG .................................................... 30
+       5.3  H261 .................................................... 30
+       5.4  H263 .................................................... 31
+       5.5  H263-1998 ............................................... 31
+       5.6  MPV ..................................................... 31
+       5.7  MP2T .................................................... 31
+       5.8  nv ...................................................... 32
+   6.  Payload Type Definitions ..................................... 32
+   7.  RTP over TCP and Similar Byte Stream Protocols ............... 34
+   8.  Port Assignment .............................................. 34
+   9.  Changes from RFC 1890 ........................................ 35
+   10. Security Considerations ...................................... 38
+   11. IANA Considerations .......................................... 39
+   12. References ................................................... 39
+       12.1 Normative References .................................... 39
+       12.2 Informative References .................................. 39
+   13. Current Locations of Related Resources ....................... 41
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 2]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   14. Acknowledgments .............................................. 42
+   15. Intellectual Property Rights Statement ....................... 43
+   16. Authors' Addresses ........................................... 43
+   17. Full Copyright Statement ..................................... 44
+
+1. Introduction
+
+   This profile defines aspects of RTP left unspecified in the RTP
+   Version 2 protocol definition (RFC 3550) [1].  This profile is
+   intended for the use within audio and video conferences with minimal
+   session control.  In particular, no support for the negotiation of
+   parameters or membership control is provided.  The profile is
+   expected to be useful in sessions where no negotiation or membership
+   control are used (e.g., using the static payload types and the
+   membership indications provided by RTCP), but this profile may also
+   be useful in conjunction with a higher-level control protocol.
+
+   Use of this profile may be implicit in the use of the appropriate
+   applications; there may be no explicit indication by port number,
+   protocol identifier or the like.  Applications such as session
+   directories may use the name for this profile specified in Section
+   11.
+
+   Other profiles may make different choices for the items specified
+   here.
+
+   This document also defines a set of encodings and payload formats for
+   audio and video.  These payload format descriptions are included here
+   only as a matter of convenience since they are too small to warrant
+   separate documents.  Use of these payload formats is NOT REQUIRED to
+   use this profile.  Only the binding of some of the payload formats to
+   static payload type numbers in Tables 4 and 5 is normative.
+
+1.1 Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [2] and
+   indicate requirement levels for implementations compliant with this
+   RTP profile.
+
+   This document defines the term media type as dividing encodings of
+   audio and video content into three classes: audio, video and
+   audio/video (interleaved).
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 3]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+2. RTP and RTCP Packet Forms and Protocol Behavior
+
+   The section "RTP Profiles and Payload Format Specifications" of RFC
+   3550 enumerates a number of items that can be specified or modified
+   in a profile.  This section addresses these items.  Generally, this
+   profile follows the default and/or recommended aspects of the RTP
+   specification.
+
+   RTP data header: The standard format of the fixed RTP data
+      header is used (one marker bit).
+
+   Payload types: Static payload types are defined in Section 6.
+
+   RTP data header additions: No additional fixed fields are
+      appended to the RTP data header.
+
+   RTP data header extensions: No RTP header extensions are
+      defined, but applications operating under this profile MAY use
+      such extensions.  Thus, applications SHOULD NOT assume that the
+      RTP header X bit is always zero and SHOULD be prepared to ignore
+      the header extension.  If a header extension is defined in the
+      future, that definition MUST specify the contents of the first 16
+      bits in such a way that multiple different extensions can be
+      identified.
+
+   RTCP packet types: No additional RTCP packet types are defined
+      by this profile specification.
+
+   RTCP report interval: The suggested constants are to be used for
+      the RTCP report interval calculation.  Sessions operating under
+      this profile MAY specify a separate parameter for the RTCP traffic
+      bandwidth rather than using the default fraction of the session
+      bandwidth.  The RTCP traffic bandwidth MAY be divided into two
+      separate session parameters for those participants which are
+      active data senders and those which are not.  Following the
+      recommendation in the RTP specification [1] that 1/4 of the RTCP
+      bandwidth be dedicated to data senders, the RECOMMENDED default
+      values for these two parameters would be 1.25% and 3.75%,
+      respectively.  For a particular session, the RTCP bandwidth for
+      non-data-senders MAY be set to zero when operating on
+      unidirectional links or for sessions that don't require feedback
+      on the quality of reception.  The RTCP bandwidth for data senders
+      SHOULD be kept non-zero so that sender reports can still be sent
+      for inter-media synchronization and to identify the source by
+      CNAME.  The means by which the one or two session parameters for
+      RTCP bandwidth are specified is beyond the scope of this memo.
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 4]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   SR/RR extension: No extension section is defined for the RTCP SR
+      or RR packet.
+
+   SDES use: Applications MAY use any of the SDES items described
+      in the RTP specification.  While CNAME information MUST be sent
+      every reporting interval, other items SHOULD only be sent every
+      third reporting interval, with NAME sent seven out of eight times
+      within that slot and the remaining SDES items cyclically taking up
+      the eighth slot, as defined in Section 6.2.2 of the RTP
+      specification.  In other words, NAME is sent in RTCP packets 1, 4,
+      7, 10, 13, 16, 19, while, say, EMAIL is used in RTCP packet 22.
+
+   Security: The RTP default security services are also the default
+      under this profile.
+
+   String-to-key mapping: No mapping is specified by this profile.
+
+   Congestion: RTP and this profile may be used in the context of
+      enhanced network service, for example, through Integrated Services
+      (RFC 1633) [4] or Differentiated Services (RFC 2475) [5], or they
+      may be used with best effort service.
+
+      If enhanced service is being used, RTP receivers SHOULD monitor
+      packet loss to ensure that the service that was requested is
+      actually being delivered.  If it is not, then they SHOULD assume
+      that they are receiving best-effort service and behave
+      accordingly.
+
+      If best-effort service is being used, RTP receivers SHOULD monitor
+      packet loss to ensure that the packet loss rate is within
+      acceptable parameters.  Packet loss is considered acceptable if a
+      TCP flow across the same network path and experiencing the same
+      network conditions would achieve an average throughput, measured
+      on a reasonable timescale, that is not less than the RTP flow is
+      achieving.  This condition can be satisfied by implementing
+      congestion control mechanisms to adapt the transmission rate (or
+      the number of layers subscribed for a layered multicast session),
+      or by arranging for a receiver to leave the session if the loss
+      rate is unacceptably high.
+
+      The comparison to TCP cannot be specified exactly, but is intended
+      as an "order-of-magnitude" comparison in timescale and throughput.
+      The timescale on which TCP throughput is measured is the round-
+      trip time of the connection.  In essence, this requirement states
+      that it is not acceptable to deploy an application (using RTP or
+      any other transport protocol) on the best-effort Internet which
+      consumes bandwidth arbitrarily and does not compete fairly with
+      TCP within an order of magnitude.
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 5]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   Underlying protocol: The profile specifies the use of RTP over
+      unicast and multicast UDP as well as TCP.  (This does not preclude
+      the use of these definitions when RTP is carried by other lower-
+      layer protocols.)
+
+   Transport mapping: The standard mapping of RTP and RTCP to
+      transport-level addresses is used.
+
+   Encapsulation: This profile leaves to applications the
+      specification of RTP encapsulation in protocols other than UDP.
+
+3.  Registering Additional Encodings
+
+   This profile lists a set of encodings, each of which is comprised of
+   a particular media data compression or representation plus a payload
+   format for encapsulation within RTP.  Some of those payload formats
+   are specified here, while others are specified in separate RFCs.  It
+   is expected that additional encodings beyond the set listed here will
+   be created in the future and specified in additional payload format
+   RFCs.
+
+   This profile also assigns to each encoding a short name which MAY be
+   used by higher-level control protocols, such as the Session
+   Description Protocol (SDP), RFC 2327 [6], to identify encodings
+   selected for a particular RTP session.
+
+   In some contexts it may be useful to refer to these encodings in the
+   form of a MIME content-type.  To facilitate this, RFC 3555 [7]
+   provides registrations for all of the encodings names listed here as
+   MIME subtype names under the "audio" and "video" MIME types through
+   the MIME registration procedure as specified in RFC 2048 [8].
+
+   Any additional encodings specified for use under this profile (or
+   others) may also be assigned names registered as MIME subtypes with
+   the Internet Assigned Numbers Authority (IANA).  This registry
+   provides a means to insure that the names assigned to the additional
+   encodings are kept unique.  RFC 3555 specifies the information that
+   is required for the registration of RTP encodings.
+
+   In addition to assigning names to encodings, this profile also
+   assigns static RTP payload type numbers to some of them.  However,
+   the payload type number space is relatively small and cannot
+   accommodate assignments for all existing and future encodings.
+   During the early stages of RTP development, it was necessary to use
+   statically assigned payload types because no other mechanism had been
+   specified to bind encodings to payload types.  It was anticipated
+   that non-RTP means beyond the scope of this memo (such as directory
+   services or invitation protocols) would be specified to establish a
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 6]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   dynamic mapping between a payload type and an encoding.  Now,
+   mechanisms for defining dynamic payload type bindings have been
+   specified in the Session Description Protocol (SDP) and in other
+   protocols such as ITU-T Recommendation H.323/H.245.  These mechanisms
+   associate the registered name of the encoding/payload format, along
+   with any additional required parameters, such as the RTP timestamp
+   clock rate and number of channels, with a payload type number.  This
+   association is effective only for the duration of the RTP session in
+   which the dynamic payload type binding is made.  This association
+   applies only to the RTP session for which it is made, thus the
+   numbers can be re-used for different encodings in different sessions
+   so the number space limitation is avoided.
+
+   This profile reserves payload type numbers in the range 96-127
+   exclusively for dynamic assignment.  Applications SHOULD first use
+   values in this range for dynamic payload types.  Those applications
+   which need to define more than 32 dynamic payload types MAY bind
+   codes below 96, in which case it is RECOMMENDED that unassigned
+   payload type numbers be used first.  However, the statically assigned
+   payload types are default bindings and MAY be dynamically bound to
+   new encodings if needed.  Redefining payload types below 96 may cause
+   incorrect operation if an attempt is made to join a session without
+   obtaining session description information that defines the dynamic
+   payload types.
+
+   Dynamic payload types SHOULD NOT be used without a well-defined
+   mechanism to indicate the mapping.  Systems that expect to
+   interoperate with others operating under this profile SHOULD NOT make
+   their own assignments of proprietary encodings to particular, fixed
+   payload types.
+
+   This specification establishes the policy that no additional static
+   payload types will be assigned beyond the ones defined in this
+   document.  Establishing this policy avoids the problem of trying to
+   create a set of criteria for accepting static assignments and
+   encourages the implementation and deployment of the dynamic payload
+   type mechanisms.
+
+   The final set of static payload type assignments is provided in
+   Tables 4 and 5.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 7]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.  Audio
+
+4.1  Encoding-Independent Rules
+
+   Since the ability to suppress silence is one of the primary
+   motivations for using packets to transmit voice, the RTP header
+   carries both a sequence number and a timestamp to allow a receiver to
+   distinguish between lost packets and periods of time when no data was
+   transmitted.  Discontiguous transmission (silence suppression) MAY be
+   used with any audio payload format.  Receivers MUST assume that
+   senders may suppress silence unless this is restricted by signaling
+   specified elsewhere.  (Even if the transmitter does not suppress
+   silence, the receiver should be prepared to handle periods when no
+   data is present since packets may be lost.)
+
+   Some payload formats (see Sections 4.5.3 and 4.5.6) define a "silence
+   insertion descriptor" or "comfort noise" frame to specify parameters
+   for artificial noise that may be generated during a period of silence
+   to approximate the background noise at the source.  For other payload
+   formats, a generic Comfort Noise (CN) payload format is specified in
+   RFC 3389 [9].  When the CN payload format is used with another
+   payload format, different values in the RTP payload type field
+   distinguish comfort-noise packets from those of the selected payload
+   format.
+
+   For applications which send either no packets or occasional comfort-
+   noise packets during silence, the first packet of a talkspurt, that
+   is, the first packet after a silence period during which packets have
+   not been transmitted contiguously, SHOULD be distinguished by setting
+   the marker bit in the RTP data header to one.  The marker bit in all
+   other packets is zero.  The beginning of a talkspurt MAY be used to
+   adjust the playout delay to reflect changing network delays.
+   Applications without silence suppression MUST set the marker bit to
+   zero.
+
+   The RTP clock rate used for generating the RTP timestamp is
+   independent of the number of channels and the encoding; it usually
+   equals the number of sampling periods per second.  For N-channel
+   encodings, each sampling period (say, 1/8,000 of a second) generates
+   N samples.  (This terminology is standard, but somewhat confusing, as
+   the total number of samples generated per second is then the sampling
+   rate times the channel count.)
+
+   If multiple audio channels are used, channels are numbered left-to-
+   right, starting at one.  In RTP audio packets, information from
+   lower-numbered channels precedes that from higher-numbered channels.
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 8]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   For more than two channels, the convention followed by the AIFF-C
+   audio interchange format SHOULD be followed [3], using the following
+   notation, unless some other convention is specified for a particular
+   encoding or payload format:
+
+      l  left
+      r  right
+      c  center
+      S  surround
+      F  front
+      R  rear
+
+      channels  description  channel
+                                1     2   3   4   5   6
+      _________________________________________________
+      2         stereo          l     r
+      3                         l     r   c
+      4                         l     c   r   S
+      5                        Fl     Fr  Fc  Sl  Sr
+      6                         l     lc  c   r   rc  S
+
+         Note: RFC 1890 defined two conventions for the ordering of four
+         audio channels.  Since the ordering is indicated implicitly by
+         the number of channels, this was ambiguous.  In this revision,
+         the order described as "quadrophonic" has been eliminated to
+         remove the ambiguity.  This choice was based on the observation
+         that quadrophonic consumer audio format did not become popular
+         whereas surround-sound subsequently has.
+
+   Samples for all channels belonging to a single sampling instant MUST
+   be within the same packet.  The interleaving of samples from
+   different channels depends on the encoding.  General guidelines are
+   given in Section 4.3 and 4.4.
+
+   The sampling frequency SHOULD be drawn from the set:  8,000, 11,025,
+   16,000, 22,050, 24,000, 32,000, 44,100 and 48,000 Hz.  (Older Apple
+   Macintosh computers had a native sample rate of 22,254.54 Hz, which
+   can be converted to 22,050 with acceptable quality by dropping 4
+   samples in a 20 ms frame.)  However, most audio encodings are defined
+   for a more restricted set of sampling frequencies.  Receivers SHOULD
+   be prepared to accept multi-channel audio, but MAY choose to only
+   play a single channel.
+
+4.2  Operating Recommendations
+
+   The following recommendations are default operating parameters.
+   Applications SHOULD be prepared to handle other values.  The ranges
+   given are meant to give guidance to application writers, allowing a
+
+
+
+Schulzrinne & Casner        Standards Track                     [Page 9]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   set of applications conforming to these guidelines to interoperate
+   without additional negotiation.  These guidelines are not intended to
+   restrict operating parameters for applications that can negotiate a
+   set of interoperable parameters, e.g., through a conference control
+   protocol.
+
+   For packetized audio, the default packetization interval SHOULD have
+   a duration of 20 ms or one frame, whichever is longer, unless
+   otherwise noted in Table 1 (column "ms/packet").  The packetization
+   interval determines the minimum end-to-end delay; longer packets
+   introduce less header overhead but higher delay and make packet loss
+   more noticeable.  For non-interactive applications such as lectures
+   or for links with severe bandwidth constraints, a higher
+   packetization delay MAY be used.  A receiver SHOULD accept packets
+   representing between 0 and 200 ms of audio data.  (For framed audio
+   encodings, a receiver SHOULD accept packets with a number of frames
+   equal to 200 ms divided by the frame duration, rounded up.)  This
+   restriction allows reasonable buffer sizing for the receiver.
+
+4.3  Guidelines for Sample-Based Audio Encodings
+
+   In sample-based encodings, each audio sample is represented by a
+   fixed number of bits.  Within the compressed audio data, codes for
+   individual samples may span octet boundaries.  An RTP audio packet
+   may contain any number of audio samples, subject to the constraint
+   that the number of bits per sample times the number of samples per
+   packet yields an integral octet count.  Fractional encodings produce
+   less than one octet per sample.
+
+   The duration of an audio packet is determined by the number of
+   samples in the packet.
+
+   For sample-based encodings producing one or more octets per sample,
+   samples from different channels sampled at the same sampling instant
+   SHOULD be packed in consecutive octets.  For example, for a two-
+   channel encoding, the octet sequence is (left channel, first sample),
+   (right channel, first sample), (left channel, second sample), (right
+   channel, second sample), ....  For multi-octet encodings, octets
+   SHOULD be transmitted in network byte order (i.e., most significant
+   octet first).
+
+   The packing of sample-based encodings producing less than one octet
+   per sample is encoding-specific.
+
+   The RTP timestamp reflects the instant at which the first sample in
+   the packet was sampled, that is, the oldest information in the
+   packet.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 10]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.4  Guidelines for Frame-Based Audio Encodings
+
+   Frame-based encodings encode a fixed-length block of audio into
+   another block of compressed data, typically also of fixed length.
+   For frame-based encodings, the sender MAY choose to combine several
+   such frames into a single RTP packet.  The receiver can tell the
+   number of frames contained in an RTP packet, if all the frames have
+   the same length, by dividing the RTP payload length by the audio
+   frame size which is defined as part of the encoding.  This does not
+   work when carrying frames of different sizes unless the frame sizes
+   are relatively prime.  If not, the frames MUST indicate their size.
+
+   For frame-based codecs, the channel order is defined for the whole
+   block.  That is, for two-channel audio, right and left samples SHOULD
+   be coded independently, with the encoded frame for the left channel
+   preceding that for the right channel.
+
+   All frame-oriented audio codecs SHOULD be able to encode and decode
+   several consecutive frames within a single packet.  Since the frame
+   size for the frame-oriented codecs is given, there is no need to use
+   a separate designation for the same encoding, but with different
+   number of frames per packet.
+
+   RTP packets SHALL contain a whole number of frames, with frames
+   inserted according to age within a packet, so that the oldest frame
+   (to be played first) occurs immediately after the RTP packet header.
+   The RTP timestamp reflects the instant at which the first sample in
+   the first frame was sampled, that is, the oldest information in the
+   packet.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 11]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5 Audio Encodings
+
+   name of                              sampling              default
+   encoding  sample/frame  bits/sample      rate  ms/frame  ms/packet
+   __________________________________________________________________
+   DVI4      sample        4                var.                   20
+   G722      sample        8              16,000                   20
+   G723      frame         N/A             8,000        30         30
+   G726-40   sample        5               8,000                   20
+   G726-32   sample        4               8,000                   20
+   G726-24   sample        3               8,000                   20
+   G726-16   sample        2               8,000                   20
+   G728      frame         N/A             8,000       2.5         20
+   G729      frame         N/A             8,000        10         20
+   G729D     frame         N/A             8,000        10         20
+   G729E     frame         N/A             8,000        10         20
+   GSM       frame         N/A             8,000        20         20
+   GSM-EFR   frame         N/A             8,000        20         20
+   L8        sample        8                var.                   20
+   L16       sample        16               var.                   20
+   LPC       frame         N/A             8,000        20         20
+   MPA       frame         N/A              var.      var.
+   PCMA      sample        8                var.                   20
+   PCMU      sample        8                var.                   20
+   QCELP     frame         N/A             8,000        20         20
+   VDVI      sample        var.             var.                   20
+
+   Table 1: Properties of Audio Encodings (N/A: not applicable; var.:
+            variable)
+
+   The characteristics of the audio encodings described in this document
+   are shown in Table 1; they are listed in order of their payload type
+   in Table 4.  While most audio codecs are only specified for a fixed
+   sampling rate, some sample-based algorithms (indicated by an entry of
+   "var." in the sampling rate column of Table 1) may be used with
+   different sampling rates, resulting in different coded bit rates.
+   When used with a sampling rate other than that for which a static
+   payload type is defined, non-RTP means beyond the scope of this memo
+   MUST be used to define a dynamic payload type and MUST indicate the
+   selected RTP timestamp clock rate, which is usually the same as the
+   sampling rate for audio.
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 12]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.1 DVI4
+
+   DVI4 uses an adaptive delta pulse code modulation (ADPCM) encoding
+   scheme that was specified by the Interactive Multimedia Association
+   (IMA) as the "IMA ADPCM wave type".  However, the encoding defined
+   here as DVI4 differs in three respects from the IMA specification:
+
+   o  The RTP DVI4 header contains the predicted value rather than the
+      first sample value contained the IMA ADPCM block header.
+
+   o  IMA ADPCM blocks contain an odd number of samples, since the first
+      sample of a block is contained just in the header (uncompressed),
+      followed by an even number of compressed samples.  DVI4 has an
+      even number of compressed samples only, using the `predict' word
+      from the header to decode the first sample.
+
+   o  For DVI4, the 4-bit samples are packed with the first sample in
+      the four most significant bits and the second sample in the four
+      least significant bits.  In the IMA ADPCM codec, the samples are
+      packed in the opposite order.
+
+   Each packet contains a single DVI block.  This profile only defines
+   the 4-bit-per-sample version, while IMA also specified a 3-bit-per-
+   sample encoding.
+
+   The "header" word for each channel has the following structure:
+
+      int16  predict;  /* predicted value of first sample
+                          from the previous block (L16 format) */
+      u_int8 index;    /* current index into stepsize table */
+      u_int8 reserved; /* set to zero by sender, ignored by receiver */
+
+   Each octet following the header contains two 4-bit samples, thus the
+   number of samples per packet MUST be even because there is no means
+   to indicate a partially filled last octet.
+
+   Packing of samples for multiple channels is for further study.
+
+   The IMA ADPCM algorithm was described in the document IMA Recommended
+   Practices for Enhancing Digital Audio Compatibility in Multimedia
+   Systems (version 3.0).  However, the Interactive Multimedia
+   Association ceased operations in 1997.  Resources for an archived
+   copy of that document and a software implementation of the RTP DVI4
+   encoding are listed in Section 13.
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 13]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.2 G722
+
+   G722 is specified in ITU-T Recommendation G.722, "7 kHz audio-coding
+   within 64 kbit/s".  The G.722 encoder produces a stream of octets,
+   each of which SHALL be octet-aligned in an RTP packet.  The first bit
+   transmitted in the G.722 octet, which is the most significant bit of
+   the higher sub-band sample, SHALL correspond to the most significant
+   bit of the octet in the RTP packet.
+
+   Even though the actual sampling rate for G.722 audio is 16,000 Hz,
+   the RTP clock rate for the G722 payload format is 8,000 Hz because
+   that value was erroneously assigned in RFC 1890 and must remain
+   unchanged for backward compatibility.  The octet rate or sample-pair
+   rate is 8,000 Hz.
+
+4.5.3 G723
+
+   G723 is specified in ITU Recommendation G.723.1, "Dual-rate speech
+   coder for multimedia communications transmitting at 5.3 and 6.3
+   kbit/s".  The G.723.1 5.3/6.3 kbit/s codec was defined by the ITU-T
+   as a mandatory codec for ITU-T H.324 GSTN videophone terminal
+   applications.  The algorithm has a floating point specification in
+   Annex B to G.723.1, a silence compression algorithm in Annex A to
+   G.723.1 and a scalable channel coding scheme for wireless
+   applications in G.723.1 Annex C.
+
+   This Recommendation specifies a coded representation that can be used
+   for compressing the speech signal component of multi-media services
+   at a very low bit rate.  Audio is encoded in 30 ms frames, with an
+   additional delay of 7.5 ms due to look-ahead.  A G.723.1 frame can be
+   one of three sizes:  24 octets (6.3 kb/s frame), 20 octets (5.3 kb/s
+   frame), or 4 octets.  These 4-octet frames are called SID frames
+   (Silence Insertion Descriptor) and are used to specify comfort noise
+   parameters.  There is no restriction on how 4, 20, and 24 octet
+   frames are intermixed.  The least significant two bits of the first
+   octet in the frame determine the frame size and codec type:
+
+         bits  content                      octets/frame
+         00    high-rate speech (6.3 kb/s)            24
+         01    low-rate speech  (5.3 kb/s)            20
+         10    SID frame                               4
+         11    reserved
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 14]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   It is possible to switch between the two rates at any 30 ms frame
+   boundary.  Both (5.3 kb/s and 6.3 kb/s) rates are a mandatory part of
+   the encoder and decoder.  Receivers MUST accept both data rates and
+   MUST accept SID frames unless restriction of these capabilities has
+   been signaled.  The MIME registration for G723 in RFC 3555 [7]
+   specifies parameters that MAY be used with MIME or SDP to restrict to
+   a single data rate or to restrict the use of SID frames.  This coder
+   was optimized to represent speech with near-toll quality at the above
+   rates using a limited amount of complexity.
+
+   The packing of the encoded bit stream into octets and the
+   transmission order of the octets is specified in Rec. G.723.1 and is
+   the same as that produced by the G.723 C code reference
+   implementation.  For the 6.3 kb/s data rate, this packing is
+   illustrated as follows, where the header (HDR) bits are always "0 0"
+   as shown in Fig. 1 to indicate operation at 6.3 kb/s, and the Z bit
+   is always set to zero.  The diagrams show the bit packing in "network
+   byte order", also known as big-endian order.  The bits of each 32-bit
+   word are numbered 0 to 31, with the most significant bit on the left
+   and numbered 0.  The octets (bytes) of each word are transmitted most
+   significant octet first.  The bits of each data field are numbered in
+   the order of the bit stream representation of the encoding (least
+   significant bit first).  The vertical bars indicate the boundaries
+   between field fragments.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 15]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    LPC    |HDR|      LPC      |      LPC      |    ACL0   |LPC|
+   |           |   |               |               |           |   |
+   |0 0 0 0 0 0|0 0|1 1 1 1 0 0 0 0|2 2 1 1 1 1 1 1|0 0 0 0 0 0|2 2|
+   |5 4 3 2 1 0|   |3 2 1 0 9 8 7 6|1 0 9 8 7 6 5 4|5 4 3 2 1 0|3 2|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  ACL2   |ACL|A| GAIN0 |ACL|ACL|    GAIN0      |    GAIN1      |
+   |         | 1 |C|       | 3 | 2 |               |               |
+   |0 0 0 0 0|0 0|0|0 0 0 0|0 0|0 0|1 1 0 0 0 0 0 0|0 0 0 0 0 0 0 0|
+   |4 3 2 1 0|1 0|6|3 2 1 0|1 0|6 5|1 0 9 8 7 6 5 4|7 6 5 4 3 2 1 0|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   | GAIN2 | GAIN1 |     GAIN2     |     GAIN3     | GRID  | GAIN3 |
+   |       |       |               |               |       |       |
+   |0 0 0 0|1 1 0 0|1 1 0 0 0 0 0 0|0 0 0 0 0 0 0 0|0 0 0 0|1 1 0 0|
+   |3 2 1 0|1 0 9 8|1 0 9 8 7 6 5 4|7 6 5 4 3 2 1 0|3 2 1 0|1 0 9 8|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   MSBPOS    |Z|POS|  MSBPOS   |     POS0      |POS|   POS0    |
+   |             | | 0 |           |               | 1 |           |
+   |0 0 0 0 0 0 0|0|0 0|1 1 1 0 0 0|0 0 0 0 0 0 0 0|0 0|1 1 1 1 1 1|
+   |6 5 4 3 2 1 0| |1 0|2 1 0 9 8 7|9 8 7 6 5 4 3 2|1 0|5 4 3 2 1 0|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     POS1      | POS2  | POS1  |     POS2      | POS3  | POS2  |
+   |               |       |       |               |       |       |
+   |0 0 0 0 0 0 0 0|0 0 0 0|1 1 1 1|1 1 0 0 0 0 0 0|0 0 0 0|1 1 1 1|
+   |9 8 7 6 5 4 3 2|3 2 1 0|3 2 1 0|1 0 9 8 7 6 5 4|3 2 1 0|5 4 3 2|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     POS3      |   PSIG0   |POS|PSIG2|  PSIG1  |  PSIG3  |PSIG2|
+   |               |           | 3 |     |         |         |     |
+   |1 1 0 0 0 0 0 0|0 0 0 0 0 0|1 1|0 0 0|0 0 0 0 0|0 0 0 0 0|0 0 0|
+   |1 0 9 8 7 6 5 4|5 4 3 2 1 0|3 2|2 1 0|4 3 2 1 0|4 3 2 1 0|5 4 3|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                  Figure 1: G.723 (6.3 kb/s) bit packing
+
+   For the 5.3 kb/s data rate, the header (HDR) bits are always "0 1",
+   as shown in Fig. 2, to indicate operation at 5.3 kb/s.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 16]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    LPC    |HDR|      LPC      |      LPC      |   ACL0    |LPC|
+   |           |   |               |               |           |   |
+   |0 0 0 0 0 0|0 1|1 1 1 1 0 0 0 0|2 2 1 1 1 1 1 1|0 0 0 0 0 0|2 2|
+   |5 4 3 2 1 0|   |3 2 1 0 9 8 7 6|1 0 9 8 7 6 5 4|5 4 3 2 1 0|3 2|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  ACL2   |ACL|A| GAIN0 |ACL|ACL|     GAIN0     |     GAIN1     |
+   |         | 1 |C|       | 3 | 2 |               |               |
+   |0 0 0 0 0|0 0|0|0 0 0 0|0 0|0 0|1 1 0 0 0 0 0 0|0 0 0 0 0 0 0 0|
+   |4 3 2 1 0|1 0|6|3 2 1 0|1 0|6 5|1 0 9 8 7 6 5 4|7 6 5 4 3 2 1 0|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   | GAIN2 | GAIN1 |     GAIN2     |    GAIN3      | GRID  | GAIN3 |
+   |       |       |               |               |       |       |
+   |0 0 0 0|1 1 0 0|1 1 0 0 0 0 0 0|0 0 0 0 0 0 0 0|0 0 0 0|1 1 0 0|
+   |3 2 1 0|1 0 9 8|1 0 9 8 7 6 5 4|7 6 5 4 3 2 1 0|4 3 2 1|1 0 9 8|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     POS0      | POS1  | POS0  |     POS1      |     POS2      |
+   |               |       |       |               |               |
+   |0 0 0 0 0 0 0 0|0 0 0 0|1 1 0 0|1 1 0 0 0 0 0 0|0 0 0 0 0 0 0 0|
+   |7 6 5 4 3 2 1 0|3 2 1 0|1 0 9 8|1 0 9 8 7 6 5 4|7 6 5 4 3 2 1 0|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   | POS3  | POS2  |     POS3      | PSIG1 | PSIG0 | PSIG3 | PSIG2 |
+   |       |       |               |       |       |       |       |
+   |0 0 0 0|1 1 0 0|1 1 0 0 0 0 0 0|0 0 0 0|0 0 0 0|0 0 0 0|0 0 0 0|
+   |3 2 1 0|1 0 9 8|1 0 9 8 7 6 5 4|3 2 1 0|3 2 1 0|3 2 1 0|3 2 1 0|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                  Figure 2: G.723 (5.3 kb/s) bit packing
+
+   The packing of G.723.1 SID (silence) frames, which are indicated by
+   the header (HDR) bits having the pattern "1 0", is depicted in Fig.
+   3.
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    LPC    |HDR|      LPC      |      LPC      |   GAIN    |LPC|
+   |           |   |               |               |           |   |
+   |0 0 0 0 0 0|1 0|1 1 1 1 0 0 0 0|2 2 1 1 1 1 1 1|0 0 0 0 0 0|2 2|
+   |5 4 3 2 1 0|   |3 2 1 0 9 8 7 6|1 0 9 8 7 6 5 4|5 4 3 2 1 0|3 2|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                   Figure 3: G.723 SID mode bit packing
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 17]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.4  G726-40, G726-32, G726-24, and G726-16
+
+   ITU-T Recommendation G.726 describes, among others, the algorithm
+   recommended for conversion of a single 64 kbit/s A-law or mu-law PCM
+   channel encoded at 8,000 samples/sec to and from a 40, 32, 24, or 16
+   kbit/s channel.  The conversion is applied to the PCM stream using an
+   Adaptive Differential Pulse Code Modulation (ADPCM) transcoding
+   technique.  The ADPCM representation consists of a series of
+   codewords with a one-to-one correspondence to the samples in the PCM
+   stream.  The G726 data rates of 40, 32, 24, and 16 kbit/s have
+   codewords of 5, 4, 3, and 2 bits, respectively.
+
+   The 16 and 24 kbit/s encodings do not provide toll quality speech.
+   They are designed for used in overloaded Digital Circuit
+   Multiplication Equipment (DCME).  ITU-T G.726 recommends that the 16
+   and 24 kbit/s encodings should be alternated with higher data rate
+   encodings to provide an average sample size of between 3.5 and 3.7
+   bits per sample.
+
+   The encodings of G.726 are here denoted as G726-40, G726-32, G726-24,
+   and G726-16.  Prior to 1990, G721 described the 32 kbit/s ADPCM
+   encoding, and G723 described the 40, 32, and 16 kbit/s encodings.
+   Thus, G726-32 designates the same algorithm as G721 in RFC 1890.
+
+   A stream of G726 codewords contains no information on the encoding
+   being used, therefore transitions between G726 encoding types are not
+   permitted within a sequence of packed codewords.  Applications MUST
+   determine the encoding type of packed codewords from the RTP payload
+   identifier.
+
+   No payload-specific header information SHALL be included as part of
+   the audio data.  A stream of G726 codewords MUST be packed into
+   octets as follows:  the first codeword is placed into the first octet
+   such that the least significant bit of the codeword aligns with the
+   least significant bit in the octet, the second codeword is then
+   packed so that its least significant bit coincides with the least
+   significant unoccupied bit in the octet.  When a complete codeword
+   cannot be placed into an octet, the bits overlapping the octet
+   boundary are placed into the least significant bits of the next
+   octet.  Packing MUST end with a completely packed final octet.  The
+   number of codewords packed will therefore be a multiple of 8, 2, 8,
+   and 4 for G726-40, G726-32, G726-24, and G726-16, respectively.  An
+   example of the packing scheme for G726-32 codewords is as shown,
+   where bit 7 is the least significant bit of the first octet, and bit
+   A3 is the least significant bit of the first codeword:
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 18]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+          0                   1
+          0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+         |B B B B|A A A A|D D D D|C C C C| ...
+         |0 1 2 3|0 1 2 3|0 1 2 3|0 1 2 3|
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+
+   An example of the packing scheme for G726-24 codewords follows, where
+   again bit 7 is the least significant bit of the first octet, and bit
+   A2 is the least significant bit of the first codeword:
+
+          0                   1                   2
+          0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+         |C C|B B B|A A A|F|E E E|D D D|C|H H H|G G G|F F| ...
+         |1 2|0 1 2|0 1 2|2|0 1 2|0 1 2|0|0 1 2|0 1 2|0 1|
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+
+   Note that the "little-endian" direction in which samples are packed
+   into octets in the G726-16, -24, -32 and -40 payload formats
+   specified here is consistent with ITU-T Recommendation X.420, but is
+   the opposite of what is specified in ITU-T Recommendation I.366.2
+   Annex E for ATM AAL2 transport.  A second set of RTP payload formats
+   matching the packetization of I.366.2 Annex E and identified by MIME
+   subtypes AAL2-G726-16, -24, -32 and -40 will be specified in a
+   separate document.
+
+4.5.5 G728
+
+   G728 is specified in ITU-T Recommendation G.728, "Coding of speech at
+   16 kbit/s using low-delay code excited linear prediction".
+
+   A G.278 encoder translates 5 consecutive audio samples into a 10-bit
+   codebook index, resulting in a bit rate of 16 kb/s for audio sampled
+   at 8,000 samples per second.  The group of five consecutive samples
+   is called a vector.  Four consecutive vectors, labeled V1 to V4
+   (where V1 is to be played first by the receiver), build one G.728
+   frame.  The four vectors of 40 bits are packed into 5 octets, labeled
+   B1 through B5.  B1 SHALL be placed first in the RTP packet.
+
+   Referring to the figure below, the principle for bit order is
+   "maintenance of bit significance".  Bits from an older vector are
+   more significant than bits from newer vectors.  The MSB of the frame
+   goes to the MSB of B1 and the LSB of the frame goes to LSB of B5.
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 19]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+                   1         2         3        3
+         0         0         0         0        9
+         ++++++++++++++++++++++++++++++++++++++++
+         <---V1---><---V2---><---V3---><---V4---> vectors
+         <--B1--><--B2--><--B3--><--B4--><--B5--> octets
+         <------------- frame 1 ---------------->
+
+   In particular, B1 contains the eight most significant bits of V1,
+   with the MSB of V1 being the MSB of B1.  B2 contains the two least
+   significant bits of V1, the more significant of the two in its MSB,
+   and the six most significant bits of V2.  B1 SHALL be placed first in
+   the RTP packet and B5 last.
+
+4.5.6 G729
+
+   G729 is specified in ITU-T Recommendation G.729, "Coding of speech at
+   8 kbit/s using conjugate structure-algebraic code excited linear
+   prediction (CS-ACELP)".  A reduced-complexity version of the G.729
+   algorithm is specified in Annex A to Rec. G.729.  The speech coding
+   algorithms in the main body of G.729 and in G.729 Annex A are fully
+   interoperable with each other, so there is no need to further
+   distinguish between them.  An implementation that signals or accepts
+   use of G729 payload format may implement either G.729 or G.729A
+   unless restricted by additional signaling specified elsewhere related
+   specifically to the encoding rather than the payload format.  The
+   G.729 and G.729 Annex A codecs were optimized to represent speech
+   with high quality, where G.729 Annex A trades some speech quality for
+   an approximate 50% complexity reduction [10].  See the next Section
+   (4.5.7) for other data rates added in later G.729 Annexes.  For all
+   data rates, the sampling frequency (and RTP timestamp clock rate) is
+   8,000 Hz.
+
+   A voice activity detector (VAD) and comfort noise generator (CNG)
+   algorithm in Annex B of G.729 is RECOMMENDED for digital simultaneous
+   voice and data applications and can be used in conjunction with G.729
+   or G.729 Annex A.  A G.729 or G.729 Annex A frame contains 10 octets,
+   while the G.729 Annex B comfort noise frame occupies 2 octets.
+   Receivers MUST accept comfort noise frames if restriction of their
+   use has not been signaled.  The MIME registration for G729 in RFC
+   3555 [7] specifies a parameter that MAY be used with MIME or SDP to
+   restrict the use of comfort noise frames.
+
+   A G729 RTP packet may consist of zero or more G.729 or G.729 Annex A
+   frames, followed by zero or one G.729 Annex B frames.  The presence
+   of a comfort noise frame can be deduced from the length of the RTP
+   payload.  The default packetization interval is 20 ms (two frames),
+   but in some situations it may be desirable to send 10 ms packets.  An
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 20]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   example would be a transition from speech to comfort noise in the
+   first 10 ms of the packet.  For some applications, a longer
+   packetization interval may be required to reduce the packet rate.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |L|      L1     |    L2   |    L3   |       P1      |P|    C1   |
+      |0|             |         |         |               |0|         |
+      | |0 1 2 3 4 5 6|0 1 2 3 4|0 1 2 3 4|0 1 2 3 4 5 6 7| |0 1 2 3 4|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       C1      |  S1   | GA1 |  GB1  |    P2   |      C2       |
+      |          1 1 1|       |     |       |         |               |
+      |5 6 7 8 9 0 1 2|0 1 2 3|0 1 2|0 1 2 3|0 1 2 3 4|0 1 2 3 4 5 6 7|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   C2    |  S2   | GA2 |  GB2  |
+      |    1 1 1|       |     |       |
+      |8 9 0 1 2|0 1 2 3|0 1 2|0 1 2 3|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                    Figure 4: G.729 and G.729A bit packing
+
+   The transmitted parameters of a G.729/G.729A 10-ms frame, consisting
+   of 80 bits, are defined in Recommendation G.729, Table 8/G.729.  The
+   mapping of the these parameters is given below in Fig. 4.  The
+   diagrams show the bit packing in "network byte order", also known as
+   big-endian order.  The bits of each 32-bit word are numbered 0 to 31,
+   with the most significant bit on the left and numbered 0.  The octets
+   (bytes) of each word are transmitted most significant octet first.
+   The bits of each data field are numbered in the order as produced by
+   the G.729 C code reference implementation.
+
+   The packing of the G.729 Annex B comfort noise frame is shown in Fig.
+   5.
+
+          0                   1
+          0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+         |L|  LSF1   |  LSF2 |   GAIN  |R|
+         |S|         |       |         |E|
+         |F|         |       |         |S|
+         |0|0 1 2 3 4|0 1 2 3|0 1 2 3 4|V|    RESV = Reserved (zero)
+         +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                       Figure 5: G.729 Annex B bit packing
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 21]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.7 G729D and G729E
+
+   Annexes D and E to ITU-T Recommendation G.729 provide additional data
+   rates.  Because the data rate is not signaled in the bitstream, the
+   different data rates are given distinct RTP encoding names which are
+   mapped to distinct payload type numbers.  G729D indicates a 6.4
+   kbit/s coding mode (G.729 Annex D, for momentary reduction in channel
+   capacity), while G729E indicates an 11.8 kbit/s mode (G.729 Annex E,
+   for improved performance with a wide range of narrow-band input
+   signals, e.g., music and background noise).  Annex E has two
+   operating modes, backward adaptive and forward adaptive, which are
+   signaled by the first two bits in each frame (the most significant
+   two bits of the first octet).
+
+   The voice activity detector (VAD) and comfort noise generator (CNG)
+   algorithm specified in Annex B of G.729 may be used with Annex D and
+   Annex E frames in addition to G.729 and G.729 Annex A frames.  The
+   algorithm details for the operation of Annexes D and E with the Annex
+   B CNG are specified in G.729 Annexes F and G.  Note that Annexes F
+   and G do not introduce any new encodings.  Receivers MUST accept
+   comfort noise frames if restriction of their use has not been
+   signaled.  The MIME registrations for G729D and G729E in RFC 3555 [7]
+   specify a parameter that MAY be used with MIME or SDP to restrict the
+   use of comfort noise frames.
+
+   For G729D, an RTP packet may consist of zero or more G.729 Annex D
+   frames, followed by zero or one G.729 Annex B frame.  Similarly, for
+   G729E, an RTP packet may consist of zero or more G.729 Annex E
+   frames, followed by zero or one G.729 Annex B frame.  The presence of
+   a comfort noise frame can be deduced from the length of the RTP
+   payload.
+
+   A single RTP packet must contain frames of only one data rate,
+   optionally followed by one comfort noise frame.  The data rate may be
+   changed from packet to packet by changing the payload type number.
+   G.729 Annexes D, E and H describe what the encoding and decoding
+   algorithms must do to accommodate a change in data rate.
+
+   For G729D, the bits of a G.729 Annex D frame are formatted as shown
+   below in Fig. 6 (cf.  Table D.1/G.729).  The frame length is 64 bits.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 22]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |L|      L1     |    L2   |    L3   |        P1     |     C1    |
+      |0|             |         |         |               |           |
+      | |0 1 2 3 4 5 6|0 1 2 3 4|0 1 2 3 4|0 1 2 3 4 5 6 7|0 1 2 3 4 5|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | C1  |S1 | GA1 | GB1 |  P2   |        C2       |S2 | GA2 | GB2 |
+      |     |   |     |     |       |                 |   |     |     |
+      |6 7 8|0 1|0 1 2|0 1 2|0 1 2 3|0 1 2 3 4 5 6 7 8|0 1|0 1 2|0 1 2|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                     Figure 6: G.729 Annex D bit packing
+
+   The net bit rate for the G.729 Annex E algorithm is 11.8 kbit/s and a
+   total of 118 bits are used.  Two bits are appended as "don't care"
+   bits to complete an integer number of octets for the frame.  For
+   G729E, the bits of a data frame are formatted as shown in the next
+   two diagrams (cf. Table E.1/G.729).  The fields for the G729E forward
+   adaptive mode are packed as shown in Fig. 7.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |0 0|L|      L1     |    L2   |    L3   |        P1     |P| C0_1|
+      |   |0|             |         |         |               |0|     |
+      |   | |0 1 2 3 4 5 6|0 1 2 3 4|0 1 2 3 4|0 1 2 3 4 5 6 7| |0 1 2|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |       |   C1_1      |     C2_1    |   C3_1      |    C4_1     |
+      |       |             |             |             |             |
+      |3 4 5 6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | GA1 |  GB1  |    P2   |   C0_2      |     C1_2    |   C2_2    |
+      |     |       |         |             |             |           |
+      |0 1 2|0 1 2 3|0 1 2 3 4|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2 3 4 5|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | |    C3_2     |     C4_2    | GA2 | GB2   |DC |
+      | |             |             |     |       |   |
+      |6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2|0 1 2 3|0 1|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+         Figure 7: G.729 Annex E (forward adaptive mode) bit packing
+
+   The fields for the G729E backward adaptive mode are packed as shown
+   in Fig. 8.
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 23]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |1 1|       P1      |P|       C0_1              |     C1_1      |
+      |   |               |0|                    1 1 1|               |
+      |   |0 1 2 3 4 5 6 7|0|0 1 2 3 4 5 6 7 8 9 0 1 2|0 1 2 3 4 5 6 7|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   |  C2_1       | C3_1        | C4_1        |GA1  | GB1   |P2 |
+      |   |             |             |             |     |       |   |
+      |8 9|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2|0 1 2 3|0 1|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     |          C0_2           |       C1_2        |    C2_2   |
+      |     |                    1 1 1|                   |           |
+      |2 3 4|0 1 2 3 4 5 6 7 8 9 0 1 2|0 1 2 3 4 5 6 7 8 9|0 1 2 3 4 5|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | |    C3_2     |     C4_2    | GA2 | GB2   |DC |
+      | |             |             |     |       |   |
+      |6|0 1 2 3 4 5 6|0 1 2 3 4 5 6|0 1 2|0 1 2 3|0 1|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+         Figure 8: G.729 Annex E (backward adaptive mode) bit packing
+
+4.5.8 GSM
+
+   GSM (Group Speciale Mobile) denotes the European GSM 06.10 standard
+   for full-rate speech transcoding, ETS 300 961, which is based on
+   RPE/LTP (residual pulse excitation/long term prediction) coding at a
+   rate of 13 kb/s [11,12,13].  The text of the standard can be obtained
+   from:
+
+   ETSI (European Telecommunications Standards Institute)
+   ETSI Secretariat: B.P.152
+   F-06561 Valbonne Cedex
+   France
+   Phone: +33 92 94 42 00
+   Fax:   +33 93 65 47 16
+
+   Blocks of 160 audio samples are compressed into 33 octets, for an
+   effective data rate of 13,200 b/s.
+
+4.5.8.1  General Packaging Issues
+
+   The GSM standard (ETS 300 961) specifies the bit stream produced by
+   the codec, but does not specify how these bits should be packed for
+   transmission.  The packetization specified here has subsequently been
+   adopted in ETSI Technical Specification TS 101 318.  Some software
+   implementations of the GSM codec use a different packing than that
+   specified here.
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 24]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+               field  field name  bits  field  field name  bits
+               ________________________________________________
+               1      LARc[0]     6     39     xmc[22]     3
+               2      LARc[1]     6     40     xmc[23]     3
+               3      LARc[2]     5     41     xmc[24]     3
+               4      LARc[3]     5     42     xmc[25]     3
+               5      LARc[4]     4     43     Nc[2]       7
+               6      LARc[5]     4     44     bc[2]       2
+               7      LARc[6]     3     45     Mc[2]       2
+               8      LARc[7]     3     46     xmaxc[2]    6
+               9      Nc[0]       7     47     xmc[26]     3
+               10     bc[0]       2     48     xmc[27]     3
+               11     Mc[0]       2     49     xmc[28]     3
+               12     xmaxc[0]    6     50     xmc[29]     3
+               13     xmc[0]      3     51     xmc[30]     3
+               14     xmc[1]      3     52     xmc[31]     3
+               15     xmc[2]      3     53     xmc[32]     3
+               16     xmc[3]      3     54     xmc[33]     3
+               17     xmc[4]      3     55     xmc[34]     3
+               18     xmc[5]      3     56     xmc[35]     3
+               19     xmc[6]      3     57     xmc[36]     3
+               20     xmc[7]      3     58     xmc[37]     3
+               21     xmc[8]      3     59     xmc[38]     3
+               22     xmc[9]      3     60     Nc[3]       7
+               23     xmc[10]     3     61     bc[3]       2
+               24     xmc[11]     3     62     Mc[3]       2
+               25     xmc[12]     3     63     xmaxc[3]    6
+               26     Nc[1]       7     64     xmc[39]     3
+               27     bc[1]       2     65     xmc[40]     3
+               28     Mc[1]       2     66     xmc[41]     3
+               29     xmaxc[1]    6     67     xmc[42]     3
+               30     xmc[13]     3     68     xmc[43]     3
+               31     xmc[14]     3     69     xmc[44]     3
+               32     xmc[15]     3     70     xmc[45]     3
+               33     xmc[16]     3     71     xmc[46]     3
+               34     xmc[17]     3     72     xmc[47]     3
+               35     xmc[18]     3     73     xmc[48]     3
+               36     xmc[19]     3     74     xmc[49]     3
+               37     xmc[20]     3     75     xmc[50]     3
+               38     xmc[21]     3     76     xmc[51]     3
+
+                      Table 2: Ordering of GSM variables
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 25]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   Octet  Bit 0   Bit 1   Bit 2   Bit 3   Bit 4   Bit 5   Bit 6   Bit 7
+   _____________________________________________________________________
+       0    1       1       0       1    LARc0.0 LARc0.1 LARc0.2 LARc0.3
+       1 LARc0.4 LARc0.5 LARc1.0 LARc1.1 LARc1.2 LARc1.3 LARc1.4 LARc1.5
+       2 LARc2.0 LARc2.1 LARc2.2 LARc2.3 LARc2.4 LARc3.0 LARc3.1 LARc3.2
+       3 LARc3.3 LARc3.4 LARc4.0 LARc4.1 LARc4.2 LARc4.3 LARc5.0 LARc5.1
+       4 LARc5.2 LARc5.3 LARc6.0 LARc6.1 LARc6.2 LARc7.0 LARc7.1 LARc7.2
+       5  Nc0.0   Nc0.1   Nc0.2   Nc0.3   Nc0.4   Nc0.5   Nc0.6  bc0.0
+       6  bc0.1   Mc0.0   Mc0.1  xmaxc00 xmaxc01 xmaxc02 xmaxc03 xmaxc04
+       7 xmaxc05 xmc0.0  xmc0.1  xmc0.2  xmc1.0  xmc1.1  xmc1.2  xmc2.0
+       8 xmc2.1  xmc2.2  xmc3.0  xmc3.1  xmc3.2  xmc4.0  xmc4.1  xmc4.2
+       9 xmc5.0  xmc5.1  xmc5.2  xmc6.0  xmc6.1  xmc6.2  xmc7.0  xmc7.1
+      10 xmc7.2  xmc8.0  xmc8.1  xmc8.2  xmc9.0  xmc9.1  xmc9.2  xmc10.0
+      11 xmc10.1 xmc10.2 xmc11.0 xmc11.1 xmc11.2 xmc12.0 xmc12.1 xcm12.2
+      12  Nc1.0   Nc1.1   Nc1.2   Nc1.3   Nc1.4   Nc1.5   Nc1.6   bc1.0
+      13  bc1.1   Mc1.0   Mc1.1  xmaxc10 xmaxc11 xmaxc12 xmaxc13 xmaxc14
+      14 xmax15  xmc13.0 xmc13.1 xmc13.2 xmc14.0 xmc14.1 xmc14.2 xmc15.0
+      15 xmc15.1 xmc15.2 xmc16.0 xmc16.1 xmc16.2 xmc17.0 xmc17.1 xmc17.2
+      16 xmc18.0 xmc18.1 xmc18.2 xmc19.0 xmc19.1 xmc19.2 xmc20.0 xmc20.1
+      17 xmc20.2 xmc21.0 xmc21.1 xmc21.2 xmc22.0 xmc22.1 xmc22.2 xmc23.0
+      18 xmc23.1 xmc23.2 xmc24.0 xmc24.1 xmc24.2 xmc25.0 xmc25.1 xmc25.2
+      19  Nc2.0   Nc2.1   Nc2.2   Nc2.3   Nc2.4   Nc2.5   Nc2.6   bc2.0
+      20  bc2.1   Mc2.0   Mc2.1  xmaxc20 xmaxc21 xmaxc22 xmaxc23 xmaxc24
+      21 xmaxc25 xmc26.0 xmc26.1 xmc26.2 xmc27.0 xmc27.1 xmc27.2 xmc28.0
+      22 xmc28.1 xmc28.2 xmc29.0 xmc29.1 xmc29.2 xmc30.0 xmc30.1 xmc30.2
+      23 xmc31.0 xmc31.1 xmc31.2 xmc32.0 xmc32.1 xmc32.2 xmc33.0 xmc33.1
+      24 xmc33.2 xmc34.0 xmc34.1 xmc34.2 xmc35.0 xmc35.1 xmc35.2 xmc36.0
+      25 Xmc36.1 xmc36.2 xmc37.0 xmc37.1 xmc37.2 xmc38.0 xmc38.1 xmc38.2
+      26  Nc3.0   Nc3.1   Nc3.2   Nc3.3   Nc3.4   Nc3.5   Nc3.6   bc3.0
+      27  bc3.1   Mc3.0   Mc3.1  xmaxc30 xmaxc31 xmaxc32 xmaxc33 xmaxc34
+      28 xmaxc35 xmc39.0 xmc39.1 xmc39.2 xmc40.0 xmc40.1 xmc40.2 xmc41.0
+      29 xmc41.1 xmc41.2 xmc42.0 xmc42.1 xmc42.2 xmc43.0 xmc43.1 xmc43.2
+      30 xmc44.0 xmc44.1 xmc44.2 xmc45.0 xmc45.1 xmc45.2 xmc46.0 xmc46.1
+      31 xmc46.2 xmc47.0 xmc47.1 xmc47.2 xmc48.0 xmc48.1 xmc48.2 xmc49.0
+      32 xmc49.1 xmc49.2 xmc50.0 xmc50.1 xmc50.2 xmc51.0 xmc51.1 xmc51.2
+
+                        Table 3: GSM payload format
+
+   In the GSM packing used by RTP, the bits SHALL be packed beginning
+   from the most significant bit.  Every 160 sample GSM frame is coded
+   into one 33 octet (264 bit) buffer.  Every such buffer begins with a
+   4 bit signature (0xD), followed by the MSB encoding of the fields of
+   the frame.  The first octet thus contains 1101 in the 4 most
+   significant bits (0-3) and the 4 most significant bits of F1 (0-3) in
+   the 4 least significant bits (4-7).  The second octet contains the 2
+   least significant bits of F1 in bits 0-1, and F2 in bits 2-7, and so
+   on.  The order of the fields in the frame is described in Table 2.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 26]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.8.2   GSM Variable Names and Numbers
+
+   In the RTP encoding we have the bit pattern described in Table 3,
+   where F.i signifies the ith bit of the field F, bit 0 is the most
+   significant bit, and the bits of every octet are numbered from 0 to 7
+   from most to least significant.
+
+4.5.9 GSM-EFR
+
+   GSM-EFR denotes GSM 06.60 enhanced full rate speech transcoding,
+   specified in ETS 300 726 which is available from ETSI at the address
+   given in Section 4.5.8.  This codec has a frame length of 244 bits.
+   For transmission in RTP, each codec frame is packed into a 31 octet
+   (248 bit) buffer beginning with a 4-bit signature 0xC in a manner
+   similar to that specified here for the original GSM 06.10 codec.  The
+   packing is specified in ETSI Technical Specification TS 101 318.
+
+4.5.10 L8
+
+   L8 denotes linear audio data samples, using 8-bits of precision with
+   an offset of 128, that is, the most negative signal is encoded as
+   zero.
+
+4.5.11 L16
+
+   L16 denotes uncompressed audio data samples, using 16-bit signed
+   representation with 65,535 equally divided steps between minimum and
+   maximum signal level, ranging from -32,768 to 32,767.  The value is
+   represented in two's complement notation and transmitted in network
+   byte order (most significant byte first).
+
+   The MIME registration for L16 in RFC 3555 [7] specifies parameters
+   that MAY be used with MIME or SDP to indicate that analog pre-
+   emphasis was applied to the signal before quantization or to indicate
+   that a multiple-channel audio stream follows a different channel
+   ordering convention than is specified in Section 4.1.
+
+4.5.12 LPC
+
+   LPC designates an experimental linear predictive encoding contributed
+   by Ron Frederick, which is based on an implementation written by Ron
+   Zuckerman posted to the Usenet group comp.dsp on June 26, 1992.  The
+   codec generates 14 octets for every frame.  The framesize is set to
+   20 ms, resulting in a bit rate of 5,600 b/s.
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 27]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.13 MPA
+
+   MPA denotes MPEG-1 or MPEG-2 audio encapsulated as elementary
+   streams.  The encoding is defined in ISO standards ISO/IEC 11172-3
+   and 13818-3.  The encapsulation is specified in RFC 2250 [14].
+
+   The encoding may be at any of three levels of complexity, called
+   Layer I, II and III.  The selected layer as well as the sampling rate
+   and channel count are indicated in the payload.  The RTP timestamp
+   clock rate is always 90,000, independent of the sampling rate.
+   MPEG-1 audio supports sampling rates of 32, 44.1, and 48 kHz (ISO/IEC
+   11172-3, section 1.1; "Scope").  MPEG-2 supports sampling rates of
+   16, 22.05 and 24 kHz.  The number of samples per frame is fixed, but
+   the frame size will vary with the sampling rate and bit rate.
+
+   The MIME registration for MPA in RFC 3555 [7] specifies parameters
+   that MAY be used with MIME or SDP to restrict the selection of layer,
+   channel count, sampling rate, and bit rate.
+
+4.5.14 PCMA and PCMU
+
+   PCMA and PCMU are specified in ITU-T Recommendation G.711.  Audio
+   data is encoded as eight bits per sample, after logarithmic scaling.
+   PCMU denotes mu-law scaling, PCMA A-law scaling.  A detailed
+   description is given by Jayant and Noll [15].  Each G.711 octet SHALL
+   be octet-aligned in an RTP packet.  The sign bit of each G.711 octet
+   SHALL correspond to the most significant bit of the octet in the RTP
+   packet (i.e., assuming the G.711 samples are handled as octets on the
+   host machine, the sign bit SHALL be the most significant bit of the
+   octet as defined by the host machine format).  The 56 kb/s and 48
+   kb/s modes of G.711 are not applicable to RTP, since PCMA and PCMU
+   MUST always be transmitted as 8-bit samples.
+
+   See Section 4.1 regarding silence suppression.
+
+4.5.15 QCELP
+
+   The Electronic Industries Association (EIA) & Telecommunications
+   Industry Association (TIA) standard IS-733, "TR45: High Rate Speech
+   Service Option for Wideband Spread Spectrum Communications Systems",
+   defines the QCELP audio compression algorithm for use in wireless
+   CDMA applications.  The QCELP CODEC compresses each 20 milliseconds
+   of 8,000 Hz, 16-bit sampled input speech into one of four different
+   size output frames:  Rate 1 (266 bits), Rate 1/2 (124 bits), Rate 1/4
+   (54 bits) or Rate 1/8 (20 bits).  For typical speech patterns, this
+   results in an average output of 6.8 kb/s for normal mode and 4.7 kb/s
+   for reduced rate mode.  The packetization of the QCELP audio codec is
+   described in [16].
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 28]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+4.5.16 RED
+
+   The redundant audio payload format "RED" is specified by RFC 2198
+   [17].  It defines a means by which multiple redundant copies of an
+   audio packet may be transmitted in a single RTP stream.  Each packet
+   in such a stream contains, in addition to the audio data for that
+   packetization interval, a (more heavily compressed) copy of the data
+   from a previous packetization interval.  This allows an approximation
+   of the data from lost packets to be recovered upon decoding of a
+   subsequent packet, giving much improved sound quality when compared
+   with silence substitution for lost packets.
+
+4.5.17 VDVI
+
+   VDVI is a variable-rate version of DVI4, yielding speech bit rates of
+   between 10 and 25 kb/s.  It is specified for single-channel operation
+   only.  Samples are packed into octets starting at the most-
+   significant bit.  The last octet is padded with 1 bits if the last
+   sample does not fill the last octet.  This padding is distinct from
+   the valid codewords.  The receiver needs to detect the padding
+   because there is no explicit count of samples in the packet.
+
+   It uses the following encoding:
+
+            DVI4 codeword  VDVI bit pattern
+            _______________________________
+                        0  00
+                        1  010
+                        2  1100
+                        3  11100
+                        4  111100
+                        5  1111100
+                        6  11111100
+                        7  11111110
+                        8  10
+                        9  011
+                       10  1101
+                       11  11101
+                       12  111101
+                       13  1111101
+                       14  11111101
+                       15  11111111
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 29]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+5.  Video
+
+   The following sections describe the video encodings that are defined
+   in this memo and give their abbreviated names used for
+   identification.  These video encodings and their payload types are
+   listed in Table 5.
+
+   All of these video encodings use an RTP timestamp frequency of 90,000
+   Hz, the same as the MPEG presentation time stamp frequency.  This
+   frequency yields exact integer timestamp increments for the typical
+   24 (HDTV), 25 (PAL), and 29.97 (NTSC) and 30 Hz (HDTV) frame rates
+   and 50, 59.94 and 60 Hz field rates.  While 90 kHz is the RECOMMENDED
+   rate for future video encodings used within this profile, other rates
+   MAY be used.  However, it is not sufficient to use the video frame
+   rate (typically between 15 and 30 Hz) because that does not provide
+   adequate resolution for typical synchronization requirements when
+   calculating the RTP timestamp corresponding to the NTP timestamp in
+   an RTCP SR packet.  The timestamp resolution MUST also be sufficient
+   for the jitter estimate contained in the receiver reports.
+
+   For most of these video encodings, the RTP timestamp encodes the
+   sampling instant of the video image contained in the RTP data packet.
+   If a video image occupies more than one packet, the timestamp is the
+   same on all of those packets.  Packets from different video images
+   are distinguished by their different timestamps.
+
+   Most of these video encodings also specify that the marker bit of the
+   RTP header SHOULD be set to one in the last packet of a video frame
+   and otherwise set to zero.  Thus, it is not necessary to wait for a
+   following packet with a different timestamp to detect that a new
+   frame should be displayed.
+
+5.1  CelB
+
+   The CELL-B encoding is a proprietary encoding proposed by Sun
+   Microsystems.  The byte stream format is described in RFC 2029 [18].
+
+5.2 JPEG
+
+   The encoding is specified in ISO Standards 10918-1 and 10918-2.  The
+   RTP payload format is as specified in RFC 2435 [19].
+
+5.3 H261
+
+   The encoding is specified in ITU-T Recommendation H.261, "Video codec
+   for audiovisual services at p x 64 kbit/s".  The packetization and
+   RTP-specific properties are described in RFC 2032 [20].
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 30]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+5.4 H263
+
+   The encoding is specified in the 1996 version of ITU-T Recommendation
+   H.263, "Video coding for low bit rate communication".  The
+   packetization and RTP-specific properties are described in RFC 2190
+   [21].  The H263-1998 payload format is RECOMMENDED over this one for
+   use by new implementations.
+
+5.5 H263-1998
+
+   The encoding is specified in the 1998 version of ITU-T Recommendation
+   H.263, "Video coding for low bit rate communication".  The
+   packetization and RTP-specific properties are described in RFC 2429
+   [22].  Because the 1998 version of H.263 is a superset of the 1996
+   syntax, this payload format can also be used with the 1996 version of
+   H.263, and is RECOMMENDED for this use by new implementations.  This
+   payload format does not replace RFC 2190, which continues to be used
+   by existing implementations, and may be required for backward
+   compatibility in new implementations.  Implementations using the new
+   features of the 1998 version of H.263 MUST use the payload format
+   described in RFC 2429.
+
+5.6 MPV
+
+   MPV designates the use of MPEG-1 and MPEG-2 video encoding elementary
+   streams as specified in ISO Standards ISO/IEC 11172 and 13818-2,
+   respectively.  The RTP payload format is as specified in RFC 2250
+   [14], Section 3.
+
+   The MIME registration for MPV in RFC 3555 [7] specifies a parameter
+   that MAY be used with MIME or SDP to restrict the selection of the
+   type of MPEG video.
+
+5.7 MP2T
+
+   MP2T designates the use of MPEG-2 transport streams, for either audio
+   or video.  The RTP payload format is described in RFC 2250 [14],
+   Section 2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 31]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+5.8 nv
+
+   The encoding is implemented in the program `nv', version 4, developed
+   at Xerox PARC by Ron Frederick.  Further information is available
+   from the author:
+
+   Ron Frederick
+   Blue Coat Systems Inc.
+   650 Almanor Avenue
+   Sunnyvale, CA 94085
+   United States
+   EMail: ronf@bluecoat.com
+
+6.  Payload Type Definitions
+
+   Tables 4 and 5 define this profile's static payload type values for
+   the PT field of the RTP data header.  In addition, payload type
+   values in the range 96-127 MAY be defined dynamically through a
+   conference control protocol, which is beyond the scope of this
+   document.  For example, a session directory could specify that for a
+   given session, payload type 96 indicates PCMU encoding, 8,000 Hz
+   sampling rate, 2 channels.  Entries in Tables 4 and 5 with payload
+   type "dyn" have no static payload type assigned and are only used
+   with a dynamic payload type.  Payload type 2 was assigned to G721 in
+   RFC 1890 and to its equivalent successor G726-32 in draft versions of
+   this specification, but its use is now deprecated and that static
+   payload type is marked reserved due to conflicting use for the
+   payload formats G726-32 and AAL2-G726-32 (see Section 4.5.4).
+   Payload type 13 indicates the Comfort Noise (CN) payload format
+   specified in RFC 3389 [9].  Payload type 19 is marked "reserved"
+   because some draft versions of this specification assigned that
+   number to an earlier version of the comfort noise payload format.
+   The payload type range 72-76 is marked "reserved" so that RTCP and
+   RTP packets can be reliably distinguished (see Section "Summary of
+   Protocol Constants" of the RTP protocol specification).
+
+   The payload types currently defined in this profile are assigned to
+   exactly one of three categories or media types:  audio only, video
+   only and those combining audio and video.  The media types are marked
+   in Tables 4 and 5 as "A", "V" and "AV", respectively.  Payload types
+   of different media types SHALL NOT be interleaved or multiplexed
+   within a single RTP session, but multiple RTP sessions MAY be used in
+   parallel to send multiple media types.  An RTP source MAY change
+   payload types within the same media type during a session.  See the
+   section "Multiplexing RTP Sessions" of RFC 3550 for additional
+   explanation.
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 32]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+               PT   encoding    media type  clock rate   channels
+                    name                    (Hz)
+               ___________________________________________________
+               0    PCMU        A            8,000       1
+               1    reserved    A
+               2    reserved    A
+               3    GSM         A            8,000       1
+               4    G723        A            8,000       1
+               5    DVI4        A            8,000       1
+               6    DVI4        A           16,000       1
+               7    LPC         A            8,000       1
+               8    PCMA        A            8,000       1
+               9    G722        A            8,000       1
+               10   L16         A           44,100       2
+               11   L16         A           44,100       1
+               12   QCELP       A            8,000       1
+               13   CN          A            8,000       1
+               14   MPA         A           90,000       (see text)
+               15   G728        A            8,000       1
+               16   DVI4        A           11,025       1
+               17   DVI4        A           22,050       1
+               18   G729        A            8,000       1
+               19   reserved    A
+               20   unassigned  A
+               21   unassigned  A
+               22   unassigned  A
+               23   unassigned  A
+               dyn  G726-40     A            8,000       1
+               dyn  G726-32     A            8,000       1
+               dyn  G726-24     A            8,000       1
+               dyn  G726-16     A            8,000       1
+               dyn  G729D       A            8,000       1
+               dyn  G729E       A            8,000       1
+               dyn  GSM-EFR     A            8,000       1
+               dyn  L8          A            var.        var.
+               dyn  RED         A                        (see text)
+               dyn  VDVI        A            var.        1
+
+               Table 4: Payload types (PT) for audio encodings
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 33]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+               PT      encoding    media type  clock rate
+                       name                    (Hz)
+               _____________________________________________
+               24      unassigned  V
+               25      CelB        V           90,000
+               26      JPEG        V           90,000
+               27      unassigned  V
+               28      nv          V           90,000
+               29      unassigned  V
+               30      unassigned  V
+               31      H261        V           90,000
+               32      MPV         V           90,000
+               33      MP2T        AV          90,000
+               34      H263        V           90,000
+               35-71   unassigned  ?
+               72-76   reserved    N/A         N/A
+               77-95   unassigned  ?
+               96-127  dynamic     ?
+               dyn     H263-1998   V           90,000
+
+               Table 5: Payload types (PT) for video and combined
+                        encodings
+
+   Session participants agree through mechanisms beyond the scope of
+   this specification on the set of payload types allowed in a given
+   session.  This set MAY, for example, be defined by the capabilities
+   of the applications used, negotiated by a conference control protocol
+   or established by agreement between the human participants.
+
+   Audio applications operating under this profile SHOULD, at a minimum,
+   be able to send and/or receive payload types 0 (PCMU) and 5 (DVI4).
+   This allows interoperability without format negotiation and ensures
+   successful negotiation with a conference control protocol.
+
+7.  RTP over TCP and Similar Byte Stream Protocols
+
+   Under special circumstances, it may be necessary to carry RTP in
+   protocols offering a byte stream abstraction, such as TCP, possibly
+   multiplexed with other data.  The application MUST define its own
+   method of delineating RTP and RTCP packets (RTSP [23] provides an
+   example of such an encapsulation specification).
+
+8.  Port Assignment
+
+   As specified in the RTP protocol definition, RTP data SHOULD be
+   carried on an even UDP port number and the corresponding RTCP packets
+   SHOULD be carried on the next higher (odd) port number.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 34]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   Applications operating under this profile MAY use any such UDP port
+   pair.  For example, the port pair MAY be allocated randomly by a
+   session management program.  A single fixed port number pair cannot
+   be required because multiple applications using this profile are
+   likely to run on the same host, and there are some operating systems
+   that do not allow multiple processes to use the same UDP port with
+   different multicast addresses.
+
+   However, port numbers 5004 and 5005 have been registered for use with
+   this profile for those applications that choose to use them as the
+   default pair.  Applications that operate under multiple profiles MAY
+   use this port pair as an indication to select this profile if they
+   are not subject to the constraint of the previous paragraph.
+   Applications need not have a default and MAY require that the port
+   pair be explicitly specified.  The particular port numbers were
+   chosen to lie in the range above 5000 to accommodate port number
+   allocation practice within some versions of the Unix operating
+   system, where port numbers below 1024 can only be used by privileged
+   processes and port numbers between 1024 and 5000 are automatically
+   assigned by the operating system.
+
+9.  Changes from RFC 1890
+
+   This RFC revises RFC 1890.  It is mostly backwards-compatible with
+   RFC 1890 except for functions removed because two interoperable
+   implementations were not found.  The additions to RFC 1890 codify
+   existing practice in the use of payload formats under this profile.
+   Since this profile may be used without using any of the payload
+   formats listed here, the addition of new payload formats in this
+   revision does not affect backwards compatibility.  The changes are
+   listed below, categorized into functional and non-functional changes.
+
+   Functional changes:
+
+   o  Section 11, "IANA Considerations" was added to specify the
+      registration of the name for this profile.  That appendix also
+      references a new Section 3 "Registering Additional Encodings"
+      which establishes a policy that no additional registration of
+      static payload types for this profile will be made beyond those
+      added in this revision and included in Tables 4 and 5.  Instead,
+      additional encoding names may be registered as MIME subtypes for
+      binding to dynamic payload types.  Non-normative references were
+      added to RFC 3555 [7] where MIME subtypes for all the listed
+      payload formats are registered, some with optional parameters for
+      use of the payload formats.
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 35]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   o  Static payload types 4, 16, 17 and 34 were added to incorporate
+      IANA registrations made since the publication of RFC 1890, along
+      with the corresponding payload format descriptions for G723 and
+      H263.
+
+   o  Following working group discussion, static payload types 12 and 18
+      were added along with the corresponding payload format
+      descriptions for QCELP and G729.  Static payload type 13 was
+      assigned to the Comfort Noise (CN) payload format defined in RFC
+      3389.  Payload type 19 was marked reserved because it had been
+      temporarily allocated to an earlier version of Comfort Noise
+      present in some draft revisions of this document.
+
+   o  The payload format for G721 was renamed to G726-32 following the
+      ITU-T renumbering, and the payload format description for G726 was
+      expanded to include the -16, -24 and -40 data rates.  Because of
+      confusion regarding draft revisions of this document, some
+      implementations of these G726 payload formats packed samples into
+      octets starting with the most significant bit rather than the
+      least significant bit as specified here.  To partially resolve
+      this incompatibility, new payload formats named AAL2-G726-16, -24,
+      -32 and -40 will be specified in a separate document (see note in
+      Section 4.5.4), and use of static payload type 2 is deprecated as
+      explained in Section 6.
+
+   o  Payload formats G729D and G729E were added following the ITU-T
+      addition of Annexes D and E to Recommendation G.729.  Listings
+      were added for payload formats GSM-EFR, RED, and H263-1998
+      published in other documents subsequent to RFC 1890.  These
+      additional payload formats are referenced only by dynamic payload
+      type numbers.
+
+   o  The descriptions of the payload formats for G722, G728, GSM, VDVI
+      were expanded.
+
+   o  The payload format for 1016 audio was removed and its static
+      payload type assignment 1 was marked "reserved" because two
+      interoperable implementations were not found.
+
+   o  Requirements for congestion control were added in Section 2.
+
+   o  This profile follows the suggestion in the revised RTP spec that
+      RTCP bandwidth may be specified separately from the session
+      bandwidth and separately for active senders and passive receivers.
+
+   o  The mapping of a user pass-phrase string into an encryption key
+      was deleted from Section 2 because two interoperable
+      implementations were not found.
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 36]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   o  The "quadrophonic" sample ordering convention for four-channel
+      audio was removed to eliminate an ambiguity as noted in Section
+      4.1.
+
+   Non-functional changes:
+
+   o  In Section 4.1, it is now explicitly stated that silence
+      suppression is allowed for all audio payload formats.  (This has
+      always been the case and derives from a fundamental aspect of
+      RTP's design and the motivations for packet audio, but was not
+      explicit stated before.)  The use of comfort noise is also
+      explained.
+
+   o  In Section 4.1, the requirement level for setting of the marker
+      bit on the first packet after silence for audio was changed from
+      "is" to "SHOULD be", and clarified that the marker bit is set only
+      when packets are intentionally not sent.
+
+   o  Similarly, text was added to specify that the marker bit SHOULD be
+      set to one on the last packet of a video frame, and that video
+      frames are distinguished by their timestamps.
+
+   o  RFC references are added for payload formats published after RFC
+      1890.
+
+   o  The security considerations and full copyright sections were
+      added.
+
+   o  According to Peter Hoddie of Apple, only pre-1994 Macintosh used
+      the 22254.54 rate and none the 11127.27 rate, so the latter was
+      dropped from the discussion of suggested sampling frequencies.
+
+   o  Table 1 was corrected to move some values from the "ms/packet"
+      column to the "default ms/packet" column where they belonged.
+
+   o  Since the Interactive Multimedia Association ceased operations, an
+      alternate resource was provided for a referenced IMA document.
+
+   o  A note has been added for G722 to clarify a discrepancy between
+      the actual sampling rate and the RTP timestamp clock rate.
+
+   o  Small clarifications of the text have been made in several places,
+      some in response to questions from readers.  In particular:
+
+      -  A definition for "media type" is given in Section 1.1 to allow
+         the explanation of multiplexing RTP sessions in Section 6 to be
+         more clear regarding the multiplexing of multiple media.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 37]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+      -  The explanation of how to determine the number of audio frames
+         in a packet from the length was expanded.
+
+      -  More description of the allocation of bandwidth to SDES items
+         is given.
+
+      -  A note was added that the convention for the order of channels
+         specified in Section 4.1 may be overridden by a particular
+         encoding or payload format specification.
+
+      -  The terms MUST, SHOULD, MAY, etc. are used as defined in RFC
+         2119.
+
+   o  A second author for this document was added.
+
+10. Security Considerations
+
+   Implementations using the profile defined in this specification are
+   subject to the security considerations discussed in the RTP
+   specification [1].  This profile does not specify any different
+   security services.  The primary function of this profile is to list a
+   set of data compression encodings for audio and video media.
+
+   Confidentiality of the media streams is achieved by encryption.
+   Because the data compression used with the payload formats described
+   in this profile is applied end-to-end, encryption may be performed
+   after compression so there is no conflict between the two operations.
+
+   A potential denial-of-service threat exists for data encodings using
+   compression techniques that have non-uniform receiver-end
+   computational load.  The attacker can inject pathological datagrams
+   into the stream which are complex to decode and cause the receiver to
+   be overloaded.
+
+   As with any IP-based protocol, in some circumstances a receiver may
+   be overloaded simply by the receipt of too many packets, either
+   desired or undesired.  Network-layer authentication MAY be used to
+   discard packets from undesired sources, but the processing cost of
+   the authentication itself may be too high.  In a multicast
+   environment, source pruning is implemented in IGMPv3 (RFC 3376) [24]
+   and in multicast routing protocols to allow a receiver to select
+   which sources are allowed to reach it.
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 38]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+11. IANA Considerations
+
+   The RTP specification establishes a registry of profile names for use
+   by higher-level control protocols, such as the Session Description
+   Protocol (SDP), RFC 2327 [6], to refer to transport methods.  This
+   profile registers the name "RTP/AVP".
+
+   Section 3 establishes the policy that no additional registration of
+   static RTP payload types for this profile will be made beyond those
+   added in this document revision and included in Tables 4 and 5.  IANA
+   may reference that section in declining to accept any additional
+   registration requests.  In Tables 4 and 5, note that types 1 and 2
+   have been marked reserved and the set of "dyn" payload types included
+   has been updated.  These changes are explained in Sections 6 and 9.
+
+12.  References
+
+12.1 Normative References
+
+   [1]  Schulzrinne, H., Casner, S., Frederick, R. and V. Jacobson,
+        "RTP:  A Transport Protocol for Real-Time Applications", RFC
+        3550, July 2003.
+
+   [2]  Bradner, S., "Key Words for Use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [3]  Apple Computer, "Audio Interchange File Format AIFF-C", August
+        1991.  (also ftp://ftp.sgi.com/sgi/aiff-c.9.26.91.ps.Z).
+
+12.2 Informative References
+
+   [4]  Braden, R., Clark, D. and S. Shenker, "Integrated Services in
+        the Internet Architecture: an Overview", RFC 1633, June 1994.
+
+   [5]  Blake, S., Black, D., Carlson, M., Davies, E., Wang, Z. and W.
+        Weiss, "An Architecture for Differentiated Service", RFC 2475,
+        December 1998.
+
+   [6]  Handley, M. and V. Jacobson, "SDP: Session Description
+        Protocol", RFC 2327, April 1998.
+
+   [7]  Casner, S. and P. Hoschka, "MIME Type Registration of RTP
+        Payload Types", RFC 3555, July 2003.
+
+   [8]  Freed, N., Klensin, J. and J. Postel, "Multipurpose Internet
+        Mail Extensions (MIME) Part Four: Registration Procedures", BCP
+        13, RFC 2048, November 1996.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 39]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   [9]  Zopf, R., "Real-time Transport Protocol (RTP) Payload for
+        Comfort Noise (CN)", RFC 3389, September 2002.
+
+   [10] Deleam, D. and J.-P. Petit, "Real-time implementations of the
+        recent ITU-T low bit rate speech coders on the TI TMS320C54X
+        DSP: results, methodology, and applications", in Proc. of
+        International Conference on Signal Processing, Technology, and
+        Applications (ICSPAT) , (Boston, Massachusetts), pp. 1656--1660,
+        October 1996.
+
+   [11] Mouly, M. and M.-B. Pautet, The GSM system for mobile
+        communications Lassay-les-Chateaux, France: Europe Media
+        Duplication, 1993.
+
+   [12] Degener, J., "Digital Speech Compression", Dr. Dobb's Journal,
+        December 1994.
+
+   [13] Redl, S., Weber, M. and M. Oliphant, An Introduction to GSM
+        Boston: Artech House, 1995.
+
+   [14] Hoffman, D., Fernando, G., Goyal, V. and M. Civanlar, "RTP
+        Payload Format for MPEG1/MPEG2 Video", RFC 2250, January 1998.
+
+   [15] Jayant, N. and P. Noll, Digital Coding of Waveforms--Principles
+        and Applications to Speech and Video Englewood Cliffs, New
+        Jersey: Prentice-Hall, 1984.
+
+   [16] McKay, K., "RTP Payload Format for PureVoice(tm) Audio", RFC
+        2658, August 1999.
+
+   [17] Perkins, C., Kouvelas, I., Hodson, O., Hardman, V., Handley, M.,
+        Bolot, J.-C., Vega-Garcia, A. and S. Fosse-Parisis, "RTP Payload
+        for Redundant Audio Data", RFC 2198, September 1997.
+
+   [18] Speer, M. and D. Hoffman, "RTP Payload Format of Sun's CellB
+        Video Encoding", RFC 2029, October 1996.
+
+   [19] Berc, L., Fenner, W., Frederick, R., McCanne, S. and P. Stewart,
+        "RTP Payload Format for JPEG-Compressed Video", RFC 2435,
+        October 1998.
+
+   [20] Turletti, T. and C. Huitema, "RTP Payload Format for H.261 Video
+        Streams", RFC 2032, October 1996.
+
+   [21] Zhu, C., "RTP Payload Format for H.263 Video Streams", RFC 2190,
+        September 1997.
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 40]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   [22] Bormann, C., Cline, L., Deisher, G., Gardos, T., Maciocco, C.,
+        Newell, D., Ott, J., Sullivan, G., Wenger, S. and C. Zhu, "RTP
+        Payload Format for the 1998 Version of ITU-T Rec. H.263 Video
+        (H.263+)", RFC 2429, October 1998.
+
+   [23] Schulzrinne, H., Rao, A. and R. Lanphier, "Real Time Streaming
+        Protocol (RTSP)", RFC 2326, April 1998.
+
+   [24] Cain, B., Deering, S., Kouvelas, I., Fenner, B. and A.
+        Thyagarajan, "Internet Group Management Protocol, Version 3",
+        RFC 3376, October 2002.
+
+13. Current Locations of Related Resources
+
+   Note:  Several sections below refer to the ITU-T Software Tool
+   Library (STL).  It is available from the ITU Sales Service, Place des
+   Nations, CH-1211 Geneve 20, Switzerland (also check
+   http://www.itu.int).  The ITU-T STL is covered by a license defined
+   in ITU-T Recommendation G.191, "Software tools for speech and audio
+   coding standardization".
+
+   DVI4
+
+   An archived copy of the document IMA Recommended Practices for
+   Enhancing Digital Audio Compatibility in Multimedia Systems (version
+   3.0), which describes the IMA ADPCM algorithm, is available at:
+
+      http://www.cs.columbia.edu/~hgs/audio/dvi/
+
+   An implementation is available from Jack Jansen at
+
+      ftp://ftp.cwi.nl/local/pub/audio/adpcm.shar
+
+   G722
+
+   An implementation of the G.722 algorithm is available as part of the
+   ITU-T STL, described above.
+
+   G723
+
+   The reference C code implementation defining the G.723.1 algorithm
+   and its Annexes A, B, and C are available as an integral part of
+   Recommendation G.723.1 from the ITU Sales Service, address listed
+   above.  Both the algorithm and C code are covered by a specific
+   license.  The ITU-T Secretariat should be contacted to obtain such
+   licensing information.
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 41]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+   G726
+
+   G726 is specified in the ITU-T Recommendation G.726, "40, 32, 24, and
+   16 kb/s Adaptive Differential Pulse Code Modulation (ADPCM)".  An
+   implementation of the G.726 algorithm is available as part of the
+   ITU-T STL, described above.
+
+   G729
+
+   The reference C code implementation defining the G.729 algorithm and
+   its Annexes A through I are available as an integral part of
+   Recommendation G.729 from the ITU Sales Service, listed above.  Annex
+   I contains the integrated C source code for all G.729 operating
+   modes.  The G.729 algorithm and associated C code are covered by a
+   specific license.  The contact information for obtaining the license
+   is available from the ITU-T Secretariat.
+
+   GSM
+
+   A reference implementation was written by Carsten Bormann and Jutta
+   Degener (then at TU Berlin, Germany).  It is available at
+
+      http://www.dmn.tzi.org/software/gsm/
+
+   Although the RPE-LTP algorithm is not an ITU-T standard, there is a C
+   code implementation of the RPE-LTP algorithm available as part of the
+   ITU-T STL.  The STL implementation is an adaptation of the TU Berlin
+   version.
+
+   LPC
+
+   An implementation is available at
+
+      ftp://parcftp.xerox.com/pub/net-research/lpc.tar.Z
+
+   PCMU, PCMA
+
+   An implementation of these algorithms is available as part of the
+   ITU-T STL, described above.
+
+14. Acknowledgments
+
+   The comments and careful review of Simao Campos, Richard Cox and AVT
+   Working Group participants are gratefully acknowledged.  The GSM
+   description was adopted from the IMTC Voice over IP Forum Service
+   Interoperability Implementation Agreement (January 1997).  Fred Burg
+   and Terry Lyons helped with the G.729 description.
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 42]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+15. Intellectual Property Rights Statement
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+16. Authors' Addresses
+
+   Henning Schulzrinne
+   Department of Computer Science
+   Columbia University
+   1214 Amsterdam Avenue
+   New York, NY 10027
+   United States
+
+   EMail: schulzrinne@cs.columbia.edu
+
+
+   Stephen L. Casner
+   Packet Design
+   3400 Hillview Avenue, Building 3
+   Palo Alto, CA 94304
+   United States
+
+   EMail: casner@acm.org
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 43]
+
+RFC 3551                    RTP A/V Profile                    July 2003
+
+
+17. Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Casner        Standards Track                    [Page 44]
+

--- a/rfcs/rfc3665.txt
+++ b/rfcs/rfc3665.txt
@@ -1,0 +1,5267 @@
+
+
+
+
+
+
+Network Working Group                                        A. Johnston
+Request for Comments: 3665                                           MCI
+BCP: 75                                                       S. Donovan
+Category: Best Current Practice                                R. Sparks
+                                                           C. Cunningham
+                                                             dynamicsoft
+                                                              K. Summers
+                                                                   Sonus
+                                                           December 2003
+
+
+      Session Initiation Protocol (SIP) Basic Call Flow Examples
+
+Status of this Memo
+
+   This document specifies an Internet Best Current Practices for the
+   Internet Community, and requests discussion and suggestions for
+   improvements.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   This document gives examples of Session Initiation Protocol (SIP)
+   call flows.  Elements in these call flows include SIP User Agents and
+   Clients, SIP Proxy and Redirect Servers.  Scenarios include SIP
+   Registration and SIP session establishment.  Call flow diagrams and
+   message details are shown.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 1]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+Table of Contents
+
+   1.  Overview . . . . . . . . . . . . . . . . . . . . . . . . . . .  2
+       1.1.  General Assumptions. . . . . . . . . . . . . . . . . . .  3
+       1.2.  Legend for Message Flows . . . . . . . . . . . . . . . .  3
+       1.3.  SIP Protocol Assumptions . . . . . . . . . . . . . . . .  4
+   2.  SIP Registration . . . . . . . . . . . . . . . . . . . . . . .  4
+       2.1.  Successful New Registration. . . . . . . . . . . . . . .  5
+       2.2.  Update of Contact List . . . . . . . . . . . . . . . . .  7
+       2.3.  Request for Current Contact List . . . . . . . . . . . .  8
+       2.4.  Cancellation of Registration . . . . . . . . . . . . . .  9
+       2.5.  Unsuccessful Registration. . . . . . . . . . . . . . . . 10
+   3.  SIP Session Establishment. . . . . . . . . . . . . . . . . . . 12
+       3.1.  Successful Session Establishment . . . . . . . . . . . . 12
+       3.2.  Session Establishment Through Two Proxies. . . . . . . . 15
+       3.3.  Session with Multiple Proxy Authentication . . . . . . . 26
+       3.4.  Successful Session with Proxy Failure. . . . . . . . . . 37
+       3.5.  Session Through a SIP ALG. . . . . . . . . . . . . . . . 46
+       3.6.  Session via Redirect and Proxy Servers with SDP in ACK . 54
+       3.7.  Session with re-INVITE (IP Address Change) . . . . . . . 61
+       3.8.  Unsuccessful No Answer . . . . . . . . . . . . . . . . . 67
+       3.9.  Unsuccessful Busy. . . . . . . . . . . . . . . . . . . . 75
+       3.10. Unsuccessful No Response from User Agent . . . . . . . . 80
+       3.11. Unsuccessful Temporarily Unavailable . . . . . . . . . . 85
+   4.  Security Considerations. . . . . . . . . . . . . . . . . . . . 91
+   5.  References . . . . . . . . . . . . . . . . . . . . . . . . . . 91
+       5.1.  Normative References . . . . . . . . . . . . . . . . . . 91
+       5.2.  Informative References . . . . . . . . . . . . . . . . . 91
+   6.  Intellectual Property Statement. . . . . . . . . . . . . . . . 91
+   7.  Acknowledgments. . . . . . . . . . . . . . . . . . . . . . . . 92
+   8.  Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . 93
+   9.  Full Copyright Statement . . . . . . . . . . . . . . . . . . . 94
+
+1.  Overview
+
+   The call flows shown in this document were developed in the design of
+   a SIP IP communications network.  They represent an example minimum
+   set of functionality.
+
+   It is the hope of the authors that this document will be useful for
+   SIP implementers, designers, and protocol researchers alike and will
+   help further the goal of a standard implementation of RFC 3261 [1].
+   These flows represent carefully checked and working group reviewed
+   scenarios of the most basic examples as a companion to the
+   specifications.
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 2]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   These call flows are based on the current version 2.0 of SIP in RFC
+   3261 [1] with SDP usage described in RFC 3264 [2].  Other RFCs also
+   comprise the SIP standard but are not used in this set of basic call
+   flows.
+
+   Call flow examples of SIP interworking with the PSTN through gateways
+   are contained in a companion document, RFC 3666 [5].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119 [4].
+
+1.1.  General Assumptions
+
+   A number of architecture, network, and protocol assumptions underlie
+   the call flows in this document.  Note that these assumptions are not
+   requirements.  They are outlined in this section so that they may be
+   taken into consideration and to aid in the understanding of the call
+   flow examples.
+
+   The authentication of SIP User Agents in these example call flows is
+   performed using HTTP Digest as defined in [1] and [3].
+
+   Some Proxy Servers in these call flows insert Record-Route headers
+   into requests to ensure that they are in the signaling path for
+   future message exchanges.
+
+   These flows show TCP, TLS, and UDP for transport.  See the discussion
+   in RFC 3261 for details on the transport issues for SIP.
+
+1.2.  Legend for Message Flows
+
+   Dashed lines (---) represent signaling messages that are mandatory to
+   the call scenario.  These messages can be SIP or PSTN signaling.  The
+   arrow indicates the direction of message flow.
+
+   Double dashed lines (===) represent media paths between network
+   elements.
+
+   Messages with parentheses around their name represent optional
+   messages.
+
+   Messages are identified in the Figures as F1, F2, etc.  This
+   references the message details in the list that follows the Figure.
+   Comments in the message details are shown in the following form:
+
+    /* Comments. */
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 3]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+1.3.  SIP Protocol Assumptions
+
+   This document does not prescribe the flows precisely as they are
+   shown, but rather the flows illustrate the principles for best
+   practice.  They are best practices usages (orderings, syntax,
+   selection of features for the purpose, handling of error) of SIP
+   methods, headers and parameters.  IMPORTANT: The exact flows here
+   must not be copied as is by an implementer due to specific incorrect
+   characteristics that were introduced into the document for
+   convenience and are listed below.  To sum up, the basic flows
+   represent well-reviewed examples of SIP usage, which are best common
+   practice according to IETF consensus.
+
+   For simplicity in reading and editing the document, there are a
+   number of differences between some of the examples and actual SIP
+   messages.  For example, the HTTP Digest responses are not actual MD5
+   encodings.  Call-IDs are often repeated, and CSeq counts often begin
+   at 1.  Header fields are usually shown in the same order.  Usually
+   only the minimum required header field set is shown, others that
+   would normally be present such as Accept, Supported, Allow, etc are
+   not shown.
+
+   Actors:
+
+   Element       Display Name   URI                         IP Address
+   -------       ------------   ---                         ----------
+
+   User Agent    Alice          alice@atlanta.example.com   192.0.2.101
+   User Agent    Bob            bob@biloxi.example.com      192.0.2.201
+   User Agent                   bob@chicago.example.com     192.0.2.100
+   Proxy Server                 ss1.atlanta.example.com     192.0.2.111
+   Proxy/Registrar              ss2.biloxi.example.com      192.0.2.222
+   Proxy Server                 ss3.chicago.example.com     192.0.2.233
+   ALG                          alg1.atlanta.example.com    192.0.2.128
+
+2.  SIP Registration
+
+   Registration binds a particular device Contact URI with a SIP user
+   Address of Record (AOR).
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 4]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+2.1.  Successful New Registration
+
+    Bob                        SIP Server
+     |                               |
+     |          REGISTER F1          |
+     |------------------------------>|
+     |      401 Unauthorized F2      |
+     |<------------------------------|
+     |          REGISTER F3          |
+     |------------------------------>|
+     |            200 OK F4          |
+     |<------------------------------|
+     |                               |
+
+   Bob sends a SIP REGISTER request to the SIP server.  The request
+   includes the user's contact list.  This flow shows the use of HTTP
+   Digest for authentication using TLS transport.  TLS transport is used
+   due to the lack of integrity protection in HTTP Digest and the danger
+   of registration hijacking without it, as described in RFC 3261 [1].
+   The SIP server provides a challenge to Bob.  Bob enters her/his valid
+   user ID and password.  Bob's SIP client encrypts the user information
+   according to the challenge issued by the SIP server and sends the
+   response to the SIP server.  The SIP server validates the user's
+   credentials.  It registers the user in its contact database and
+   returns a response (200 OK) to Bob's SIP client.  The response
+   includes the user's current contact list in Contact headers.  The
+   format of the authentication shown is HTTP digest.  It is assumed
+   that Bob has not previously registered with this Server.
+
+   Message Details
+
+   F1 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 5]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F2 401 Unauthorized SIP Server -> Bob
+
+   SIP/2.0 401 Unauthorized
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>;tag=1410948204
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   WWW-Authenticate: Digest realm="atlanta.example.com", qop="auth",
+    nonce="ea9c8e88df84f1cec4341ae6cbe5a359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+   F3 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashd92
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=ja743ks76zlflH
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 2 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>
+   Authorization: Digest username="bob", realm="atlanta.example.com"
+    nonce="ea9c8e88df84f1cec4341ae6cbe5a359", opaque="",
+    uri="sips:ss2.biloxi.example.com",
+    response="dfe56131d1958046689d83306477ecc"
+   Content-Length: 0
+
+
+   F4 200 OK SIP Server -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashd92
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=ja743ks76zlflH
+   To: Bob <sips:bob@biloxi.example.com>;tag=37GkEhwl6
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 2 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>;expires=3600
+   Content-Length: 0
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 6]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+2.2.  Update of Contact List
+
+   Bob                        SIP Server
+     |                               |
+     |          REGISTER F1          |
+     |------------------------------>|
+     |            200 OK F2          |
+     |<------------------------------|
+     |                               |
+
+   Bob wishes to update the list of addresses where the SIP server will
+   redirect or forward INVITE requests.
+
+   Bob sends a SIP REGISTER request to the SIP server.  Bob's request
+   includes an updated contact list.  Since the user already has
+   authenticated with the server, the user supplies authentication
+   credentials with the request and is not challenged by the server. The
+   SIP server validates the user's credentials.  It registers the user
+   in its contact database, updates the user's contact list, and returns
+   a response (200 OK) to Bob's SIP client.  The response includes the
+   user's current contact list in Contact headers.
+
+   Message Details
+
+   F1 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Contact: mailto:bob@biloxi.example.com
+   Authorization: Digest username="bob", realm="atlanta.example.com",
+    qop="auth", nonce="1cec4341ae6cbe5a359ea9c8e88df84f", opaque="",
+    uri="sips:ss2.biloxi.example.com",
+    response="71ba27c64bd01de719686aa4590d5824"
+   Content-Length: 0
+
+
+   F2 200 OK SIP Server -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>;tag=34095828jh
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 7]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>;expires=3600
+   Contact: <mailto:bob@biloxi.example.com>;expires=4294967295
+   Content-Length: 0
+
+2.3.  Request for Current Contact List
+
+   Bob                        SIP Server
+     |                               |
+     |          REGISTER F1          |
+     |------------------------------>|
+     |            200 OK F2          |
+     |<------------------------------|
+     |                               |
+
+   Bob sends a register request to the Proxy Server containing no
+   Contact headers, indicating the user wishes to query the server for
+   the user's current contact list.  Since the user already has
+   authenticated with the server, the user supplies authentication
+   credentials with the request and is not challenged by the server.
+   The SIP server validates the user's credentials.  The server returns
+   a response (200 OK) which includes the user's current registration
+   list in Contact headers.
+
+   Message Details
+
+   F1 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Authorization: Digest username="bob", realm="atlanta.example.com",
+    nonce="df84f1cec4341ae6cbe5ap359a9c8e88", opaque="",
+    uri="sips:ss2.biloxi.example.com",
+    response="aa7ab4678258377c6f7d4be6087e2f60"
+   Content-Length: 0
+
+
+   F2 200 OK SIP Server -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 8]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>;tag=jqoiweu75
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>;expires=3600
+   Contact: <mailto:bob@biloxi.example.com>;expires=4294967295
+   Content-Length: 0
+
+2.4.  Cancellation of Registration
+
+   Bob                         SIP Server
+     |                               |
+     |          REGISTER F1          |
+     |------------------------------>|
+     |            200 OK F2          |
+     |<------------------------------|
+     |                               |
+
+   Bob wishes to cancel their registration with the SIP server.  Bob
+   sends a SIP REGISTER request to the SIP server.  The request has an
+   expiration period of 0 and applies to all existing contact locations.
+   Since the user already has authenticated with the server, the user
+   supplies authentication credentials with the request and is not
+   challenged by the server.  The SIP server validates the user's
+   credentials.  It clears the user's contact list, and returns a
+   response (200 OK) to Bob's SIP client.
+
+   Message Details
+
+   F1 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Expires: 0
+   Contact: *
+   Authorization: Digest username="bob", realm="atlanta.example.com",
+    nonce="88df84f1cac4341aea9c8ee6cbe5a359", opaque="",
+    uri="sips:ss2.biloxi.example.com",
+    response="ff0437c51696f9a76244f0cf1dbabbea"
+   Content-Length: 0
+
+
+   F2 200 OK SIP Server -> Bob
+
+
+
+Johnston, et al.         Best Current Practice                  [Page 9]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>;tag=1418nmdsrf
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Content-Length: 0
+
+2.5.  Unsuccessful Registration
+
+   Bob                        SIP Server
+     |                               |
+     |          REGISTER F1          |
+     |------------------------------>|
+     |      401 Unauthorized F2      |
+     |<------------------------------|
+     |          REGISTER F3          |
+     |------------------------------>|
+     |      401 Unauthorized F4      |
+     |<------------------------------|
+     |                               |
+
+   Bob sends a SIP REGISTER request to the SIP Server.  The SIP server
+   provides a challenge to Bob.  Bob enters her/his user ID and
+   password.  Bob's SIP client encrypts the user information according
+   to the challenge issued by the SIP server and sends the response to
+   the SIP server.  The SIP server attempts to validate the user's
+   credentials, but they are not valid (the user's password does not
+   match the password established for the user's account).  The server
+   returns a response (401 Unauthorized) to Bob's SIP client.
+
+   Message Details
+
+   F1 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 10]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F2 Unauthorized SIP Server -> Bob
+
+   SIP/2.0 401 Unauthorized
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=a73kszlfl
+   To: Bob <sips:bob@biloxi.example.com>;tag=1410948204
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 1 REGISTER
+   WWW-Authenticate: Digest realm="atlanta.example.com", qop="auth",
+    nonce="f1cec4341ae6ca9c8e88df84be55a359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+   F3 REGISTER Bob -> SIP Server
+
+   REGISTER sips:ss2.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashd92
+   Max-Forwards: 70
+   From: Bob <sips:bob@biloxi.example.com>;tag=JueHGuidj28dfga
+   To: Bob <sips:bob@biloxi.example.com>
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 2 REGISTER
+   Contact: <sips:bob@client.biloxi.example.com>
+   Authorization: Digest username="bob", realm="atlanta.example.com",
+    nonce="f1cec4341ae6ca9c8e88df84be55a359", opaque="",
+    uri="sips:ss2.biloxi.example.com",
+    response="61f8470ceb87d7ebf508220214ed438b"
+   Content-Length: 0
+
+   /*  The response above encodes the incorrect password */
+
+
+   F4 401 Unauthorized SIP Server -> Bob
+
+   SIP/2.0 401 Unauthorized
+   Via: SIP/2.0/TLS client.biloxi.example.com:5061;branch=z9hG4bKnashd92
+    ;received=192.0.2.201
+   From: Bob <sips:bob@biloxi.example.com>;tag=JueHGuidj28dfga
+   To: Bob <sips:bob@biloxi.example.com>;tag=1410948204
+   Call-ID: 1j9FpLxk3uxtm8tn@biloxi.example.com
+   CSeq: 2 REGISTER
+   WWW-Authenticate: Digest realm="atlanta.example.com", qop="auth",
+    nonce="84f1c1ae6cbe5ua9c8e88dfa3ecm3459",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 11]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.  SIP Session Establishment
+
+   This section details session establishment between two SIP User
+   Agents (UAs): Alice and Bob.  Alice (sip:alice@atlanta.example.com)
+   and Bob (sip:bob@biloxi.example.com) are assumed to be SIP phones or
+   SIP-enabled devices.  The successful calls show the initial
+   signaling, the exchange of media information in the form of SDP
+   payloads, the establishment of the media session, then finally the
+   termination of the call.
+
+   HTTP Digest authentication is used by Proxy Servers to authenticate
+   the caller Alice.  It is assumed that Bob has registered with Proxy
+   Server Proxy 2 as per Section 2 to be able to receive the calls via
+   the Proxy.
+
+3.1.  Successful Session Establishment
+
+   Alice                     Bob
+     |                        |
+     |       INVITE F1        |
+     |----------------------->|
+     |    180 Ringing F2      |
+     |<-----------------------|
+     |                        |
+     |       200 OK F3        |
+     |<-----------------------|
+     |         ACK F4         |
+     |----------------------->|
+     |   Both Way RTP Media   |
+     |<======================>|
+     |                        |
+     |         BYE F5         |
+     |<-----------------------|
+     |       200 OK F6        |
+     |----------------------->|
+     |                        |
+
+   In this scenario, Alice completes a call to Bob directly.
+
+   Message Details
+
+   F1 INVITE Alice -> Bob
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 12]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F2 180 Ringing Bob -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=8321234356
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   Content-Length: 0
+
+
+   F3 200 OK Bob -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=8321234356
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 13]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+
+   F4 ACK Alice -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bd5
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=8321234356
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+   /* RTP streams are established between Alice and Bob */
+
+   /* Bob Hangs Up with Alice. Note that the CSeq is NOT 2, since
+      Alice and Bob maintain their own independent CSeq counts.
+      (The INVITE was request 1 generated by Alice, and the BYE is
+      request 1 generated by Bob) */
+
+
+   F5 BYE Bob -> Alice
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sip:bob@biloxi.example.com>;tag=8321234356
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F6 200 OK Alice -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sip:bob@biloxi.example.com>;tag=8321234356
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 14]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.2.  Session Establishment Through Two Proxies
+
+   Alice           Proxy 1          Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|                |                |
+     |     407 F2     |                |                |
+     |<---------------|                |                |
+     |     ACK F3     |                |                |
+     |--------------->|                |                |
+     |   INVITE F4    |                |                |
+     |--------------->|   INVITE F5    |                |
+     |     100  F6    |--------------->|   INVITE F7    |
+     |<---------------|     100  F8    |--------------->|
+     |                |<---------------|                |
+     |                |                |     180 F9     |
+     |                |    180 F10     |<---------------|
+     |     180 F11    |<---------------|                |
+     |<---------------|                |     200 F12    |
+     |                |    200 F13     |<---------------|
+     |     200 F14    |<---------------|                |
+     |<---------------|                |                |
+     |     ACK F15    |                |                |
+     |--------------->|    ACK F16     |                |
+     |                |--------------->|     ACK F17    |
+     |                |                |--------------->|
+     |                Both Way RTP Media                |
+     |<================================================>|
+     |                |                |     BYE F18    |
+     |                |    BYE F19     |<---------------|
+     |     BYE F20    |<---------------|                |
+     |<---------------|                |                |
+     |     200 F21    |                |                |
+     |--------------->|     200 F22    |                |
+     |                |--------------->|     200 F23    |
+     |                |                |--------------->|
+     |                |                |                |
+
+   In this scenario, Alice completes a call to Bob using two proxies
+   Proxy 1 and Proxy 2.  The initial INVITE (F1) contains a pre-loaded
+   Route header with the address of Proxy 1 (Proxy 1 is configured as a
+   default outbound proxy for Alice).  The request does not contain the
+   Authorization credentials Proxy 1 requires, so a 407 Proxy
+   Authorization response is sent containing the challenge information.
+   A new INVITE (F4) is then sent containing the correct credentials and
+   the call proceeds.  The call terminates when Bob disconnects by
+   initiating a BYE message.
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 15]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Proxy 1 inserts a Record-Route header into the INVITE message to
+   ensure that it is present in all subsequent message exchanges.  Proxy
+   2 also inserts itself into the Record-Route header.  The ACK (F15)
+   and BYE (F18) both have a Route header.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b43
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 1 challenges Alice for authentication */
+
+
+   F2 407 Proxy Authorization Required Proxy 1 -> Alice
+
+   SIP/2.0 407 Proxy Authorization Required
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b43
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=3flal12sf
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 INVITE
+   Proxy-Authenticate: Digest realm="atlanta.example.com", qop="auth",
+    nonce="f84f1cec41e6cbe5aea9c8e88d359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 16]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F3 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b43
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=3flal12sf
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+   /* Alice responds be re-sending the INVITE with authentication
+      credentials in it. */
+
+
+   F4 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="42ce3cef44b22f50c6a6071bc8"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 1 accepts the credentials and forwards the INVITE to Proxy
+   2.  Client for Alice prepares to receive data on port 49172 from the
+   network. */
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 17]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F5 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F6 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F7 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 18]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F8 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F9 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 19]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   F10 180 Ringing Proxy 2 -> Proxy 1
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F11 180 Ringing Proxy 1 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F12 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 20]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F13 200 OK Proxy 2 -> Proxy 1
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F14 200 OK Proxy 1 -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 21]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F15 ACK Alice -> Proxy 1
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b76
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>,
+    <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Length: 0
+
+
+   F16 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b76
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Length: 0
+
+
+   F17 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 22]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74b76
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Length: 0
+
+   /* RTP streams are established between Alice and Bob */
+
+   /* Bob Hangs Up with Alice. */
+
+   /* Again, note that the CSeq is NOT 3.  Alice and Bob maintain
+      their own separate CSeq counts */
+
+
+   F18 BYE Bob -> Proxy 2
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F19 BYE Proxy 2 -> Proxy 1
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   Max-Forwards: 69
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 23]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F20 BYE Proxy 1 -> Alice
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   Max-Forwards: 68
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F21 200 OK Alice -> Proxy 1
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F22 200 OK Proxy 1 -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.101
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 24]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F23 200 OK Proxy 2 -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 3848276298220188511@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 25]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.3.  Session with Multiple Proxy Authentication
+
+     Alice        Proxy 1     Proxy 2         Bob
+       |            |           |             |
+       |  INVITE F1 |           |             |
+       |----------->|           |             |
+       |  407 Proxy Authorization Required F2 |
+       |<-----------|           |             |
+       |   ACK F3   |           |             |
+       |----------->|           |             |
+       |  INVITE F4 |           |             |
+       |----------->|           |             |
+       |   100 F5   |           |             |
+       |<-----------| INVITE F6 |             |
+       |            |---------->|             |
+       |            |  407 Proxy Authorization Required F7
+       |            |<----------|             |
+       |            |   ACK F8  |             |
+       |            |---------->|             |
+       |  407 Proxy Authorization Required F9 |
+       |<-----------|           |             |
+       |   ACK F10  |           |             |
+       |----------->|           |             |
+       |  INVITE F11|           |             |
+       |----------->|           |             |
+       |   100 F12  |           |             |
+       |<-----------| INVITE F13|             |
+       |            |---------->|             |
+       |            |  100 F14  |             |
+       |            |<----------|  INVITE F15 |
+       |            |           |------------>|
+       |            |           | 200 OK F16  |
+       |            | 200 OK F17|<------------|
+       | 200 OK F18 |<----------|             |
+       |<-----------|           |             |
+       |   ACK F19  |           |             |
+       |----------->|  ACK F20  |             |
+       |            |---------->|   ACK F21   |
+       |            |           |------------>|
+       |           RTP Media Path             |
+       |<====================================>|
+
+   In this scenario, Alice completes a call to Bob using two proxies
+   Proxy 1 and Proxy 2.  Alice has valid credentials in both domains.
+   Since the initial INVITE (F1) does not contain the Authorization
+   credentials Proxy 1 requires, so a 407 Proxy Authorization response
+   is sent containing the challenge information. A new INVITE (F4) is
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 26]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   then sent containing the correct credentials and the call proceeds
+   after Proxy 2 challenges and receives valid credentials.  The call
+   terminates when Bob disconnects by initiating a BYE message.
+
+   Proxy 1 inserts a Record-Route header into the INVITE message to
+   ensure that it is present in all subsequent message exchanges.  Proxy
+   2 also inserts itself into the Record-Route header.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b03
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 1 challenges Alice for authentication */
+
+
+   F2 407 Proxy Authorization Required Proxy 1 -> Alice
+
+   SIP/2.0 407 Proxy Authorization Required
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b03
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=876321
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Proxy-Authenticate: Digest realm="atlanta.example.com", qop="auth",
+    nonce="wf84f1cczx41ae6cbeaea9ce88d359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 27]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+
+   F3 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Max-Forwards: 70
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b03
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=876321
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+   /* Alice responds be re-sending the INVITE with authentication
+      credentials in it.  The same Call-ID is used, so the CSeq is
+      increased. */
+
+
+   F4 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="42ce3cef44b22f50c6a6071bc8"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 1 accepts the credentials and forwards the INVITE to Proxy
+   2.  Client for Alice prepares to receive data on port 49172 from the
+   network. */
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 28]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   F5 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F6 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 2 challenges Alice for authentication */
+
+
+   F7 407 Proxy Authorization Required Proxy 2 -> Proxy 1
+
+   SIP/2.0 407 Proxy Authorization Required
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+    ;received=192.0.2.101
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 29]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=838209
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Proxy-Authenticate: Digest realm="biloxi.example.com", qop="auth",
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+   F8 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=838209
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Length: 0
+
+   /* Proxy 1 forwards the challenge to Alice for authentication from
+   Proxy 2 */
+
+
+   F9 407 Proxy Authorization Required Proxy 1 -> Alice
+
+   SIP/2.0 407 Proxy Authorization Required
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=838209
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Proxy-Authenticate: Digest realm="biloxi.example.com", qop="auth",
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+   F10 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b21
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=838209
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 30]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   CSeq: 2 ACK
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="42ce3cef44b22f50c6a6071bc8"
+   Content-Length: 0
+
+   /* Alice responds be re-sending the INVITE with authentication
+   credentials for Proxy 1 AND Proxy 2.  */
+
+
+   F11 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="42ce3cef44b22f50c6a6071bc8"
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com", response="f44ab22f150c6a56071bce8"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 1 finds its credentials and authorizes Alice, forwarding the
+   INVITE to Proxy.  */
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 31]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F12 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Content-Length: 0
+
+
+   F13 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com", response="f44ab22f150c6a56071bce8"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 2 finds its credentials and authorizes Alice, forwarding the
+   INVITE to Bob.  */
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 32]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F14 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Content-Length: 0
+
+
+   F15 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK31972.1
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Bob answers the call immediately */
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 33]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F16 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK31972.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F17 200 OK Proxy 2 -> Proxy 1
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 34]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F18 200 OK Proxy 1 -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F19 ACK Alice -> Proxy 1
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b44
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>,
+    <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 ACK
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="42ce3cef44b22f50c6a6071bc8"
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 35]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com", response="f44ab22f150c6a56071bce8"
+   Content-Length: 0
+
+
+   F20 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b44
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 ACK
+   Contact: <sip:bob@client.biloxi.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+    nonce="c1e22c41ae6cbe5ae983a9c8e88d359", opaque="",
+    uri="sip:bob@biloxi.example.com", response="f44ab22f150c6a56071bce8"
+   Content-Length: 0
+
+
+   F21 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK31972.1
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK230f2.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b44
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=9103874
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 3 ACK
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 36]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.4.  Successful Session with Proxy Failure
+
+    Alice           Proxy 1          Proxy 2            Bob
+      |                |                |                |
+      |   INVITE F1    |                |                |
+      |--------------->|                |                |
+      |   INVITE F2    |                |                |
+      |--------------->|                |                |
+      |   INVITE F3    |                |                |
+      |--------------->|                |                |
+      |   INVITE F4    |                |                |
+      |--------------->|                |                |
+      |   INVITE F5    |                |                |
+      |--------------->|                |                |
+      |   INVITE F6    |                |                |
+      |--------------->|                |                |
+      |   INVITE F7    |                |                |
+      |--------------->|                |                |
+      |     INVITE F8                   |                |
+      |-------------------------------->|                |
+      |            407 F9               |                |
+      |<--------------------------------|                |
+      |             ACK F10             |                |
+      |-------------------------------->|                |
+      |           INVITE F11            |                |
+      |-------------------------------->|   INVITE F12   |
+      |             100  F13            |--------------->|
+      |<--------------------------------|                |
+      |                                 |     180 F14    |
+      |             180 F15             |<---------------|
+      |<--------------------------------|                |
+      |                                 |     200 F16    |
+      |             200 F17             |<---------------|
+      |<--------------------------------|                |
+      |             ACK F18             |                |
+      |-------------------------------->|     ACK F19    |
+      |                                 |--------------->|
+      |                Both Way RTP Media                |
+      |<================================================>|
+      |                                 |     BYE F20    |
+      |             BYE F21             |<---------------|
+      |<--------------------------------|                |
+      |             200 F22             |                |
+      |-------------------------------->|     200 F23    |
+      |                                 |--------------->|
+      |                                 |                |
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 37]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   In this scenario, Alice completes a call to Bob via a Proxy Server.
+   Alice is configured for a primary SIP Proxy Server Proxy 1 and a
+   secondary SIP Proxy Server Proxy 2 (Or is able to use DNS SRV records
+   to locate Proxy 1 and Proxy 2).  Alice has valid credentials for both
+   domains.  Proxy 1 is out of service and does not respond to INVITEs
+   (it is reachable, but unresponsive).  Alice then completes the call
+   to Bob using Proxy 2.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK465b6d
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F2 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+
+   F3 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+
+   F4 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 38]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F5 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+
+   F6 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+
+   F7 INVITE Alice -> Proxy 1
+
+   Same as Message F1
+
+   /* Alice gives up on the unresponsive proxy */
+
+
+   F8 INVITE Alice -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b8a
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Proxy 2 challenges Alice for authentication */
+
+
+   F9 407 Proxy Authorization Required Proxy 2 -> Alice
+
+   SIP/2.0 407 Proxy Authorization Required
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b8a
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=2421452
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 39]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 INVITE
+   Proxy-Authenticate: Digest realm="biloxi.example.com", qop="auth",
+    nonce="1ae6cbe5ea9c8e8df84fqnlec434a359",
+    opaque="", stale=FALSE, algorithm=MD5
+   Content-Length: 0
+
+
+   F10 ACK Alice -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b8a
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=2421452
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+   /* Alice responds by re-sending the INVITE with authentication
+   credentials in it.  */
+
+
+   F11 INVITE Alice -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+    nonce="1ae6cbe5ea9c8e8df84fqnlec434a359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="8a880c919d1a52f20a1593e228adf599"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 40]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   /* Proxy 2 accepts the credentials and forwards the INVITE to Bob.
+   Client for Alice prepares to receive data on port 49172 from the
+   network.
+   */
+
+
+   F12 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F13 100 Trying Proxy 2 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F14 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 41]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F15 180 Ringing Proxy 2 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F16 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 42]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+
+   F17 200 OK Proxy 2 -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F18 ACK Alice -> Proxy 2
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b8g
+   Max-Forwards: 70
+   Route: <sip:ss2.biloxi.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Length: 0
+
+
+   F19 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b8g
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 43]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   CSeq: 2 ACK
+   Content-Length: 0
+
+   /* RTP streams are established between Alice and Bob */
+
+   /* Bob Hangs Up with Alice. */
+
+
+   F20 BYE Bob -> Proxy 2
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   Route: <sip:ss2.biloxi.example.com;lr>
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F21 BYE Proxy 2 -> Alice
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   Max-Forwards: 69
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F22 200 OK Alice -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 44]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   F23 200 OK Proxy 2 -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.biloxi.example.com:5060;branch=z9hG4bKnashds7
+    ;received=192.0.2.201
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 4Fde34wkd11wsGFDs3@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 45]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.5.  Session Through a SIP ALG
+
+   Alice             ALG           Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|   INVITE F2    |                |
+     |     100 F3     |--------------->|   INVITE F4    |
+     |<---------------|     100 F5     |--------------->|
+     |                |<---------------|      180 F6    |
+     |                |     180 F7     |<---------------|
+     |     180 F8     |<---------------|                |
+     |<---------------|                |      200 F9    |
+     |                |    200 F10     |<---------------|
+     |     200 F11    |<---------------|                |
+     |<---------------|                                 |
+     |     ACK F12    |                                 |
+     |--------------->|             ACK F13             |
+     |                |-------------------------------->|
+     |    RTP Media   |        Both Way RTP Media       |
+     |<==============>|<===============================>|
+     |     BYE F14    |                                 |
+     |--------------->|             BYE F15             |
+     |                |-------------------------------->|
+     |                |             200 F16             |
+     |     200 F17    |<--------------------------------|
+     |<---------------|                                 |
+     |                |                                 |
+
+   Alice completes a call to Bob through a ALG (Application Layer
+   Gateway) and a SIP Proxy.  The routing through the ALG is
+   accomplished using a pre-loaded Route header in the INVITE F1.  Note
+   that the media stream setup is not end-to-end - the ALG terminates
+   both media streams and bridges them.  This is done by the ALG
+   modifying the SDP in the INVITE (F1) and 200 OK (F10) messages, and
+   possibly any 18x or ACK messages containing SDP.
+
+   In addition to firewall traversal, this Back-to-Back User Agent
+   (B2BUA) could be used as part of an anonymizer service (in which all
+   identifying information on Alice would be removed), or to perform
+   codec media conversion, such as mu-law to A-law conversion of PCM on
+   an international call.
+
+   Also note that Proxy 2 does not Record-Route in this call flow.
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 46]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Message Details
+
+   F1 INVITE Alice -> SIP ALG
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Route: <sip:alg1.atlanta.example.com;lr>
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+    nonce="85b4f1cen4341ae6cbe5a3a9c8e88df9", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="b3f392f9218a328b9294076d708e6815"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* Client for Alice prepares to receive data on port 49172 from the
+   network. */
+
+
+   F2 INVITE SIP ALG -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="biloxi.example.com",
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 47]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+    nonce="85b4f1cen4341ae6cbe5a3a9c8e88df9", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="b3f392f9218a328b9294076d708e6815"
+   Content-Type: application/sdp
+   Content-Length: 150
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.128
+   t=0 0
+   m=audio 2000 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F3 100 Trying SIP ALG -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+   /* SIP ALG prepares to proxy data from port 192.0.2.128/2000 to
+   192.0.2.101/49172.   Proxy 2 uses a Location Service function to
+   determine where Bob is located. Based upon location analysis the call
+   is forwarded to Bob */
+
+
+   F4 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 48]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Content-Length: 150
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.128
+   t=0 0
+   m=audio 2000 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F5 100 Trying Proxy 2 -> SIP ALG
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F6 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F7 180 Ringing Proxy 2 -> SIP ALG
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 49]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F8 180 Ringing SIP ALG -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F9 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 50]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F10 200 OK Proxy 2 -> SIP ALG
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F11 200 OK SIP ALG -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.128
+   t=0 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 51]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   m=audio 1734 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* The ALG prepares to proxy packets from 192.0.2.128/
+      1734 to 192.0.2.201/3456 */
+
+
+   F12 ACK Alice -> SIP ALG
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bhh
+   Max-Forwards: 70
+   Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F13 ACK SIP ALG -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bhh
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+   /* RTP streams are established between Alice and the ALG and
+   between the ALG and B*/
+
+   /* Alice Hangs Up with Bob. */
+
+
+   F14 BYE Alice -> SIP ALG
+
+   BYE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74be5
+   Max-Forwards: 70
+   Route: <sip:alg1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 52]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+   F15 BYE SIP ALG -> Bob
+
+   BYE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74be5
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+   F16 200 OK Bob -> SIP ALG
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP alg1.atlanta.example.com:5060;branch=z9hG4bK739578.1
+    ;received=192.0.2.128
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74be5
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+   F17 200 OK SIP ALG -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74be5
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 53]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.6.  Session via Redirect and Proxy Servers with SDP in ACK
+
+   Alice        Redirect Server     Proxy 3             Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|                |                |
+     |     302 F2     |                |                |
+     |<---------------|                |                |
+     |     ACK F3     |                |                |
+     |--------------->|                |                |
+     |     INVITE F4                   |                |
+     |-------------------------------->|    INVITE F5   |
+     |             100  F6             |--------------->|
+     |<--------------------------------|      180 F7    |
+     |             180 F8              |<---------------|
+     |<--------------------------------|                |
+     |                                 |     200 F9     |
+     |             200 F10             |<---------------|
+     |<--------------------------------|                |
+     |             ACK F11             |                |
+     |-------------------------------->|     ACK F12    |
+     |                                 |--------------->|
+     |                Both Way RTP Media                |
+     |<================================================>|
+     |                                 |     BYE F13    |
+     |             BYE F14             |<---------------|
+     |<--------------------------------|                |
+     |             200 F15             |                |
+     |-------------------------------->|     200 F16    |
+     |                                 |--------------->|
+     |                                 |                |
+
+   In this scenario, Alice places a call to Bob using first a Redirect
+   server then a Proxy Server.  The INVITE message is first sent to the
+   Redirect Server.  The Server returns a 302 Moved Temporarily response
+   (F2) containing a Contact header with Bob's current SIP address.
+   Alice then generates a new INVITE and sends to Bob via the Proxy
+   Server and the call proceeds normally.  In this example, no SDP is
+   present in the INVITE, so the SDP is carried in the ACK message.
+
+   The call is terminated when Bob sends a BYE message.
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 54]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Message Details
+
+   F1 INVITE Alice -> Redirect Server
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bKbf9f44
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Length: 0
+
+
+   F2 302 Moved Temporarily Redirect Proxy -> Alice
+
+   SIP/2.0 302 Moved Temporarily
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bKbf9f44
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=53fHlqlQ2
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@chicago.example.com;transport=tcp>
+   Content-Length: 0
+
+
+   F3 ACK Alice -> Redirect Server
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bKbf9f44
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=53fHlqlQ2
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F4 INVITE Alice -> Proxy 3
+
+   INVITE sip:bob@chicago.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 55]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Length: 0
+
+
+   F5 INVITE Proxy 3 -> Bob
+
+   INVITE sip:bob@client.chicago.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Length: 0
+
+
+   F6 100 Trying Proxy 3 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Content-Length: 0
+
+
+   F7 180 Ringing Bob -> Proxy 3
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+    ;received=192.0.2.233
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.chicago.example.com;transport=tcp>
+   Content-Length: 0
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 56]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   F8 180 Ringing Proxy 3 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.chicago.example.com;transport=tcp>
+   Content-Length: 0
+
+
+   F9 200 OK Bob -> Proxy 3
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+    ;received=192.0.2.233
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.chicago.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 148
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.chicago.example.com
+   s=-
+   c=IN IP4 192.0.2.100
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F10 200 OK Proxy -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 57]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 INVITE
+   Contact: <sip:bob@client.chicago.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 148
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.chicago.example.com
+   s=-
+   c=IN IP4 192.0.2.100
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* ACK contains SDP of Alice since none present in INVITE */
+
+
+   F11 ACK Alice -> Proxy 3
+
+   ACK sip:bob@client.chicago.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bq9
+   Max-Forwards: 70
+   Route: <sip:ss3.chicago.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F12 ACK Proxy 3 -> Bob
+
+   ACK sip:bob@client.chicago.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bq9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 58]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 ACK
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /* RTP streams are established between Alice and Bob */
+
+   /* Bob Hangs Up with Alice. */
+
+
+   F13 BYE Bob -> Proxy 3
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.chicago.example.com:5060;branch=z9hG4bKfgaw2
+   Max-Forwards: 70
+   Route: <sip:ss3.chicago.example.com;lr>
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F14 BYE Proxy 3 -> Alice
+
+   BYE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+    ;received=192.0.2.100
+   Via: SIP/2.0/TCP client.chicago.example.com:5060;branch=z9hG4bKfgaw2
+   Max-Forwards: 69
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F15 200 OK Alice -> Proxy 3
+
+   SIP/2.0 200 OK
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 59]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Via: SIP/2.0/TCP ss3.chicago.example.com:5060;branch=z9hG4bK721e.1
+    ;received=192.0.2.233
+   Via: SIP/2.0/TCP client.chicago.example.com:5060;branch=z9hG4bKfgaw2
+    ;received=192.0.2.100
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+   F16 200 OK Proxy 3 -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP client.chicago.example.com:5060;branch=z9hG4bKfgaw2
+    ;received=192.0.2.100
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 60]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.7.  Session with re-INVITE (IP Address Change)
+
+
+     Alice                Proxy 2                Bob
+        |   F1 INVITE        |                    |
+        |------------------->|      F2 INVITE     |
+        |   F3 100 Trying    |------------------->|
+        |<-------------------|   F4 180 Ringing   |
+        |   F5 180 Ringing   |<-------------------|
+        |<-------------------|                    |
+        |                    |    F6 200 OK       |
+        |    F7 200 OK       |<-------------------|
+        |<-------------------|                    |
+        |                 F8  ACK                 |
+        |---------------------------------------->|
+        |      Both Way RTP Media Established     |
+        |<=======================================>|
+        |                                         |
+        |           Bob changes IP address        |
+        |                                         |
+        |                 F9 INVITE               |
+        |<----------------------------------------|
+        |                F10 200 OK               |
+        |---------------------------------------->|
+        |                 F11  ACK                |
+        |<----------------------------------------|
+        |         New RTP Media Stream            |
+        |<=======================================>|
+        |                 F12 BYE                 |
+        |---------------------------------------->|
+        |               F13 200 OK                |
+        |<----------------------------------------|
+        |                                         |
+
+   This example shows a session in which the media changes midway
+   through the session.  When Bob's IP address changes during the
+   session, Bob sends a re-INVITE containing a new Contact and SDP
+   (version number incremented) information to A.  In this flow, the
+   proxy does not Record-Route so is not in the SIP messaging path after
+   the initial exchange.
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 61]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F2 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 62]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F3 100 Trying Proxy 2 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F4 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F5 180 Ringing Proxy 2 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F6 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 63]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F7 200 OK Proxy 2 -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Type: application/sdp
+   Content-Length: 147
+
+   v=0
+   o=bob 2890844527 2890844527 IN IP4 client.biloxi.example.com
+   s=-
+   c=IN IP4 192.0.2.201
+   t=0 0
+   m=audio 3456 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F8 ACK Alice -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74b7b
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 64]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   /* RTP streams are established between Alice and Bob */
+
+   /* Bob changes IP address and re-INVITEs Alice with new Contact and
+   SDP */
+
+
+   F9 INVITE Bob -> Alice
+
+   INVITE sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.chicago.example.com:5060;branch=z9hG4bKlkld5l
+   Max-Forwards: 70
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 14 INVITE
+   Contact: <sip:bob@client.chicago.example.com>
+   Content-Type: application/sdp
+   Content-Length: 149
+
+   v=0
+   o=bob 2890844527 2890844528 IN IP4 client.chicago.example.com
+   s=-
+   c=IN IP4 192.0.2.100
+   t=0 0
+   m=audio 47172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F10 200 OK Alice -> Bob
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.chicago.example.com:5060;branch=z9hG4bKlkld5l
+    ;received=192.0.2.100
+   Max-Forwards: 70
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 14 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 150
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 65]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   m=audio 1000 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F11 ACK Bob -> Alice
+
+   ACK sip:alice@client.atlanta.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.chicago.example.com:5060;branch=z9hG4bKlkldcc
+   Max-Forwards: 70
+   From: Bob <sip:bob@biloxi.example.com>;tag=314159
+   To: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 14 ACK
+   Content-Length: 0
+
+   /* New RTP stream established between Alice and Bob */
+
+   /* Alice hangs up with Bob */
+
+
+   F12 BYE Alice -> Bob
+
+   BYE sip:bob@client.chicago.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bo4
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+   F13 200 OK Bob -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bo4
+    ;received=192.0.2.101
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 2 BYE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 66]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.8.  Unsuccessful No Answer
+
+   Alice           Proxy 1          Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|   INVITE F2    |                |
+     |     100  F3    |--------------->|   INVITE F4    |
+     |<---------------|     100  F5    |--------------->|
+     |                |<---------------|                |
+     |                |                |      180 F6    |
+     |                |     180 F7     |<---------------|
+     |     180 F8     |<---------------|                |
+     |<---------------|                |                |
+     |   CANCEL F9    |                |                |
+     |--------------->|                |                |
+     |     200 F10    |                |                |
+     |<---------------|   CANCEL F11   |                |
+     |                |--------------->|                |
+     |                |     200 F12    |                |
+     |                |<---------------|                |
+     |                |                |   CANCEL F13   |
+     |                |                |--------------->|
+     |                |                |     200 F14    |
+     |                |                |<---------------|
+     |                |                |     487 F15    |
+     |                |                |<---------------|
+     |                |                |     ACK F16    |
+     |                |     487 F17    |--------------->|
+     |                |<---------------|                |
+     |                |     ACK F18    |                |
+     |     487 F19    |--------------->|                |
+     |<---------------|                |                |
+     |     ACK F20    |                |                |
+     |--------------->|                |                |
+     |                |                |                |
+
+   In this scenario, Alice gives up on the call before Bob answers
+   (sends a 200 OK response).  Alice sends a CANCEL (F9) since no final
+   response had been received from Bob.  If a 200 OK to the INVITE had
+   crossed with the CANCEL, Alice would have sent an ACK then a BYE to
+   Bob in order to properly terminate the call.
+
+   Note that the CANCEL message is acknowledged with a 200 OK on a hop
+   by hop basis, rather than end to end.
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 67]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="ze7k1ee88df84f1cec431ae6cbe5a359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="b00b416324679d7e243f55708d44be7b"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /*Client for Alice prepares to receive data on port 49172 from the
+   network.*/
+
+
+   F2 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 68]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F3 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F4 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   Max-Forwards: 68
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 69]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+
+   F5 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F6 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F7 180 Ringing Proxy 2 -> Proxy 1
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 70]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F8 180 Ringing Proxy 1 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F9 CANCEL Alice -> Proxy 1
+
+   CANCEL sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Route: <sip:ss1.atlanta.example.com;lr>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+   F10 200 OK Proxy 1 -> Alice
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 71]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F11 CANCEL Proxy 1 -> Proxy 2
+
+   CANCEL sip:alice@atlanta.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+   F12 200 OK Proxy 2 -> Proxy 1
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+   F13 CANCEL Proxy 2 -> Bob
+
+   CANCEL sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+   F14 200 OK Bob -> Proxy 2
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 CANCEL
+   Content-Length: 0
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 72]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F15 487 Request Terminated Bob -> Proxy 2
+
+   SIP/2.0 487 Request Terminated
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F16 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F17 487 Request Terminated Proxy 2 -> Proxy 1
+
+   SIP/2.0 487 Request Terminated
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 73]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F18 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F19 487 Request Terminated Proxy 1 -> Alice
+
+   SIP/2.0 487 Request Terminated
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+
+
+   F20 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="ze7k1ee88df84f1cec431ae6cbe5a359", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="b00b416324679d7e243f55708d44be7b"
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 74]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.9.  Unsuccessful Busy
+
+   Alice           Proxy 1          Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|   INVITE F2    |                |
+     |     100  F3    |--------------->|   INVITE F4    |
+     |<---------------|     100  F5    |--------------->|
+     |                |<---------------|                |
+     |                |                |      486 F6    |
+     |                |                |<---------------|
+     |                |                |     ACK F7     |
+     |                |      486 F8    |--------------->|
+     |                |<---------------|                |
+     |                |      ACK F9    |                |
+     |     486 F10    |--------------->|                |
+     |<---------------|                |                |
+     |     ACK F11    |                |                |
+     |--------------->|                |                |
+     |                |                |                |
+
+
+   In this scenario, Bob is busy and sends a 486 Busy Here response to
+   Alice's INVITE.  Note that the non-2xx response is acknowledged on a
+   hop-by-hop basis instead of end-to-end.  Also note that many SIP UAs
+   will not return a 486 response, as they have multiple line and other
+   features.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="dc3a5ab2530aa93112cf5904ba7d88fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="702138b27d869ac8741e10ec643d55be"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 75]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /*Client for Alice prepares to receive data on port 49172 from the
+   network.*/
+
+
+   F2 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F3 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 76]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F4 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com;transport=tcp>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F5 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F6 486 Busy Here Bob -> Proxy 2
+
+   SIP/2.0  486 Busy Here
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 77]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F7 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F8 486 Busy Here Proxy 2 -> Proxy 1
+
+   SIP/2.0  486 Busy Here
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F9 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 78]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F10 486 Busy Here Proxy 1 -> Alice
+
+   SIP/2.0  486 Busy Here
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F11 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/TCP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="dc3a5ab2530aa93112cf5904ba7d88fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="702138b27d869ac8741e10ec643d55be"
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 79]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.10.  Unsuccessful No Response from User Agent
+
+   Alice           Proxy 1          Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|   INVITE F2    |                |
+     |     100  F3    |--------------->|   INVITE F4    |
+     |<---------------|     100  F5    |--------------->|
+     |                |<---------------|   INVITE F6    |
+     |                |                |--------------->|
+     |                |                |   INVITE F7    |
+     |                |                |--------------->|
+     |                |                |   INVITE F8    |
+     |                |                |--------------->|
+     |                |                |   INVITE F9    |
+     |                |                |--------------->|
+     |                |                |   INVITE F10   |
+     |                |                |--------------->|
+     |                |                |   INVITE F11   |
+     |                |     480 F12    |--------------->|
+     |                |<---------------|                |
+     |                |     ACK F13    |                |
+     |     480 F14    |--------------->|                |
+     |<---------------|                |                |
+     |     ACK F15    |                |                |
+     |--------------->|                |                |
+     |                |                |                |
+
+   In this example, there is no response from Bob to Alice's INVITE
+   messages being re-transmitted by Proxy 2.  After the sixth
+   re-transmission, Proxy 2 gives up and sends a 480 No Response to
+   Alice.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 80]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+    nonce="cf5904ba7d8dc3a5ab2530aa931128fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="7afc04be7961f053c24f80e7dbaf888f"
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /*Client for Alice prepares to receive data on port 49172 from the
+   network.*/
+
+
+   F2 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F3 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 81]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F4 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+   <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F5 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 82]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+
+   F6 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+
+   F7 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+
+   F8 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+
+   F9 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+
+   F10 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+
+   F11 INVITE Proxy 2 -> Bob
+
+   Resend of Message F4
+
+   /* Proxy 2 gives up */
+
+
+   F12 480 No Response Proxy 2 -> Proxy 1
+
+   SIP/2.0 480 No Response
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 83]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F13 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F14 480 No Response Proxy 1 -> Alice
+
+   SIP/2.0 480 No Response
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F15 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="cf5904ba7d8dc3a5ab2530aa931128fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="7afc04be7961f053c24f80e7dbaf888f"
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 84]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+3.11.  Unsuccessful Temporarily Unavailable
+
+   Alice          Proxy 1          Proxy 2            Bob
+     |                |                |                |
+     |   INVITE F1    |                |                |
+     |--------------->|   INVITE F2    |                |
+     |     100  F3    |--------------->|   INVITE F4    |
+     |<---------------|     100  F5    |--------------->|
+     |                |<---------------|      180 F6    |
+     |                |     180 F7     |<---------------|
+     |     180 F8     |<---------------|                |
+     |<---------------|                |     480 F9     |
+     |                |                |<---------------|
+     |                |                |     ACK F10    |
+     |                |     480 F11    |--------------->|
+     |                |<---------------|                |
+     |                |     ACK F12    |                |
+     |     480 F13    |--------------->|                |
+     |<---------------|                |                |
+     |     ACK F14    |                |                |
+     |--------------->|                |                |
+     |                |                |                |
+
+
+   In this scenario, Bob initially sends a 180 Ringing response to
+   Alice, indicating that alerting is taking place.  However, then a
+   480 Unavailable is then sent to Alice.  This response is
+   acknowledged then proxied back to Alice.
+
+   Message Details
+
+   F1 INVITE Alice -> Proxy 1
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="aa9311cf5904ba7d8dc3a5ab253028fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="59a46a91bf1646562a4d486c84b399db"
+   Content-Type: application/sdp
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 85]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+   /*Client for Alice prepares to receive data on port 49172 from the
+   network.*/
+
+
+   F2 INVITE Proxy 1 -> Proxy 2
+
+   INVITE sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 69
+   Record-Route: <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F3 100 Trying Proxy 1 -> Alice
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 86]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Content-Length: 0
+
+
+   F4 INVITE Proxy 2 -> Bob
+
+   INVITE sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Max-Forwards: 68
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:alice@client.atlanta.example.com>
+   Content-Type: application/sdp
+   Content-Length: 151
+
+   v=0
+   o=alice 2890844526 2890844526 IN IP4 client.atlanta.example.com
+   s=-
+   c=IN IP4 192.0.2.101
+   t=0 0
+   m=audio 49172 RTP/AVP 0
+   a=rtpmap:0 PCMU/8000
+
+
+   F5 100 Trying Proxy 2 -> Proxy 1
+
+   SIP/2.0 100 Trying
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 87]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F6 180 Ringing Bob -> Proxy 2
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F7 180 Ringing Proxy 2 -> Proxy 1
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+   Content-Length: 0
+
+
+   F8 180 Ringing Proxy 1 -> Alice
+
+   SIP/2.0 180 Ringing
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   Record-Route: <sip:ss2.biloxi.example.com;lr>,
+    <sip:ss1.atlanta.example.com;lr>
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Contact: <sip:bob@client.biloxi.example.com>
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 88]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   Content-Length: 0
+
+
+   F9 480 Temporarily Unavailable Bob -> Proxy 2
+
+   SIP/2.0 480 Temporarily Unavailable
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+    ;received=192.0.2.222
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F10 ACK Proxy 2 -> Bob
+
+   ACK sip:bob@client.biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss2.biloxi.example.com:5060;branch=z9hG4bK721e4.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F11 480 Temporarily Unavailable Proxy 2 -> Proxy 1
+
+   SIP/2.0 480 Temporarily Unavailable
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+    ;received=192.0.2.111
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 89]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   F12 ACK Proxy 1 -> Proxy 2
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP ss1.atlanta.example.com:5060;branch=z9hG4bK2d4790.1
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+   F13 480 Temporarily Unavailable Proxy 1 -> Alice
+
+   SIP/2.0 480 Temporarily Unavailable
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+    ;received=192.0.2.101
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   CSeq: 1 INVITE
+   Content-Length: 0
+
+
+   F14 ACK Alice -> Proxy 1
+
+   ACK sip:bob@biloxi.example.com SIP/2.0
+   Via: SIP/2.0/UDP client.atlanta.example.com:5060;branch=z9hG4bK74bf9
+   Max-Forwards: 70
+   From: Alice <sip:alice@atlanta.example.com>;tag=9fxced76sl
+   To: Bob <sip:bob@biloxi.example.com>;tag=314159
+   Call-ID: 2xTb9vxSit55XU7p8@atlanta.example.com
+   Proxy-Authorization: Digest username="alice",
+    realm="atlanta.example.com",
+    nonce="aa9311cf5904ba7d8dc3a5ab253028fa", opaque="",
+    uri="sip:bob@biloxi.example.com",
+    response="59a46a91bf1646562a4d486c84b399db"
+   CSeq: 1 ACK
+   Content-Length: 0
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 90]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+4.  Security Considerations
+
+   Since this document contains examples of SIP session establishment,
+   the security considerations in RFC 3261 [1] apply.  RFC 3261
+   describes the basic threats including registration hijacking, server
+   impersonation, message body tampering, session modifying or teardown,
+   and denial of service and amplification attacks.  The use of HTTP
+   Digest as shown in this document provides one-way authentication and
+   protection against replay attacks.  TLS transport is used in
+   registration scenarios due to the lack of integrity protection in
+   HTTP Digest and the danger of registration hijacking without it, as
+   described in RFC 3261 [1].  A full discussion of the weaknesses of
+   HTTP Digest is provided in RFC 3261 [1].  The use of TLS and the
+   Secure SIP (sips) URI scheme provides a better level of security
+   including two-way authentication.  S/MIME can provide end-to-end
+   confidentiality and integrity protection of message bodies, as
+   described in RFC 3261.
+
+5.  References
+
+5.1.  Normative References
+
+   [1] Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston, A.,
+       Peterson, J., Sparks, R., Handley, M. and E. Schooler, "SIP:
+       Session Initiation Protocol", RFC 3261, June 2002.
+
+   [2] Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model with
+       SDP", RFC 3264, April 2002.
+
+   [3] Franks, J., Hallam-Baker, P., Hostetler, J., Lawrence, S., Leach,
+       P., Luotonen, A. and L. Stewart, "HTTP authentication: Basic and
+       Digest Access Authentication", RFC 2617, June 1999.
+
+   [4] Bradner, S., "Key words for use in RFCs to Indicate Requirement
+       Levels", BCP 14, RFC 2119, March 1997.
+
+5.2.  Informative References
+
+   [5] Johnston, A., Donovan, S., Sparks, R., Cunningham, C. and K.
+       Summers, "Session Initiation Protocol (SIP) Public Switched
+       Telephone Network (PSTN) Call Flows", BCP 76, RFC 3666, December
+       2003.
+
+6.  Intellectual Property Statement
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 91]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+7.  Acknowledgments
+
+   This document is has been a group effort by the SIP and SIPPING WGs.
+   The authors wish to thank everyone who has read, reviewed, commented,
+   or made suggestions to improve this document.
+
+   Thanks to Rohan Mahy, Adam Roach, Gonzalo Camarillo, Cullen Jennings,
+   and Tom Taylor for their detailed comments during the final review.
+   Thanks to Dean Willis for his early contributions to the development
+   of this document.
+
+   The authors wish to thank Kundan Singh for performing parser
+   validation of messages.
+
+   The authors wish to thank the following individuals for their
+   participation in the review of this call flows document: Aseem
+   Agarwal, Rafi Assadi, Ben Campbell, Sunitha Kumar, Jon Peterson, Marc
+   Petit-Huguenin, Vidhi Rastogi, and Bodgey Yin Shaohua.
+
+   The authors also wish to thank the following individuals for their
+   assistance: Jean-Francois Mule, Hemant Agrawal, Henry Sinnreich,
+   David Devanatham, Joe Pizzimenti, Matt Cannon, John Hearty, the whole
+   MCI WorldCom IPOP Design team, Scott Orton, Greg Osterhout, Pat
+   Sollee, Doug Weisenberg, Danny Mistry, Steve McKinnon, and Denise
+   Ingram, Denise Caballero, Tom Redman, Ilya Slain, Pat Sollee, John
+   Truetken, and others from MCI WorldCom, 3Com, Cisco, Lucent and
+   Nortel.
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 92]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+8.  Authors' Addresses
+
+   All listed authors actively contributed large amounts of text to this
+   document.
+
+   Alan Johnston
+   MCI
+   100 South 4th Street
+   St. Louis, MO 63102
+   USA
+
+   EMail: alan.johnston@mci.com
+
+   Steve Donovan
+   dynamicsoft, Inc.
+   5100 Tennyson Parkway
+   Suite 1200
+   Plano, Texas 75024
+   USA
+
+   EMail: sdonovan@dynamicsoft.com
+
+   Robert Sparks
+   dynamicsoft, Inc.
+   5100 Tennyson Parkway
+   Suite 1200
+   Plano, Texas 75024
+   USA
+
+   EMail: rsparks@dynamicsoft.com
+
+   Chris Cunningham
+   dynamicsoft, Inc.
+   5100 Tennyson Parkway
+   Suite 1200
+   Plano, Texas 75024
+   USA
+
+   EMail: ccunningham@dynamicsoft.com
+
+   Kevin Summers
+   Sonus
+   1701 North Collins Blvd, Suite 3000
+   Richardson, TX 75080
+   USA
+
+   EMail: kevin.summers@sonusnet.com
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 93]
+
+RFC 3665              SIP Basic Call Flow Examples         December 2003
+
+
+9.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assignees.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Johnston, et al.         Best Current Practice                 [Page 94]
+

--- a/rfcs/rfc4566.txt
+++ b/rfcs/rfc4566.txt
@@ -1,0 +1,2747 @@
+
+
+
+
+
+
+Network Working Group                                         M. Handley
+Request for Comments: 4566                                           UCL
+Obsoletes: 2327, 3266                                        V. Jacobson
+Category: Standards Track                                  Packet Design
+                                                              C. Perkins
+                                                   University of Glasgow
+                                                               July 2006
+
+
+                   SDP: Session Description Protocol
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This memo defines the Session Description Protocol (SDP).  SDP is
+   intended for describing multimedia sessions for the purposes of
+   session announcement, session invitation, and other forms of
+   multimedia session initiation.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. Glossary of Terms ...............................................3
+   3. Examples of SDP Usage ...........................................4
+      3.1. Session Initiation .........................................4
+      3.2. Streaming Media ............................................4
+      3.3. Email and the World Wide Web ...............................4
+      3.4. Multicast Session Announcement .............................4
+   4. Requirements and Recommendations ................................5
+      4.1. Media and Transport Information ............................6
+      4.2. Timing Information .........................................6
+      4.3. Private Sessions ...........................................7
+      4.4. Obtaining Further Information about a Session ..............7
+      4.5. Categorisation .............................................7
+      4.6. Internationalisation .......................................7
+
+
+
+
+
+Handley, et al.             Standards Track                     [Page 1]
+
+RFC 4566                          SDP                          July 2006
+
+
+   5. SDP Specification ...............................................7
+      5.1. Protocol Version ("v=") ...................................10
+      5.2. Origin ("o=") .............................................11
+      5.3. Session Name ("s=") .......................................12
+      5.4. Session Information ("i=") ................................12
+      5.5. URI ("u=") ................................................13
+      5.6. Email Address and Phone Number ("e=" and "p=") ............13
+      5.7. Connection Data ("c=") ....................................14
+      5.8. Bandwidth ("b=") ..........................................16
+      5.9. Timing ("t=") .............................................17
+      5.10. Repeat Times ("r=") ......................................18
+      5.11. Time Zones ("z=") ........................................19
+      5.12. Encryption Keys ("k=") ...................................19
+      5.13. Attributes ("a=") ........................................21
+      5.14. Media Descriptions ("m=") ................................22
+   6. SDP Attributes .................................................24
+   7. Security Considerations ........................................31
+   8. IANA Considerations ............................................33
+      8.1. The "application/sdp" Media Type ..........................33
+      8.2. Registration of Parameters ................................34
+           8.2.1. Media Types ("media") ..............................34
+           8.2.2. Transport Protocols ("proto") ......................34
+           8.2.3. Media Formats ("fmt") ..............................35
+           8.2.4. Attribute Names ("att-field") ......................36
+           8.2.5. Bandwidth Specifiers ("bwtype") ....................37
+           8.2.6. Network Types ("nettype") ..........................37
+           8.2.7. Address Types ("addrtype") .........................38
+           8.2.8. Registration Procedure .............................38
+      8.3. Encryption Key Access Methods .............................39
+   9. SDP Grammar ....................................................39
+   10. Summary of Changes from RFC 2327 ..............................44
+   11. Acknowledgements ..............................................45
+   12. References ....................................................45
+      12.1. Normative References .....................................45
+      12.2. Informative References ...................................46
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                     [Page 2]
+
+RFC 4566                          SDP                          July 2006
+
+
+1.  Introduction
+
+   When initiating multimedia teleconferences, voice-over-IP calls,
+   streaming video, or other sessions, there is a requirement to convey
+   media details, transport addresses, and other session description
+   metadata to the participants.
+
+   SDP provides a standard representation for such information,
+   irrespective of how that information is transported.  SDP is purely a
+   format for session description -- it does not incorporate a transport
+   protocol, and it is intended to use different transport protocols as
+   appropriate, including the Session Announcement Protocol [14],
+   Session Initiation Protocol [15], Real Time Streaming Protocol [16],
+   electronic mail using the MIME extensions, and the Hypertext
+   Transport Protocol.
+
+   SDP is intended to be general purpose so that it can be used in a
+   wide range of network environments and applications.  However, it is
+   not intended to support negotiation of session content or media
+   encodings: this is viewed as outside the scope of session
+   description.
+
+   This memo obsoletes RFC 2327 [6] and RFC 3266 [10].  Section 10
+   outlines the changes introduced in this memo.
+
+2.  Glossary of Terms
+
+   The following terms are used in this document and have specific
+   meaning within the context of this document.
+
+   Conference: A multimedia conference is a set of two or more
+      communicating users along with the software they are using to
+      communicate.
+
+   Session: A multimedia session is a set of multimedia senders and
+      receivers and the data streams flowing from senders to receivers.
+      A multimedia conference is an example of a multimedia session.
+
+   Session Description: A well-defined format for conveying sufficient
+      information to discover and participate in a multimedia session.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [3].
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                     [Page 3]
+
+RFC 4566                          SDP                          July 2006
+
+
+3.  Examples of SDP Usage
+
+3.1.  Session Initiation
+
+   The Session Initiation Protocol (SIP) [15] is an application-layer
+   control protocol for creating, modifying, and terminating sessions
+   such as Internet multimedia conferences, Internet telephone calls,
+   and multimedia distribution.  The SIP messages used to create
+   sessions carry session descriptions that allow participants to agree
+   on a set of compatible media types.  These session descriptions are
+   commonly formatted using SDP.  When used with SIP, the offer/answer
+   model [17] provides a limited framework for negotiation using SDP.
+
+3.2.  Streaming Media
+
+   The Real Time Streaming Protocol (RTSP) [16], is an application-level
+   protocol for control over the delivery of data with real-time
+   properties.  RTSP provides an extensible framework to enable
+   controlled, on-demand delivery of real-time data, such as audio and
+   video.  An RTSP client and server negotiate an appropriate set of
+   parameters for media delivery, partially using SDP syntax to describe
+   those parameters.
+
+3.3.  Email and the World Wide Web
+
+   Alternative means of conveying session descriptions include
+   electronic mail and the World Wide Web (WWW).  For both email and WWW
+   distribution, the media type "application/sdp" is used.  This enables
+   the automatic launching of applications for participation in the
+   session from the WWW client or mail reader in a standard manner.
+
+   Note that announcements of multicast sessions made only via email or
+   the WWW do not have the property that the receiver of a session
+   announcement can necessarily receive the session because the
+   multicast sessions may be restricted in scope, and access to the WWW
+   server or reception of email is possible outside this scope.
+
+3.4.  Multicast Session Announcement
+
+   In order to assist the advertisement of multicast multimedia
+   conferences and other multicast sessions, and to communicate the
+   relevant session setup information to prospective participants, a
+   distributed session directory may be used.  An instance of such a
+   session directory periodically sends packets containing a description
+   of the session to a well-known multicast group.  These advertisements
+   are received by other session directories such that potential remote
+   participants can use the session description to start the tools
+   required to participate in the session.
+
+
+
+Handley, et al.             Standards Track                     [Page 4]
+
+RFC 4566                          SDP                          July 2006
+
+
+   One protocol used to implement such a distributed directory is the
+   Session Announcement Protocol (SAP) [14].  SDP provides the
+   recommended session description format for such session
+   announcements.
+
+4.  Requirements and Recommendations
+
+   The purpose of SDP is to convey information about media streams in
+   multimedia sessions to allow the recipients of a session description
+   to participate in the session.  SDP is primarily intended for use in
+   an internetwork, although it is sufficiently general that it can
+   describe conferences in other network environments.  Media streams
+   can be many-to-many.  Sessions need not be continually active.
+
+   Thus far, multicast-based sessions on the Internet have differed from
+   many other forms of conferencing in that anyone receiving the traffic
+   can join the session (unless the session traffic is encrypted).  In
+   such an environment, SDP serves two primary purposes.  It is a means
+   to communicate the existence of a session, and it is a means to
+   convey sufficient information to enable joining and participating in
+   the session.  In a unicast environment, only the latter purpose is
+   likely to be relevant.
+
+   An SDP session description includes the following:
+
+   o  Session name and purpose
+
+   o  Time(s) the session is active
+
+   o  The media comprising the session
+
+   o  Information needed to receive those media (addresses, ports,
+      formats, etc.)
+
+   As resources necessary to participate in a session may be limited,
+   some additional information may also be desirable:
+
+   o  Information about the bandwidth to be used by the session
+
+   o  Contact information for the person responsible for the session
+
+   In general, SDP must convey sufficient information to enable
+   applications to join a session (with the possible exception of
+   encryption keys) and to announce the resources to be used to any
+   non-participants that may need to know.  (This latter feature is
+   primarily useful when SDP is used with a multicast session
+   announcement protocol.)
+
+
+
+
+Handley, et al.             Standards Track                     [Page 5]
+
+RFC 4566                          SDP                          July 2006
+
+
+4.1.  Media and Transport Information
+
+   An SDP session description includes the following media information:
+
+   o  The type of media (video, audio, etc.)
+
+   o  The transport protocol (RTP/UDP/IP, H.320, etc.)
+
+   o  The format of the media (H.261 video, MPEG video, etc.)
+
+   In addition to media format and transport protocol, SDP conveys
+   address and port details.  For an IP multicast session, these
+   comprise:
+
+   o  The multicast group address for media
+
+   o  The transport port for media
+
+   This address and port are the destination address and destination
+   port of the multicast stream, whether being sent, received, or both.
+
+   For unicast IP sessions, the following are conveyed:
+
+   o  The remote address for media
+
+   o  The remote transport port for media
+
+   The semantics of this address and port depend on the media and
+   transport protocol defined.  By default, this SHOULD be the remote
+   address and remote port to which data is sent.  Some media types may
+   redefine this behaviour, but this is NOT RECOMMENDED since it
+   complicates implementations (including middleboxes that must parse
+   the addresses to open Network Address Translation (NAT) or firewall
+   pinholes).
+
+4.2.  Timing Information
+
+   Sessions may be either bounded or unbounded in time.  Whether or not
+   they are bounded, they may be only active at specific times.  SDP can
+   convey:
+
+   o  An arbitrary list of start and stop times bounding the session
+
+   o  For each bound, repeat times such as "every Wednesday at 10am for
+      one hour"
+
+   This timing information is globally consistent, irrespective of local
+   time zone or daylight saving time (see Section 5.9).
+
+
+
+Handley, et al.             Standards Track                     [Page 6]
+
+RFC 4566                          SDP                          July 2006
+
+
+4.3.  Private Sessions
+
+   It is possible to create both public sessions and private sessions.
+   SDP itself does not distinguish between these; private sessions are
+   typically conveyed by encrypting the session description during
+   distribution.  The details of how encryption is performed are
+   dependent on the mechanism used to convey SDP; mechanisms are
+   currently defined for SDP transported using SAP [14] and SIP [15],
+   and others may be defined in the future.
+
+   If a session announcement is private, it is possible to use that
+   private announcement to convey encryption keys necessary to decode
+   each of the media in a conference, including enough information to
+   know which encryption scheme is used for each media.
+
+4.4.  Obtaining Further Information about a Session
+
+   A session description should convey enough information to decide
+   whether or not to participate in a session.  SDP may include
+   additional pointers in the form of Uniform Resource Identifiers
+   (URIs) for more information about the session.
+
+4.5.  Categorisation
+
+   When many session descriptions are being distributed by SAP, or any
+   other advertisement mechanism, it may be desirable to filter session
+   announcements that are of interest from those that are not.  SDP
+   supports a categorisation mechanism for sessions that is capable of
+   being automated (the "a=cat:" attribute; see Section 6).
+
+4.6.  Internationalisation
+
+   The SDP specification recommends the use of the ISO 10646 character
+   sets in the UTF-8 encoding [5] to allow many different languages to
+   be represented.  However, to assist in compact representations, SDP
+   also allows other character sets such as ISO 8859-1 to be used when
+   desired.  Internationalisation only applies to free-text fields
+   (session name and background information), and not to SDP as a whole.
+
+5.  SDP Specification
+
+   An SDP session description is denoted by the media type
+   "application/sdp" (See Section 8).
+
+   An SDP session description is entirely textual using the ISO 10646
+   character set in UTF-8 encoding.  SDP field names and attribute names
+   use only the US-ASCII subset of UTF-8, but textual fields and
+   attribute values MAY use the full ISO 10646 character set.  Field and
+
+
+
+Handley, et al.             Standards Track                     [Page 7]
+
+RFC 4566                          SDP                          July 2006
+
+
+   attribute values that use the full UTF-8 character set are never
+   directly compared, hence there is no requirement for UTF-8
+   normalisation.  The textual form, as opposed to a binary encoding
+   such as ASN.1 or XDR, was chosen to enhance portability, to enable a
+   variety of transports to be used, and to allow flexible, text-based
+   toolkits to be used to generate and process session descriptions.
+   However, since SDP may be used in environments where the maximum
+   permissible size of a session description is limited, the encoding is
+   deliberately compact.  Also, since announcements may be transported
+   via very unreliable means or damaged by an intermediate caching
+   server, the encoding was designed with strict order and formatting
+   rules so that most errors would result in malformed session
+   announcements that could be detected easily and discarded.  This also
+   allows rapid discarding of encrypted session announcements for which
+   a receiver does not have the correct key.
+
+   An SDP session description consists of a number of lines of text of
+   the form:
+
+      <type>=<value>
+
+   where <type> MUST be exactly one case-significant character and
+   <value> is structured text whose format depends on <type>.  In
+   general, <value> is either a number of fields delimited by a single
+   space character or a free format string, and is case-significant
+   unless a specific field defines otherwise.  Whitespace MUST NOT be
+   used on either side of the "=" sign.
+
+   An SDP session description consists of a session-level section
+   followed by zero or more media-level sections.  The session-level
+   part starts with a "v=" line and continues to the first media-level
+   section.  Each media-level section starts with an "m=" line and
+   continues to the next media-level section or end of the whole session
+   description.  In general, session-level values are the default for
+   all media unless overridden by an equivalent media-level value.
+
+   Some lines in each description are REQUIRED and some are OPTIONAL,
+   but all MUST appear in exactly the order given here (the fixed order
+   greatly enhances error detection and allows for a simple parser).
+   OPTIONAL items are marked with a "*".
+
+
+
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                     [Page 8]
+
+RFC 4566                          SDP                          July 2006
+
+
+      Session description
+         v=  (protocol version)
+         o=  (originator and session identifier)
+         s=  (session name)
+         i=* (session information)
+         u=* (URI of description)
+         e=* (email address)
+         p=* (phone number)
+         c=* (connection information -- not required if included in
+              all media)
+         b=* (zero or more bandwidth information lines)
+         One or more time descriptions ("t=" and "r=" lines; see below)
+         z=* (time zone adjustments)
+         k=* (encryption key)
+         a=* (zero or more session attribute lines)
+         Zero or more media descriptions
+
+      Time description
+         t=  (time the session is active)
+         r=* (zero or more repeat times)
+
+      Media description, if present
+         m=  (media name and transport address)
+         i=* (media title)
+         c=* (connection information -- optional if included at
+              session level)
+         b=* (zero or more bandwidth information lines)
+         k=* (encryption key)
+         a=* (zero or more media attribute lines)
+
+   The set of type letters is deliberately small and not intended to be
+   extensible -- an SDP parser MUST completely ignore any session
+   description that contains a type letter that it does not understand.
+   The attribute mechanism ("a=" described below) is the primary means
+   for extending SDP and tailoring it to particular applications or
+   media.  Some attributes (the ones listed in Section 6 of this memo)
+   have a defined meaning, but others may be added on an application-,
+   media-, or session-specific basis.  An SDP parser MUST ignore any
+   attribute it doesn't understand.
+
+   An SDP session description may contain URIs that reference external
+   content in the "u=", "k=", and "a=" lines.  These URIs may be
+   dereferenced in some cases, making the session description non-self-
+   contained.
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                     [Page 9]
+
+RFC 4566                          SDP                          July 2006
+
+
+   The connection ("c=") and attribute ("a=") information in the
+   session-level section applies to all the media of that session unless
+   overridden by connection information or an attribute of the same name
+   in the media description.  For instance, in the example below, each
+   media behaves as if it were given a "recvonly" attribute.
+
+   An example SDP description is:
+
+      v=0
+      o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5
+      s=SDP Seminar
+      i=A Seminar on the session description protocol
+      u=http://www.example.com/seminars/sdp.pdf
+      e=j.doe@example.com (Jane Doe)
+      c=IN IP4 224.2.17.12/127
+      t=2873397496 2873404696
+      a=recvonly
+      m=audio 49170 RTP/AVP 0
+      m=video 51372 RTP/AVP 99
+      a=rtpmap:99 h263-1998/90000
+
+   Text fields such as the session name and information are octet
+   strings that may contain any octet with the exceptions of 0x00 (Nul),
+   0x0a (ASCII newline), and 0x0d (ASCII carriage return).  The sequence
+   CRLF (0x0d0a) is used to end a record, although parsers SHOULD be
+   tolerant and also accept records terminated with a single newline
+   character.  If the "a=charset" attribute is not present, these octet
+   strings MUST be interpreted as containing ISO-10646 characters in
+   UTF-8 encoding (the presence of the "a=charset" attribute may force
+   some fields to be interpreted differently).
+
+   A session description can contain domain names in the "o=", "u=",
+   "e=", "c=", and "a=" lines.  Any domain name used in SDP MUST comply
+   with [1], [2].  Internationalised domain names (IDNs) MUST be
+   represented using the ASCII Compatible Encoding (ACE) form defined in
+   [11] and MUST NOT be directly represented in UTF-8 or any other
+   encoding (this requirement is for compatibility with RFC 2327 and
+   other SDP-related standards, which predate the development of
+   internationalised domain names).
+
+5.1.  Protocol Version ("v=")
+
+      v=0
+
+   The "v=" field gives the version of the Session Description Protocol.
+   This memo defines version 0.  There is no minor version number.
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 10]
+
+RFC 4566                          SDP                          July 2006
+
+
+5.2.  Origin ("o=")
+
+      o=<username> <sess-id> <sess-version> <nettype> <addrtype>
+        <unicast-address>
+
+   The "o=" field gives the originator of the session (her username and
+   the address of the user's host) plus a session identifier and version
+   number:
+
+   <username> is the user's login on the originating host, or it is "-"
+      if the originating host does not support the concept of user IDs.
+      The <username> MUST NOT contain spaces.
+
+   <sess-id> is a numeric string such that the tuple of <username>,
+      <sess-id>, <nettype>, <addrtype>, and <unicast-address> forms a
+      globally unique identifier for the session.  The method of
+      <sess-id> allocation is up to the creating tool, but it has been
+      suggested that a Network Time Protocol (NTP) format timestamp be
+      used to ensure uniqueness [13].
+
+   <sess-version> is a version number for this session description.  Its
+      usage is up to the creating tool, so long as <sess-version> is
+      increased when a modification is made to the session data.  Again,
+      it is RECOMMENDED that an NTP format timestamp is used.
+
+   <nettype> is a text string giving the type of network.  Initially
+      "IN" is defined to have the meaning "Internet", but other values
+      MAY be registered in the future (see Section 8).
+
+   <addrtype> is a text string giving the type of the address that
+      follows.  Initially "IP4" and "IP6" are defined, but other values
+      MAY be registered in the future (see Section 8).
+
+   <unicast-address> is the address of the machine from which the
+      session was created.  For an address type of IP4, this is either
+      the fully qualified domain name of the machine or the dotted-
+      decimal representation of the IP version 4 address of the machine.
+      For an address type of IP6, this is either the fully qualified
+      domain name of the machine or the compressed textual
+      representation of the IP version 6 address of the machine.  For
+      both IP4 and IP6, the fully qualified domain name is the form that
+      SHOULD be given unless this is unavailable, in which case the
+      globally unique address MAY be substituted.  A local IP address
+      MUST NOT be used in any context where the SDP description might
+      leave the scope in which the address is meaningful (for example, a
+      local address MUST NOT be included in an application-level
+      referral that might leave the scope).
+
+
+
+
+Handley, et al.             Standards Track                    [Page 11]
+
+RFC 4566                          SDP                          July 2006
+
+
+   In general, the "o=" field serves as a globally unique identifier for
+   this version of this session description, and the subfields excepting
+   the version taken together identify the session irrespective of any
+   modifications.
+
+   For privacy reasons, it is sometimes desirable to obfuscate the
+   username and IP address of the session originator.  If this is a
+   concern, an arbitrary <username> and private <unicast-address> MAY be
+   chosen to populate the "o=" field, provided that these are selected
+   in a manner that does not affect the global uniqueness of the field.
+
+5.3.  Session Name ("s=")
+
+      s=<session name>
+
+   The "s=" field is the textual session name.  There MUST be one and
+   only one "s=" field per session description.  The "s=" field MUST NOT
+   be empty and SHOULD contain ISO 10646 characters (but see also the
+   "a=charset" attribute).  If a session has no meaningful name, the
+   value "s= " SHOULD be used (i.e., a single space as the session
+   name).
+
+5.4.  Session Information ("i=")
+
+      i=<session description>
+
+   The "i=" field provides textual information about the session.  There
+   MUST be at most one session-level "i=" field per session description,
+   and at most one "i=" field per media.  If the "a=charset" attribute
+   is present, it specifies the character set used in the "i=" field.
+   If the "a=charset" attribute is not present, the "i=" field MUST
+   contain ISO 10646 characters in UTF-8 encoding.
+
+   A single "i=" field MAY also be used for each media definition.  In
+   media definitions, "i=" fields are primarily intended for labelling
+   media streams.  As such, they are most likely to be useful when a
+   single session has more than one distinct media stream of the same
+   media type.  An example would be two different whiteboards, one for
+   slides and one for feedback and questions.
+
+   The "i=" field is intended to provide a free-form human-readable
+   description of the session or the purpose of a media stream.  It is
+   not suitable for parsing by automata.
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 12]
+
+RFC 4566                          SDP                          July 2006
+
+
+5.5.  URI ("u=")
+
+      u=<uri>
+
+   A URI is a Uniform Resource Identifier as used by WWW clients [7].
+   The URI should be a pointer to additional information about the
+   session.  This field is OPTIONAL, but if it is present it MUST be
+   specified before the first media field.  No more than one URI field
+   is allowed per session description.
+
+5.6.  Email Address and Phone Number ("e=" and "p=")
+
+      e=<email-address>
+      p=<phone-number>
+
+   The "e=" and "p=" lines specify contact information for the person
+   responsible for the conference.  This is not necessarily the same
+   person that created the conference announcement.
+
+   Inclusion of an email address or phone number is OPTIONAL.  Note that
+   the previous version of SDP specified that either an email field or a
+   phone field MUST be specified, but this was widely ignored.  The
+   change brings the specification into line with common usage.
+
+   If an email address or phone number is present, it MUST be specified
+   before the first media field.  More than one email or phone field can
+   be given for a session description.
+
+   Phone numbers SHOULD be given in the form of an international public
+   telecommunication number (see ITU-T Recommendation E.164) preceded by
+   a "+".  Spaces and hyphens may be used to split up a phone field to
+   aid readability if desired.  For example:
+
+      p=+1 617 555-6011
+
+   Both email addresses and phone numbers can have an OPTIONAL free text
+   string associated with them, normally giving the name of the person
+   who may be contacted.  This MUST be enclosed in parentheses if it is
+   present.  For example:
+
+      e=j.doe@example.com (Jane Doe)
+
+   The alternative RFC 2822 [29] name quoting convention is also allowed
+   for both email addresses and phone numbers.  For example:
+
+      e=Jane Doe <j.doe@example.com>
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 13]
+
+RFC 4566                          SDP                          July 2006
+
+
+   The free text string SHOULD be in the ISO-10646 character set with
+   UTF-8 encoding, or alternatively in ISO-8859-1 or other encodings if
+   the appropriate session-level "a=charset" attribute is set.
+
+5.7.  Connection Data ("c=")
+
+      c=<nettype> <addrtype> <connection-address>
+
+   The "c=" field contains connection data.
+
+   A session description MUST contain either at least one "c=" field in
+   each media description or a single "c=" field at the session level.
+   It MAY contain a single session-level "c=" field and additional "c="
+   field(s) per media description, in which case the per-media values
+   override the session-level settings for the respective media.
+
+   The first sub-field ("<nettype>") is the network type, which is a
+   text string giving the type of network.  Initially, "IN" is defined
+   to have the meaning "Internet", but other values MAY be registered in
+   the future (see Section 8).
+
+   The second sub-field ("<addrtype>") is the address type.  This allows
+   SDP to be used for sessions that are not IP based.  This memo only
+   defines IP4 and IP6, but other values MAY be registered in the future
+   (see Section 8).
+
+   The third sub-field ("<connection-address>") is the connection
+   address.  OPTIONAL sub-fields MAY be added after the connection
+   address depending on the value of the <addrtype> field.
+
+   When the <addrtype> is IP4 and IP6, the connection address is defined
+   as follows:
+
+   o  If the session is multicast, the connection address will be an IP
+      multicast group address.  If the session is not multicast, then
+      the connection address contains the unicast IP address of the
+      expected data source or data relay or data sink as determined by
+      additional attribute fields.  It is not expected that unicast
+      addresses will be given in a session description that is
+      communicated by a multicast announcement, though this is not
+      prohibited.
+
+   o  Sessions using an IPv4 multicast connection address MUST also have
+      a time to live (TTL) value present in addition to the multicast
+      address.  The TTL and the address together define the scope with
+      which multicast packets sent in this conference will be sent.  TTL
+      values MUST be in the range 0-255.  Although the TTL MUST be
+      specified, its use to scope multicast traffic is deprecated;
+
+
+
+Handley, et al.             Standards Track                    [Page 14]
+
+RFC 4566                          SDP                          July 2006
+
+
+      applications SHOULD use an administratively scoped address
+      instead.
+
+   The TTL for the session is appended to the address using a slash as a
+   separator.  An example is:
+
+      c=IN IP4 224.2.36.42/127
+
+   IPv6 multicast does not use TTL scoping, and hence the TTL value MUST
+   NOT be present for IPv6 multicast.  It is expected that IPv6 scoped
+   addresses will be used to limit the scope of conferences.
+
+   Hierarchical or layered encoding schemes are data streams where the
+   encoding from a single media source is split into a number of layers.
+   The receiver can choose the desired quality (and hence bandwidth) by
+   only subscribing to a subset of these layers.  Such layered encodings
+   are normally transmitted in multiple multicast groups to allow
+   multicast pruning.  This technique keeps unwanted traffic from sites
+   only requiring certain levels of the hierarchy.  For applications
+   requiring multiple multicast groups, we allow the following notation
+   to be used for the connection address:
+
+      <base multicast address>[/<ttl>]/<number of addresses>
+
+   If the number of addresses is not given, it is assumed to be one.
+   Multicast addresses so assigned are contiguously allocated above the
+   base address, so that, for example:
+
+      c=IN IP4 224.2.1.1/127/3
+
+   would state that addresses 224.2.1.1, 224.2.1.2, and 224.2.1.3 are to
+   be used at a TTL of 127.  This is semantically identical to including
+   multiple "c=" lines in a media description:
+
+      c=IN IP4 224.2.1.1/127
+      c=IN IP4 224.2.1.2/127
+      c=IN IP4 224.2.1.3/127
+
+   Similarly, an IPv6 example would be:
+
+      c=IN IP6 FF15::101/3
+
+   which is semantically equivalent to:
+
+      c=IN IP6 FF15::101
+      c=IN IP6 FF15::102
+      c=IN IP6 FF15::103
+
+
+
+
+Handley, et al.             Standards Track                    [Page 15]
+
+RFC 4566                          SDP                          July 2006
+
+
+   (remembering that the TTL field is not present in IPv6 multicast).
+
+   Multiple addresses or "c=" lines MAY be specified on a per-media
+   basis only if they provide multicast addresses for different layers
+   in a hierarchical or layered encoding scheme.  They MUST NOT be
+   specified for a session-level "c=" field.
+
+   The slash notation for multiple addresses described above MUST NOT be
+   used for IP unicast addresses.
+
+5.8.  Bandwidth ("b=")
+
+      b=<bwtype>:<bandwidth>
+
+   This OPTIONAL field denotes the proposed bandwidth to be used by the
+   session or media.  The <bwtype> is an alphanumeric modifier giving
+   the meaning of the <bandwidth> figure.  Two values are defined in
+   this specification, but other values MAY be registered in the future
+   (see Section 8 and [21], [25]):
+
+   CT If the bandwidth of a session or media in a session is different
+      from the bandwidth implicit from the scope, a "b=CT:..." line
+      SHOULD be supplied for the session giving the proposed upper limit
+      to the bandwidth used (the "conference total" bandwidth).  The
+      primary purpose of this is to give an approximate idea as to
+      whether two or more sessions can coexist simultaneously.  When
+      using the CT modifier with RTP, if several RTP sessions are part
+      of the conference, the conference total refers to total bandwidth
+      of all RTP sessions.
+
+   AS The bandwidth is interpreted to be application specific (it will
+      be the application's concept of maximum bandwidth).  Normally,
+      this will coincide with what is set on the application's "maximum
+      bandwidth" control if applicable.  For RTP-based applications, AS
+      gives the RTP "session bandwidth" as defined in Section 6.2 of
+      [19].
+
+   Note that CT gives a total bandwidth figure for all the media at all
+   sites.  AS gives a bandwidth figure for a single media at a single
+   site, although there may be many sites sending simultaneously.
+
+   A prefix "X-" is defined for <bwtype> names.  This is intended for
+   experimental purposes only.  For example:
+
+      b=X-YZ:128
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 16]
+
+RFC 4566                          SDP                          July 2006
+
+
+   Use of the "X-" prefix is NOT RECOMMENDED: instead new modifiers
+   SHOULD be registered with IANA in the standard namespace.  SDP
+   parsers MUST ignore bandwidth fields with unknown modifiers.
+   Modifiers MUST be alphanumeric and, although no length limit is
+   given, it is recommended that they be short.
+
+   The <bandwidth> is interpreted as kilobits per second by default.
+   The definition of a new <bwtype> modifier MAY specify that the
+   bandwidth is to be interpreted in some alternative unit (the "CT" and
+   "AS" modifiers defined in this memo use the default units).
+
+5.9.  Timing ("t=")
+
+      t=<start-time> <stop-time>
+
+   The "t=" lines specify the start and stop times for a session.
+   Multiple "t=" lines MAY be used if a session is active at multiple
+   irregularly spaced times; each additional "t=" line specifies an
+   additional period of time for which the session will be active.  If
+   the session is active at regular times, an "r=" line (see below)
+   should be used in addition to, and following, a "t=" line -- in which
+   case the "t=" line specifies the start and stop times of the repeat
+   sequence.
+
+   The first and second sub-fields give the start and stop times,
+   respectively, for the session.  These values are the decimal
+   representation of Network Time Protocol (NTP) time values in seconds
+   since 1900 [13].  To convert these values to UNIX time, subtract
+   decimal 2208988800.
+
+   NTP timestamps are elsewhere represented by 64-bit values, which wrap
+   sometime in the year 2036.  Since SDP uses an arbitrary length
+   decimal representation, this should not cause an issue (SDP
+   timestamps MUST continue counting seconds since 1900, NTP will use
+   the value modulo the 64-bit limit).
+
+   If the <stop-time> is set to zero, then the session is not bounded,
+   though it will not become active until after the <start-time>.  If
+   the <start-time> is also zero, the session is regarded as permanent.
+
+   User interfaces SHOULD strongly discourage the creation of unbounded
+   and permanent sessions as they give no information about when the
+   session is actually going to terminate, and so make scheduling
+   difficult.
+
+   The general assumption may be made, when displaying unbounded
+   sessions that have not timed out to the user, that an unbounded
+   session will only be active until half an hour from the current time
+
+
+
+Handley, et al.             Standards Track                    [Page 17]
+
+RFC 4566                          SDP                          July 2006
+
+
+   or the session start time, whichever is the later.  If behaviour
+   other than this is required, an end-time SHOULD be given and modified
+   as appropriate when new information becomes available about when the
+   session should really end.
+
+   Permanent sessions may be shown to the user as never being active
+   unless there are associated repeat times that state precisely when
+   the session will be active.
+
+5.10.  Repeat Times ("r=")
+
+      r=<repeat interval> <active duration> <offsets from start-time>
+
+   "r=" fields specify repeat times for a session.  For example, if a
+   session is active at 10am on Monday and 11am on Tuesday for one hour
+   each week for three months, then the <start-time> in the
+   corresponding "t=" field would be the NTP representation of 10am on
+   the first Monday, the <repeat interval> would be 1 week, the <active
+   duration> would be 1 hour, and the offsets would be zero and 25
+   hours.  The corresponding "t=" field stop time would be the NTP
+   representation of the end of the last session three months later.  By
+   default, all fields are in seconds, so the "r=" and "t=" fields might
+   be the following:
+
+      t=3034423619 3042462419
+      r=604800 3600 0 90000
+
+   To make description more compact, times may also be given in units of
+   days, hours, or minutes.  The syntax for these is a number
+   immediately followed by a single case-sensitive character.
+   Fractional units are not allowed -- a smaller unit should be used
+   instead.  The following unit specification characters are allowed:
+
+      d - days (86400 seconds)
+      h - hours (3600 seconds)
+      m - minutes (60 seconds)
+      s - seconds (allowed for completeness)
+
+   Thus, the above session announcement could also have been written:
+
+      r=7d 1h 0 25h
+
+   Monthly and yearly repeats cannot be directly specified with a single
+   SDP repeat time; instead, separate "t=" fields should be used to
+   explicitly list the session times.
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 18]
+
+RFC 4566                          SDP                          July 2006
+
+
+5.11.  Time Zones ("z=")
+
+      z=<adjustment time> <offset> <adjustment time> <offset> ....
+
+   To schedule a repeated session that spans a change from daylight
+   saving time to standard time or vice versa, it is necessary to
+   specify offsets from the base time.  This is required because
+   different time zones change time at different times of day, different
+   countries change to or from daylight saving time on different dates,
+   and some countries do not have daylight saving time at all.
+
+   Thus, in order to schedule a session that is at the same time winter
+   and summer, it must be possible to specify unambiguously by whose
+   time zone a session is scheduled.  To simplify this task for
+   receivers, we allow the sender to specify the NTP time that a time
+   zone adjustment happens and the offset from the time when the session
+   was first scheduled.  The "z=" field allows the sender to specify a
+   list of these adjustment times and offsets from the base time.
+
+   An example might be the following:
+
+      z=2882844526 -1h 2898848070 0
+
+   This specifies that at time 2882844526, the time base by which the
+   session's repeat times are calculated is shifted back by 1 hour, and
+   that at time 2898848070, the session's original time base is
+   restored.  Adjustments are always relative to the specified start
+   time -- they are not cumulative.  Adjustments apply to all "t=" and
+   "r=" lines in a session description.
+
+   If a session is likely to last several years, it is expected that the
+   session announcement will be modified periodically rather than
+   transmit several years' worth of adjustments in one session
+   announcement.
+
+5.12.  Encryption Keys ("k=")
+
+      k=<method>
+      k=<method>:<encryption key>
+
+   If transported over a secure and trusted channel, the Session
+   Description Protocol MAY be used to convey encryption keys.  A simple
+   mechanism for key exchange is provided by the key field ("k="),
+   although this is primarily supported for compatibility with older
+   implementations and its use is NOT RECOMMENDED.  Work is in progress
+   to define new key exchange mechanisms for use with SDP [27] [28], and
+   it is expected that new applications will use those mechanisms.
+
+
+
+
+Handley, et al.             Standards Track                    [Page 19]
+
+RFC 4566                          SDP                          July 2006
+
+
+   A key field is permitted before the first media entry (in which case
+   it applies to all media in the session), or for each media entry as
+   required.  The format of keys and their usage are outside the scope
+   of this document, and the key field provides no way to indicate the
+   encryption algorithm to be used, key type, or other information about
+   the key: this is assumed to be provided by the higher-level protocol
+   using SDP.  If there is a need to convey this information within SDP,
+   the extensions mentioned previously SHOULD be used.  Many security
+   protocols require two keys: one for confidentiality, another for
+   integrity.  This specification does not support transfer of two keys.
+
+   The method indicates the mechanism to be used to obtain a usable key
+   by external means, or from the encoded encryption key given.  The
+   following methods are defined:
+
+      k=clear:<encryption key>
+
+         The encryption key is included untransformed in this key field.
+         This method MUST NOT be used unless it can be guaranteed that
+         the SDP is conveyed over a secure channel.  The encryption key
+         is interpreted as text according to the charset attribute; use
+         the "k=base64:" method to convey characters that are otherwise
+         prohibited in SDP.
+
+      k=base64:<encoded encryption key>
+
+         The encryption key is included in this key field but has been
+         base64 encoded [12] because it includes characters that are
+         prohibited in SDP.  This method MUST NOT be used unless it can
+         be guaranteed that the SDP is conveyed over a secure channel.
+
+      k=uri:<URI to obtain key>
+
+         A Uniform Resource Identifier is included in the key field.
+         The URI refers to the data containing the key, and may require
+         additional authentication before the key can be returned.  When
+         a request is made to the given URI, the reply should specify
+         the encoding for the key.  The URI is often an Secure Socket
+         Layer/Transport Layer Security (SSL/TLS)-protected HTTP URI
+         ("https:"), although this is not required.
+
+      k=prompt
+
+         No key is included in this SDP description, but the session or
+         media stream referred to by this key field is encrypted.  The
+         user should be prompted for the key when attempting to join the
+         session, and this user-supplied key should then be used to
+
+
+
+
+Handley, et al.             Standards Track                    [Page 20]
+
+RFC 4566                          SDP                          July 2006
+
+
+         decrypt the media streams.  The use of user-specified keys is
+         NOT RECOMMENDED, since such keys tend to have weak security
+         properties.
+
+   The key field MUST NOT be used unless it can be guaranteed that the
+   SDP is conveyed over a secure and trusted channel.  An example of
+   such a channel might be SDP embedded inside an S/MIME message or a
+   TLS-protected HTTP session.  It is important to ensure that the
+   secure channel is with the party that is authorised to join the
+   session, not an intermediary: if a caching proxy server is used, it
+   is important to ensure that the proxy is either trusted or unable to
+   access the SDP.
+
+5.13.  Attributes ("a=")
+
+      a=<attribute>
+      a=<attribute>:<value>
+
+   Attributes are the primary means for extending SDP.  Attributes may
+   be defined to be used as "session-level" attributes, "media-level"
+   attributes, or both.
+
+   A media description may have any number of attributes ("a=" fields)
+   that are media specific.  These are referred to as "media-level"
+   attributes and add information about the media stream.  Attribute
+   fields can also be added before the first media field; these
+   "session-level" attributes convey additional information that applies
+   to the conference as a whole rather than to individual media.
+
+   Attribute fields may be of two forms:
+
+   o  A property attribute is simply of the form "a=<flag>".  These are
+      binary attributes, and the presence of the attribute conveys that
+      the attribute is a property of the session.  An example might be
+      "a=recvonly".
+
+   o  A value attribute is of the form "a=<attribute>:<value>".  For
+      example, a whiteboard could have the value attribute "a=orient:
+      landscape"
+
+   Attribute interpretation depends on the media tool being invoked.
+   Thus receivers of session descriptions should be configurable in
+   their interpretation of session descriptions in general and of
+   attributes in particular.
+
+   Attribute names MUST use the US-ASCII subset of ISO-10646/UTF-8.
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 21]
+
+RFC 4566                          SDP                          July 2006
+
+
+   Attribute values are octet strings, and MAY use any octet value
+   except 0x00 (Nul), 0x0A (LF), and 0x0D (CR).  By default, attribute
+   values are to be interpreted as in ISO-10646 character set with UTF-8
+   encoding.  Unlike other text fields, attribute values are NOT
+   normally affected by the "charset" attribute as this would make
+   comparisons against known values problematic.  However, when an
+   attribute is defined, it can be defined to be charset dependent, in
+   which case its value should be interpreted in the session charset
+   rather than in ISO-10646.
+
+   Attributes MUST be registered with IANA (see Section 8).  If an
+   attribute is received that is not understood, it MUST be ignored by
+   the receiver.
+
+5.14.  Media Descriptions ("m=")
+
+      m=<media> <port> <proto> <fmt> ...
+
+   A session description may contain a number of media descriptions.
+   Each media description starts with an "m=" field and is terminated by
+   either the next "m=" field or by the end of the session description.
+   A media field has several sub-fields:
+
+   <media> is the media type.  Currently defined media are "audio",
+      "video", "text", "application", and "message", although this list
+      may be extended in the future (see Section 8).
+
+   <port> is the transport port to which the media stream is sent.  The
+      meaning of the transport port depends on the network being used as
+      specified in the relevant "c=" field, and on the transport
+      protocol defined in the <proto> sub-field of the media field.
+      Other ports used by the media application (such as the RTP Control
+      Protocol (RTCP) port [19]) MAY be derived algorithmically from the
+      base media port or MAY be specified in a separate attribute (for
+      example, "a=rtcp:" as defined in [22]).
+
+      If non-contiguous ports are used or if they don't follow the
+      parity rule of even RTP ports and odd RTCP ports, the "a=rtcp:"
+      attribute MUST be used.  Applications that are requested to send
+      media to a <port> that is odd and where the "a=rtcp:" is present
+      MUST NOT subtract 1 from the RTP port: that is, they MUST send the
+      RTP to the port indicated in <port> and send the RTCP to the port
+      indicated in the "a=rtcp" attribute.
+
+      For applications where hierarchically encoded streams are being
+      sent to a unicast address, it may be necessary to specify multiple
+      transport ports.  This is done using a similar notation to that
+      used for IP multicast addresses in the "c=" field:
+
+
+
+Handley, et al.             Standards Track                    [Page 22]
+
+RFC 4566                          SDP                          July 2006
+
+
+         m=<media> <port>/<number of ports> <proto> <fmt> ...
+
+      In such a case, the ports used depend on the transport protocol.
+      For RTP, the default is that only the even-numbered ports are used
+      for data with the corresponding one-higher odd ports used for the
+      RTCP belonging to the RTP session, and the <number of ports>
+      denoting the number of RTP sessions.  For example:
+
+         m=video 49170/2 RTP/AVP 31
+
+      would specify that ports 49170 and 49171 form one RTP/RTCP pair
+      and 49172 and 49173 form the second RTP/RTCP pair.  RTP/AVP is the
+      transport protocol and 31 is the format (see below).  If non-
+      contiguous ports are required, they must be signalled using a
+      separate attribute (for example, "a=rtcp:" as defined in [22]).
+
+      If multiple addresses are specified in the "c=" field and multiple
+      ports are specified in the "m=" field, a one-to-one mapping from
+      port to the corresponding address is implied.  For example:
+
+         c=IN IP4 224.2.1.1/127/2
+         m=video 49170/2 RTP/AVP 31
+
+      would imply that address 224.2.1.1 is used with ports 49170 and
+      49171, and address 224.2.1.2 is used with ports 49172 and 49173.
+
+      The semantics of multiple "m=" lines using the same transport
+      address are undefined.  This implies that, unlike limited past
+      practice, there is no implicit grouping defined by such means and
+      an explicit grouping framework (for example, [18]) should instead
+      be used to express the intended semantics.
+
+   <proto> is the transport protocol.  The meaning of the transport
+      protocol is dependent on the address type field in the relevant
+      "c=" field.  Thus a "c=" field of IP4 indicates that the transport
+      protocol runs over IP4.  The following transport protocols are
+      defined, but may be extended through registration of new protocols
+      with IANA (see Section 8):
+
+      *  udp: denotes an unspecified protocol running over UDP.
+
+      *  RTP/AVP: denotes RTP [19] used under the RTP Profile for Audio
+         and Video Conferences with Minimal Control [20] running over
+         UDP.
+
+      *  RTP/SAVP: denotes the Secure Real-time Transport Protocol [23]
+         running over UDP.
+
+
+
+
+Handley, et al.             Standards Track                    [Page 23]
+
+RFC 4566                          SDP                          July 2006
+
+
+      The main reason to specify the transport protocol in addition to
+      the media format is that the same standard media formats may be
+      carried over different transport protocols even when the network
+      protocol is the same -- a historical example is vat Pulse Code
+      Modulation (PCM) audio and RTP PCM audio; another might be TCP/RTP
+      PCM audio.  In addition, relays and monitoring tools that are
+      transport-protocol-specific but format-independent are possible.
+
+   <fmt> is a media format description.  The fourth and any subsequent
+      sub-fields describe the format of the media.  The interpretation
+      of the media format depends on the value of the <proto> sub-field.
+
+      If the <proto> sub-field is "RTP/AVP" or "RTP/SAVP" the <fmt>
+      sub-fields contain RTP payload type numbers.  When a list of
+      payload type numbers is given, this implies that all of these
+      payload formats MAY be used in the session, but the first of these
+      formats SHOULD be used as the default format for the session.  For
+      dynamic payload type assignments the "a=rtpmap:" attribute (see
+      Section 6) SHOULD be used to map from an RTP payload type number
+      to a media encoding name that identifies the payload format.  The
+      "a=fmtp:"  attribute MAY be used to specify format parameters (see
+      Section 6).
+
+      If the <proto> sub-field is "udp" the <fmt> sub-fields MUST
+      reference a media type describing the format under the "audio",
+      "video", "text", "application", or "message" top-level media
+      types.  The media type registration SHOULD define the packet
+      format for use with UDP transport.
+
+      For media using other transport protocols, the <fmt> field is
+      protocol specific.  Rules for interpretation of the <fmt> sub-
+      field MUST be defined when registering new protocols (see Section
+      8.2.2).
+
+6.  SDP Attributes
+
+   The following attributes are defined.  Since application writers may
+   add new attributes as they are required, this list is not exhaustive.
+   Registration procedures for new attributes are defined in Section
+   8.2.4.
+
+      a=cat:<category>
+
+         This attribute gives the dot-separated hierarchical category of
+         the session.  This is to enable a receiver to filter unwanted
+         sessions by category.  There is no central registry of
+         categories.  It is a session-level attribute, and it is not
+         dependent on charset.
+
+
+
+Handley, et al.             Standards Track                    [Page 24]
+
+RFC 4566                          SDP                          July 2006
+
+
+      a=keywds:<keywords>
+
+         Like the cat attribute, this is to assist identifying wanted
+         sessions at the receiver.  This allows a receiver to select
+         interesting session based on keywords describing the purpose of
+         the session; there is no central registry of keywords.  It is a
+         session-level attribute.  It is a charset-dependent attribute,
+         meaning that its value should be interpreted in the charset
+         specified for the session description if one is specified, or
+         by default in ISO 10646/UTF-8.
+
+      a=tool:<name and version of tool>
+
+         This gives the name and version number of the tool used to
+         create the session description.  It is a session-level
+         attribute, and it is not dependent on charset.
+
+      a=ptime:<packet time>
+
+         This gives the length of time in milliseconds represented by
+         the media in a packet.  This is probably only meaningful for
+         audio data, but may be used with other media types if it makes
+         sense.  It should not be necessary to know ptime to decode RTP
+         or vat audio, and it is intended as a recommendation for the
+         encoding/packetisation of audio.  It is a media-level
+         attribute, and it is not dependent on charset.
+
+      a=maxptime:<maximum packet time>
+
+         This gives the maximum amount of media that can be encapsulated
+         in each packet, expressed as time in milliseconds.  The time
+         SHALL be calculated as the sum of the time the media present in
+         the packet represents.  For frame-based codecs, the time SHOULD
+         be an integer multiple of the frame size.  This attribute is
+         probably only meaningful for audio data, but may be used with
+         other media types if it makes sense.  It is a media-level
+         attribute, and it is not dependent on charset.  Note that this
+         attribute was introduced after RFC 2327, and non-updated
+         implementations will ignore this attribute.
+
+      a=rtpmap:<payload type> <encoding name>/<clock rate> [/<encoding
+         parameters>]
+
+         This attribute maps from an RTP payload type number (as used in
+         an "m=" line) to an encoding name denoting the payload format
+         to be used.  It also provides information on the clock rate and
+         encoding parameters.  It is a media-level attribute that is not
+         dependent on charset.
+
+
+
+Handley, et al.             Standards Track                    [Page 25]
+
+RFC 4566                          SDP                          July 2006
+
+
+         Although an RTP profile may make static assignments of payload
+         type numbers to payload formats, it is more common for that
+         assignment to be done dynamically using "a=rtpmap:" attributes.
+         As an example of a static payload type, consider u-law PCM
+         coded single-channel audio sampled at 8 kHz.  This is
+         completely defined in the RTP Audio/Video profile as payload
+         type 0, so there is no need for an "a=rtpmap:" attribute, and
+         the media for such a stream sent to UDP port 49232 can be
+         specified as:
+
+            m=audio 49232 RTP/AVP 0
+
+         An example of a dynamic payload type is 16-bit linear encoded
+         stereo audio sampled at 16 kHz.  If we wish to use the dynamic
+         RTP/AVP payload type 98 for this stream, additional information
+         is required to decode it:
+
+            m=audio 49232 RTP/AVP 98
+            a=rtpmap:98 L16/16000/2
+
+         Up to one rtpmap attribute can be defined for each media format
+         specified.  Thus, we might have the following:
+
+            m=audio 49230 RTP/AVP 96 97 98
+            a=rtpmap:96 L8/8000
+            a=rtpmap:97 L16/8000
+            a=rtpmap:98 L16/11025/2
+
+         RTP profiles that specify the use of dynamic payload types MUST
+         define the set of valid encoding names and/or a means to
+         register encoding names if that profile is to be used with SDP.
+         The "RTP/AVP" and "RTP/SAVP" profiles use media subtypes for
+         encoding names, under the top-level media type denoted in the
+         "m=" line.  In the example above, the media types are
+         "audio/l8" and "audio/l16".
+
+         For audio streams, <encoding parameters> indicates the number
+         of audio channels.  This parameter is OPTIONAL and may be
+         omitted if the number of channels is one, provided that no
+         additional parameters are needed.
+
+         For video streams, no encoding parameters are currently
+         specified.
+
+         Additional encoding parameters MAY be defined in the future,
+         but codec-specific parameters SHOULD NOT be added.  Parameters
+         added to an "a=rtpmap:" attribute SHOULD only be those required
+         for a session directory to make the choice of appropriate media
+
+
+
+Handley, et al.             Standards Track                    [Page 26]
+
+RFC 4566                          SDP                          July 2006
+
+
+         to participate in a session.  Codec-specific parameters should
+         be added in other attributes (for example, "a=fmtp:").
+
+         Note: RTP audio formats typically do not include information
+         about the number of samples per packet.  If a non-default (as
+         defined in the RTP Audio/Video Profile) packetisation is
+         required, the "ptime" attribute is used as given above.
+
+      a=recvonly
+
+         This specifies that the tools should be started in receive-only
+         mode where applicable.  It can be either a session- or media-
+         level attribute, and it is not dependent on charset.  Note that
+         recvonly applies to the media only, not to any associated
+         control protocol (e.g., an RTP-based system in recvonly mode
+         SHOULD still send RTCP packets).
+
+      a=sendrecv
+
+         This specifies that the tools should be started in send and
+         receive mode.  This is necessary for interactive conferences
+         with tools that default to receive-only mode.  It can be either
+         a session or media-level attribute, and it is not dependent on
+         charset.
+
+         If none of the attributes "sendonly", "recvonly", "inactive",
+         and "sendrecv" is present, "sendrecv" SHOULD be assumed as the
+         default for sessions that are not of the conference type
+         "broadcast" or "H332" (see below).
+
+      a=sendonly
+
+         This specifies that the tools should be started in send-only
+         mode.  An example may be where a different unicast address is
+         to be used for a traffic destination than for a traffic source.
+         In such a case, two media descriptions may be used, one
+         sendonly and one recvonly.  It can be either a session- or
+         media-level attribute, but would normally only be used as a
+         media attribute.  It is not dependent on charset.  Note that
+         sendonly applies only to the media, and any associated control
+         protocol (e.g., RTCP) SHOULD still be received and processed as
+         normal.
+
+      a=inactive
+
+         This specifies that the tools should be started in inactive
+         mode.  This is necessary for interactive conferences where
+         users can put other users on hold.  No media is sent over an
+
+
+
+Handley, et al.             Standards Track                    [Page 27]
+
+RFC 4566                          SDP                          July 2006
+
+
+         inactive media stream.  Note that an RTP-based system SHOULD
+         still send RTCP, even if started inactive.  It can be either a
+         session or media-level attribute, and it is not dependent on
+         charset.
+
+      a=orient:<orientation>
+
+         Normally this is only used for a whiteboard or presentation
+         tool.  It specifies the orientation of a the workspace on the
+         screen.  It is a media-level attribute.  Permitted values are
+         "portrait", "landscape", and "seascape" (upside-down
+         landscape).  It is not dependent on charset.
+
+      a=type:<conference type>
+
+         This specifies the type of the conference.  Suggested values
+         are "broadcast", "meeting", "moderated", "test", and "H332".
+         "recvonly" should be the default for "type:broadcast" sessions,
+         "type:meeting" should imply "sendrecv", and "type:moderated"
+         should indicate the use of a floor control tool and that the
+         media tools are started so as to mute new sites joining the
+         conference.
+
+         Specifying the attribute "type:H332" indicates that this
+         loosely coupled session is part of an H.332 session as defined
+         in the ITU H.332 specification [26].  Media tools should be
+         started "recvonly".
+
+         Specifying the attribute "type:test" is suggested as a hint
+         that, unless explicitly requested otherwise, receivers can
+         safely avoid displaying this session description to users.
+
+         The type attribute is a session-level attribute, and it is not
+         dependent on charset.
+
+      a=charset:<character set>
+
+         This specifies the character set to be used to display the
+         session name and information data.  By default, the ISO-10646
+         character set in UTF-8 encoding is used.  If a more compact
+         representation is required, other character sets may be used.
+         For example, the ISO 8859-1 is specified with the following SDP
+         attribute:
+
+            a=charset:ISO-8859-1
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 28]
+
+RFC 4566                          SDP                          July 2006
+
+
+         This is a session-level attribute and is not dependent on
+         charset.  The charset specified MUST be one of those registered
+         with IANA, such as ISO-8859-1.  The character set identifier is
+         a US-ASCII string and MUST be compared against the IANA
+         identifiers using a case-insensitive comparison.  If the
+         identifier is not recognised or not supported, all strings that
+         are affected by it SHOULD be regarded as octet strings.
+
+         Note that a character set specified MUST still prohibit the use
+         of bytes 0x00 (Nul), 0x0A (LF), and 0x0d (CR).  Character sets
+         requiring the use of these characters MUST define a quoting
+         mechanism that prevents these bytes from appearing within text
+         fields.
+
+      a=sdplang:<language tag>
+
+         This can be a session-level attribute or a media-level
+         attribute.  As a session-level attribute, it specifies the
+         language for the session description.  As a media-level
+         attribute, it specifies the language for any media-level SDP
+         information field associated with that media.  Multiple sdplang
+         attributes can be provided either at session or media level if
+         multiple languages in the session description or media use
+         multiple languages, in which case the order of the attributes
+         indicates the order of importance of the various languages in
+         the session or media from most important to least important.
+
+         In general, sending session descriptions consisting of multiple
+         languages is discouraged.  Instead, multiple descriptions
+         SHOULD be sent describing the session, one in each language.
+         However, this is not possible with all transport mechanisms,
+         and so multiple sdplang attributes are allowed although NOT
+         RECOMMENDED.
+
+         The "sdplang" attribute value must be a single RFC 3066
+         language tag in US-ASCII [9].  It is not dependent on the
+         charset attribute.  An "sdplang" attribute SHOULD be specified
+         when a session is of sufficient scope to cross geographic
+         boundaries where the language of recipients cannot be assumed,
+         or where the session is in a different language from the
+         locally assumed norm.
+
+      a=lang:<language tag>
+
+         This can be a session-level attribute or a media-level
+         attribute.  As a session-level attribute, it specifies the
+         default language for the session being described.  As a media-
+         level attribute, it specifies the language for that media,
+
+
+
+Handley, et al.             Standards Track                    [Page 29]
+
+RFC 4566                          SDP                          July 2006
+
+
+         overriding any session-level language specified.  Multiple lang
+         attributes can be provided either at session or media level if
+         the session description or media use multiple languages, in
+         which case the order of the attributes indicates the order of
+         importance of the various languages in the session or media
+         from most important to least important.
+
+         The "lang" attribute value must be a single RFC 3066 language
+         tag in US-ASCII [9].  It is not dependent on the charset
+         attribute.  A "lang" attribute SHOULD be specified when a
+         session is of sufficient scope to cross geographic boundaries
+         where the language of recipients cannot be assumed, or where
+         the session is in a different language from the locally assumed
+         norm.
+
+      a=framerate:<frame rate>
+
+         This gives the maximum video frame rate in frames/sec.  It is
+         intended as a recommendation for the encoding of video data.
+         Decimal representations of fractional values using the notation
+         "<integer>.<fraction>" are allowed.  It is a media-level
+         attribute, defined only for video media, and it is not
+         dependent on charset.
+
+      a=quality:<quality>
+
+         This gives a suggestion for the quality of the encoding as an
+         integer value.  The intention of the quality attribute for
+         video is to specify a non-default trade-off between frame-rate
+         and still-image quality.  For video, the value is in the range
+         0 to 10, with the following suggested meaning:
+
+            10 - the best still-image quality the compression scheme can
+                 give.
+            5  - the default behaviour given no quality suggestion.
+            0  - the worst still-image quality the codec designer thinks
+                 is still usable.
+
+         It is a media-level attribute, and it is not dependent on
+         charset.
+
+      a=fmtp:<format> <format specific parameters>
+
+         This attribute allows parameters that are specific to a
+         particular format to be conveyed in a way that SDP does not
+         have to understand them.  The format must be one of the formats
+         specified for the media.  Format-specific parameters may be any
+         set of parameters required to be conveyed by SDP and given
+
+
+
+Handley, et al.             Standards Track                    [Page 30]
+
+RFC 4566                          SDP                          July 2006
+
+
+         unchanged to the media tool that will use this format.  At most
+         one instance of this attribute is allowed for each format.
+
+         It is a media-level attribute, and it is not dependent on
+         charset.
+
+7.  Security Considerations
+
+   SDP is frequently used with the Session Initiation Protocol [15]
+   using the offer/answer model [17] to agree on parameters for unicast
+   sessions.  When used in this manner, the security considerations of
+   those protocols apply.
+
+   SDP is a session description format that describes multimedia
+   sessions.  Entities receiving and acting upon an SDP message SHOULD
+   be aware that a session description cannot be trusted unless it has
+   been obtained by an authenticated transport protocol from a known and
+   trusted source.  Many different transport protocols may be used to
+   distribute session description, and the nature of the authentication
+   will differ from transport to transport.  For some transports,
+   security features are often not deployed.  In case a session
+   description has not been obtained in a trusted manner, the endpoint
+   SHOULD exercise care because, among other attacks, the media sessions
+   received may not be the intended ones, the destination where media is
+   sent to may not be the expected one, any of the parameters of the
+   session may be incorrect, or the media security may be compromised.
+   It is up to the endpoint to make a sensible decision taking into
+   account the security risks of the application and the user
+   preferences and may decide to ask the user whether or not to accept
+   the session.
+
+   One transport that can be used to distribute session descriptions is
+   the Session Announcement Protocol (SAP).  SAP provides both
+   encryption and authentication mechanisms, but due to the nature of
+   session announcements it is likely that there are many occasions
+   where the originator of a session announcement cannot be
+   authenticated because the originator is previously unknown to the
+   receiver of the announcement and because no common public key
+   infrastructure is available.
+
+   On receiving a session description over an unauthenticated transport
+   mechanism or from an untrusted party, software parsing the session
+   should take a few precautions.  Session descriptions contain
+   information required to start software on the receiver's system.
+   Software that parses a session description MUST NOT be able to start
+   other software except that which is specifically configured as
+   appropriate software to participate in multimedia sessions.  It is
+   normally considered inappropriate for software parsing a session
+
+
+
+Handley, et al.             Standards Track                    [Page 31]
+
+RFC 4566                          SDP                          July 2006
+
+
+   description to start, on a user's system, software that is
+   appropriate to participate in multimedia sessions, without the user
+   first being informed that such software will be started and giving
+   the user's consent.  Thus, a session description arriving by session
+   announcement, email, session invitation, or WWW page MUST NOT deliver
+   the user into an interactive multimedia session unless the user has
+   explicitly pre-authorised such action.  As it is not always simple to
+   tell whether or not a session is interactive, applications that are
+   unsure should assume sessions are interactive.
+
+   In this specification, there are no attributes that would allow the
+   recipient of a session description to be informed to start multimedia
+   tools in a mode where they default to transmitting.  Under some
+   circumstances it might be appropriate to define such attributes.  If
+   this is done, an application parsing a session description containing
+   such attributes SHOULD either ignore them or inform the user that
+   joining this session will result in the automatic transmission of
+   multimedia data.  The default behaviour for an unknown attribute is
+   to ignore it.
+
+   In certain environments, it has become common for intermediary
+   systems to intercept and analyse session descriptions contained
+   within other signalling protocols.  This is done for a range of
+   purposes, including but not limited to opening holes in firewalls to
+   allow media streams to pass, or to mark, prioritize, or block traffic
+   selectively.  In some cases, such intermediary systems may modify the
+   session description, for example, to have the contents of the session
+   description match NAT bindings dynamically created.  These behaviours
+   are NOT RECOMMENDED unless the session description is conveyed in
+   such a manner that allows the intermediary system to conduct proper
+   checks to establish the authenticity of the session description, and
+   the authority of its source to establish such communication sessions.
+   SDP by itself does not include sufficient information to enable these
+   checks: they depend on the encapsulating protocol (e.g., SIP or
+   RTSP).
+
+   Use of the "k=" field poses a significant security risk, since it
+   conveys session encryption keys in the clear.  SDP MUST NOT be used
+   to convey key material, unless it can be guaranteed that the channel
+   over which the SDP is delivered is both private and authenticated.
+   Moreover, the "k=" line provides no way to indicate or negotiate
+   cryptographic key algorithms.  As it provides for only a single
+   symmetric key, rather than separate keys for confidentiality and
+   integrity, its utility is severely limited.  The use of the "k=" line
+   is NOT RECOMMENDED, as discussed in Section 5.12.
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 32]
+
+RFC 4566                          SDP                          July 2006
+
+
+8.  IANA Considerations
+
+8.1.  The "application/sdp" Media Type
+
+   One media type registration from RFC 2327 is to be updated, as
+   defined below.
+
+      To: ietf-types@iana.org
+      Subject: Registration of media type "application/sdp"
+
+      Type name: application
+
+      Subtype name: sdp
+
+      Required parameters: None.
+
+      Optional parameters: None.
+
+      Encoding considerations:
+         SDP files are primarily UTF-8 format text.  The "a=charset:"
+         attribute may be used to signal the presence of other
+         character sets in certain parts of an SDP file (see
+         Section 6 of RFC 4566).  Arbitrary binary content cannot
+         be directly represented in SDP.
+
+      Security considerations:
+         See Section 7 of RFC 4566
+
+      Interoperability considerations:
+         See RFC 4566
+
+      Published specification:
+         See RFC 4566
+
+      Applications which use this media type:
+         Voice over IP, video teleconferencing, streaming media, instant
+         messaging, among others.  See also Section 3 of RFC 4566.
+
+      Additional information:
+
+      Magic number(s):   None.
+      File extension(s): The extension ".sdp" is commonly used.
+      Macintosh File Type Code(s): "sdp "
+
+      Person & email address to contact for further information:
+         Mark Handley  <M.Handley@cs.ucl.ac.uk>
+         Colin Perkins <csp@csperkins.org>
+         IETF MMUSIC working group <mmusic@ietf.org>
+
+
+
+Handley, et al.             Standards Track                    [Page 33]
+
+RFC 4566                          SDP                          July 2006
+
+
+      Intended usage: COMMON
+
+      Author/Change controller:
+         Authors of RFC 4566
+         IETF MMUSIC working group delegated from the IESG
+
+8.2.  Registration of Parameters
+
+   There are seven field names that may be registered with IANA.  Using
+   the terminology in the SDP specification Backus-Naur Form (BNF), they
+   are "media", "proto", "fmt", "att-field", "bwtype", "nettype", and
+   "addrtype".
+
+8.2.1.  Media Types ("media")
+
+   The set of media types is intended to be small and SHOULD NOT be
+   extended except under rare circumstances.  The same rules should
+   apply for media names as for top-level media content types, and where
+   possible the same name should be registered for SDP as for MIME.  For
+   media other than existing top-level media content types, a Standards
+   Track RFC MUST be produced for a new top-level content type to be
+   registered, and the registration MUST provide good justification why
+   no existing media name is appropriate (the "Standards Action" policy
+   of RFC 2434 [8].
+
+   This memo registers the media types "audio", "video", "text",
+   "application", and "message".
+
+   Note: The media types "control" and "data" were listed as valid in
+   the previous version of this specification [6]; however, their
+   semantics were never fully specified and they are not widely used.
+   These media types have been removed in this specification, although
+   they still remain valid media type capabilities for a SIP user agent
+   as defined in RFC 3840 [24].  If these media types are considered
+   useful in the future, a Standards Track RFC MUST be produced to
+   document their use.  Until that is done, applications SHOULD NOT use
+   these types and SHOULD NOT declare support for them in SIP
+   capabilities declarations (even though they exist in the registry
+   created by RFC 3840).
+
+8.2.2.  Transport Protocols ("proto")
+
+   The "proto" field describes the transport protocol used.  This SHOULD
+   reference a standards-track protocol RFC.  This memo registers three
+   values: "RTP/AVP" is a reference to RTP [19] used under the RTP
+   Profile for Audio and Video Conferences with Minimal Control [20]
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 34]
+
+RFC 4566                          SDP                          July 2006
+
+
+   running over UDP/IP, "RTP/SAVP" is a reference to the Secure Real-
+   time Transport Protocol [23], and "udp" indicates an unspecified
+   protocol over UDP.
+
+   If other RTP profiles are defined in the future, their "proto" name
+   SHOULD be specified in the same manner.  For example, an RTP profile
+   whose short name is "XYZ" would be denoted by a "proto" field of
+   "RTP/XYZ".
+
+   New transport protocols SHOULD be registered with IANA.
+   Registrations MUST reference an RFC describing the protocol.  Such an
+   RFC MAY be Experimental or Informational, although it is preferable
+   that it be Standards Track.  Registrations MUST also define the rules
+   by which their "fmt" namespace is managed (see below).
+
+8.2.3.  Media Formats ("fmt")
+
+   Each transport protocol, defined by the "proto" field, has an
+   associated "fmt" namespace that describes the media formats that may
+   be conveyed by that protocol.  Formats cover all the possible
+   encodings that might want to be transported in a multimedia session.
+
+   RTP payload formats under the "RTP/AVP" and "RTP/SAVP" profiles MUST
+   use the payload type number as their "fmt" value.  If the payload
+   type number is dynamically assigned by this session description, an
+   additional "rtpmap" attribute MUST be included to specify the format
+   name and parameters as defined by the media type registration for the
+   payload format.  It is RECOMMENDED that other RTP profiles that are
+   registered (in combination with RTP) as SDP transport protocols
+   specify the same rules for the "fmt" namespace.
+
+   For the "udp" protocol, new formats SHOULD be registered.  Use of an
+   existing media subtype for the format is encouraged.  If no media
+   subtype exists, it is RECOMMENDED that a suitable one be registered
+   through the IETF process [31] by production of, or reference to, a
+   standards-track RFC that defines the transport protocol for the
+   format.
+
+   For other protocols, formats MAY be registered according to the rules
+   of the associated "proto" specification.
+
+   Registrations of new formats MUST specify which transport protocols
+   they apply to.
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 35]
+
+RFC 4566                          SDP                          July 2006
+
+
+8.2.4.  Attribute Names ("att-field")
+
+   Attribute field names ("att-field") MUST be registered with IANA and
+   documented, because of noticeable issues due to conflicting
+   attributes under the same name.  Unknown attributes in SDP are simply
+   ignored, but conflicting ones that fragment the protocol are a
+   serious problem.
+
+   New attribute registrations are accepted according to the
+   "Specification Required" policy of RFC 2434, provided that the
+   specification includes the following information:
+
+   o  contact name, email address, and telephone number
+
+   o  attribute name (as it will appear in SDP)
+
+   o  long-form attribute name in English
+
+   o  type of attribute (session level, media level, or both)
+
+   o  whether the attribute value is subject to the charset attribute
+
+   o  a one-paragraph explanation of the purpose of the attribute
+
+   o  a specification of appropriate attribute values for this attribute
+
+   The above is the minimum that IANA will accept.  Attributes that are
+   expected to see widespread use and interoperability SHOULD be
+   documented with a standards-track RFC that specifies the attribute
+   more precisely.
+
+   Submitters of registrations should ensure that the specification is
+   in the spirit of SDP attributes, most notably that the attribute is
+   platform independent in the sense that it makes no implicit
+   assumptions about operating systems and does not name specific pieces
+   of software in a manner that might inhibit interoperability.
+
+   IANA has registered the following initial set of attribute names
+   ("att-field" values), with definitions as in Section 6 of this memo
+   (these definitions update those in RFC 2327):
+
+
+
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 36]
+
+RFC 4566                          SDP                          July 2006
+
+
+      Name      | Session or Media level? | Dependent on charset?
+      ----------+-------------------------+----------------------
+      cat       | Session                 | No
+      keywds    | Session                 | Yes
+      tool      | Session                 | No
+      ptime     | Media                   | No
+      maxptime  | Media                   | No
+      rtpmap    | Media                   | No
+      recvonly  | Either                  | No
+      sendrecv  | Either                  | No
+      sendonly  | Either                  | No
+      inactive  | Either                  | No
+      orient    | Media                   | No
+      type      | Session                 | No
+      charset   | Session                 | No
+      sdplang   | Either                  | No
+      lang      | Either                  | No
+      framerate | Media                   | No
+      quality   | Media                   | No
+      fmtp      | Media                   | No
+
+8.2.5.  Bandwidth Specifiers ("bwtype")
+
+   A proliferation of bandwidth specifiers is strongly discouraged.
+
+   New bandwidth specifiers ("bwtype" fields) MUST be registered with
+   IANA.  The submission MUST reference a standards-track RFC specifying
+   the semantics of the bandwidth specifier precisely, and indicating
+   when it should be used, and why the existing registered bandwidth
+   specifiers do not suffice.
+
+   IANA has registered the bandwidth specifiers "CT" and "AS" with
+   definitions as in Section 5.8 of this memo (these definitions update
+   those in RFC 2327).
+
+8.2.6.  Network Types ("nettype")
+
+   New network types (the "nettype" field) may be registered with IANA
+   if SDP needs to be used in the context of non-Internet environments.
+   Although these are not normally the preserve of IANA, there may be
+   circumstances when an Internet application needs to interoperate with
+   a non-Internet application, such as when gatewaying an Internet
+   telephone call into the Public Switched Telephone Network (PSTN).
+   The number of network types should be small and should be rarely
+   extended.  A new network type cannot be registered without
+   registering at least one address type to be used with that network
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 37]
+
+RFC 4566                          SDP                          July 2006
+
+
+   type.  A new network type registration MUST reference an RFC that
+   gives details of the network type and address type and specifies how
+   and when they would be used.
+
+   IANA has registered the network type "IN" to represent the Internet,
+   with definition as in Sections 5.2 and 5.7 of this memo (these
+   definitions update those in RFC 2327).
+
+8.2.7.  Address Types ("addrtype")
+
+   New address types ("addrtype") may be registered with IANA.  An
+   address type is only meaningful in the context of a network type, and
+   any registration of an address type MUST specify a registered network
+   type or be submitted along with a network type registration.  A new
+   address type registration MUST reference an RFC giving details of the
+   syntax of the address type.  Address types are not expected to be
+   registered frequently.
+
+   IANA has registered the address types "IP4" and "IP6" with
+   definitions as in Sections 5.2 and 5.7 of this memo (these
+   definitions update those in RFC 2327).
+
+8.2.8.  Registration Procedure
+
+   In the RFC documentation that registers SDP "media", "proto", "fmt",
+   "bwtype", "nettype", and "addrtype" fields, the authors MUST include
+   the following information for IANA to place in the appropriate
+   registry:
+
+   o  contact name, email address, and telephone number
+
+   o  name being registered (as it will appear in SDP)
+
+   o  long-form name in English
+
+   o  type of name ("media", "proto", "fmt", "bwtype", "nettype", or
+      "addrtype")
+
+   o  a one-paragraph explanation of the purpose of the registered name
+
+   o  a reference to the specification for the registered name (this
+      will typically be an RFC number)
+
+   IANA may refer any registration to the IESG for review, and may
+   request revisions to be made before a registration will be made.
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 38]
+
+RFC 4566                          SDP                          July 2006
+
+
+8.3.  Encryption Key Access Methods
+
+   The IANA previously maintained a table of SDP encryption key access
+   method ("enckey") names.  This table is obsolete, since the "k=" line
+   is not extensible.  New registrations MUST NOT be accepted.
+
+9.  SDP Grammar
+
+   This section provides an Augmented BNF grammar for SDP.  ABNF is
+   defined in [4].
+
+   ; SDP Syntax
+   session-description = proto-version
+                         origin-field
+                         session-name-field
+                         information-field
+                         uri-field
+                         email-fields
+                         phone-fields
+                         connection-field
+                         bandwidth-fields
+                         time-fields
+                         key-field
+                         attribute-fields
+                         media-descriptions
+
+   proto-version =       %x76 "=" 1*DIGIT CRLF
+                         ;this memo describes version 0
+
+   origin-field =        %x6f "=" username SP sess-id SP sess-version SP
+                         nettype SP addrtype SP unicast-address CRLF
+
+   session-name-field =  %x73 "=" text CRLF
+
+   information-field =   [%x69 "=" text CRLF]
+
+   uri-field =           [%x75 "=" uri CRLF]
+
+   email-fields =        *(%x65 "=" email-address CRLF)
+
+   phone-fields =        *(%x70 "=" phone-number CRLF)
+
+   connection-field =    [%x63 "=" nettype SP addrtype SP
+                         connection-address CRLF]
+                         ;a connection field must be present
+                         ;in every media description or at the
+                         ;session-level
+
+
+
+
+Handley, et al.             Standards Track                    [Page 39]
+
+RFC 4566                          SDP                          July 2006
+
+
+   bandwidth-fields =    *(%x62 "=" bwtype ":" bandwidth CRLF)
+
+   time-fields =         1*( %x74 "=" start-time SP stop-time
+                         *(CRLF repeat-fields) CRLF)
+                         [zone-adjustments CRLF]
+
+   repeat-fields =       %x72 "=" repeat-interval SP typed-time
+                         1*(SP typed-time)
+
+   zone-adjustments =    %x7a "=" time SP ["-"] typed-time
+                         *(SP time SP ["-"] typed-time)
+
+   key-field =           [%x6b "=" key-type CRLF]
+
+   attribute-fields =    *(%x61 "=" attribute CRLF)
+
+   media-descriptions =  *( media-field
+                         information-field
+                         *connection-field
+                         bandwidth-fields
+                         key-field
+                         attribute-fields )
+
+   media-field =         %x6d "=" media SP port ["/" integer]
+                         SP proto 1*(SP fmt) CRLF
+
+   ; sub-rules of 'o='
+   username =            non-ws-string
+                         ;pretty wide definition, but doesn't
+                         ;include space
+
+   sess-id =             1*DIGIT
+                         ;should be unique for this username/host
+
+   sess-version =        1*DIGIT
+
+   nettype =             token
+                         ;typically "IN"
+
+   addrtype =            token
+                         ;typically "IP4" or "IP6"
+
+   ; sub-rules of 'u='
+   uri =                 URI-reference
+                         ; see RFC 3986
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 40]
+
+RFC 4566                          SDP                          July 2006
+
+
+   ; sub-rules of 'e=', see RFC 2822 for definitions
+   email-address        = address-and-comment / dispname-and-address
+                          / addr-spec
+   address-and-comment  = addr-spec 1*SP "(" 1*email-safe ")"
+   dispname-and-address = 1*email-safe 1*SP "<" addr-spec ">"
+
+   ; sub-rules of 'p='
+   phone-number =        phone *SP "(" 1*email-safe ")" /
+                         1*email-safe "<" phone ">" /
+                         phone
+
+   phone =               ["+"] DIGIT 1*(SP / "-" / DIGIT)
+
+   ; sub-rules of 'c='
+   connection-address =  multicast-address / unicast-address
+
+   ; sub-rules of 'b='
+   bwtype =              token
+
+   bandwidth =           1*DIGIT
+
+   ; sub-rules of 't='
+   start-time =          time / "0"
+
+   stop-time =           time / "0"
+
+   time =                POS-DIGIT 9*DIGIT
+                         ; Decimal representation of NTP time in
+                         ; seconds since 1900.  The representation
+                         ; of NTP time is an unbounded length field
+                         ; containing at least 10 digits.  Unlike the
+                         ; 64-bit representation used elsewhere, time
+                         ; in SDP does not wrap in the year 2036.
+
+   ; sub-rules of 'r=' and 'z='
+   repeat-interval =     POS-DIGIT *DIGIT [fixed-len-time-unit]
+
+   typed-time =          1*DIGIT [fixed-len-time-unit]
+
+   fixed-len-time-unit = %x64 / %x68 / %x6d / %x73
+
+   ; sub-rules of 'k='
+   key-type =            %x70 %x72 %x6f %x6d %x70 %x74 /     ; "prompt"
+                         %x63 %x6c %x65 %x61 %x72 ":" text / ; "clear:"
+                         %x62 %x61 %x73 %x65 "64:" base64 /  ; "base64:"
+                         %x75 %x72 %x69 ":" uri              ; "uri:"
+
+   base64      =         *base64-unit [base64-pad]
+
+
+
+Handley, et al.             Standards Track                    [Page 41]
+
+RFC 4566                          SDP                          July 2006
+
+
+   base64-unit =         4base64-char
+   base64-pad  =         2base64-char "==" / 3base64-char "="
+   base64-char =         ALPHA / DIGIT / "+" / "/"
+
+   ; sub-rules of 'a='
+   attribute =           (att-field ":" att-value) / att-field
+
+   att-field =           token
+
+   att-value =           byte-string
+
+   ; sub-rules of 'm='
+   media =               token
+                         ;typically "audio", "video", "text", or
+                         ;"application"
+
+   fmt =                 token
+                         ;typically an RTP payload type for audio
+                         ;and video media
+
+   proto  =              token *("/" token)
+                         ;typically "RTP/AVP" or "udp"
+
+   port =                1*DIGIT
+
+   ; generic sub-rules: addressing
+   unicast-address =     IP4-address / IP6-address / FQDN / extn-addr
+
+   multicast-address =   IP4-multicast / IP6-multicast / FQDN
+                         / extn-addr
+
+   IP4-multicast =       m1 3( "." decimal-uchar )
+                         "/" ttl [ "/" integer ]
+                         ; IPv4 multicast addresses may be in the
+                         ; range 224.0.0.0 to 239.255.255.255
+
+   m1 =                  ("22" ("4"/"5"/"6"/"7"/"8"/"9")) /
+                         ("23" DIGIT )
+
+   IP6-multicast =       hexpart [ "/" integer ]
+                         ; IPv6 address starting with FF
+
+   ttl =                 (POS-DIGIT *2DIGIT) / "0"
+
+   FQDN =                4*(alpha-numeric / "-" / ".")
+                         ; fully qualified domain name as specified
+                         ; in RFC 1035 (and updates)
+
+
+
+
+Handley, et al.             Standards Track                    [Page 42]
+
+RFC 4566                          SDP                          July 2006
+
+
+   IP4-address =         b1 3("." decimal-uchar)
+
+   b1 =                  decimal-uchar
+                         ; less than "224"
+
+   ; The following is consistent with RFC 2373 [30], Appendix B.
+   IP6-address =         hexpart [ ":" IP4-address ]
+
+   hexpart =             hexseq / hexseq "::" [ hexseq ] /
+                         "::" [ hexseq ]
+
+   hexseq  =             hex4 *( ":" hex4)
+
+   hex4    =             1*4HEXDIG
+
+   ; Generic for other address families
+   extn-addr =           non-ws-string
+
+   ; generic sub-rules: datatypes
+   text =                byte-string
+                         ;default is to interpret this as UTF8 text.
+                         ;ISO 8859-1 requires "a=charset:ISO-8859-1"
+                         ;session-level attribute to be used
+
+   byte-string =         1*(%x01-09/%x0B-0C/%x0E-FF)
+                         ;any byte except NUL, CR, or LF
+
+   non-ws-string =       1*(VCHAR/%x80-FF)
+                         ;string of visible characters
+
+   token-char =          %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39
+                         / %x41-5A / %x5E-7E
+
+   token =               1*(token-char)
+
+   email-safe =          %x01-09/%x0B-0C/%x0E-27/%x2A-3B/%x3D/%x3F-FF
+                         ;any byte except NUL, CR, LF, or the quoting
+                         ;characters ()<>
+
+   integer =             POS-DIGIT *DIGIT
+
+   ; generic sub-rules: primitives
+   alpha-numeric =       ALPHA / DIGIT
+
+   POS-DIGIT =           %x31-39 ; 1 - 9
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 43]
+
+RFC 4566                          SDP                          July 2006
+
+
+   decimal-uchar =       DIGIT
+                         / POS-DIGIT DIGIT
+                         / ("1" 2*(DIGIT))
+                         / ("2" ("0"/"1"/"2"/"3"/"4") DIGIT)
+                         / ("2" "5" ("0"/"1"/"2"/"3"/"4"/"5"))
+
+   ; external references:
+         ; ALPHA, DIGIT, CRLF, SP, VCHAR: from RFC 4234
+         ; URI-reference: from RFC 3986
+         ; addr-spec: from RFC 2822
+
+10.  Summary of Changes from RFC 2327
+
+   The memo has been significantly restructured, incorporating a large
+   number of clarifications to the specification in light of use.  With
+   the exception of those items noted below, the changes to the memo are
+   intended to be backward-compatible clarifications.  However, due to
+   inconsistencies and unclear definitions in RFC 2327 it is likely that
+   some implementations interpreted that memo in ways that differ from
+   this version of SDP.
+
+   The ABNF grammar in Section 9 has been extensively revised and
+   updated, correcting a number of mistakes and incorporating the RFC
+   3266 IPv6 extensions.  Known inconsistencies between the grammar and
+   the specification text have been resolved.
+
+   A media type registration for SDP is included.  Requirements for the
+   registration of attributes and other parameters with IANA have been
+   clarified and tightened (Section 8).  It is noted that "text" and
+   "message" are valid media types for use with SDP, but that "control"
+   and "data" are under-specified and deprecated.
+
+   RFC 2119 terms are now used throughout to specify requirements
+   levels.  Certain of those requirements, in particular in relation to
+   parameter registration, are stricter than those in RFC 2327.
+
+   The "RTP/SAVP" RTP profile and its "fmt" namespace are registered.
+
+   The attributes "a=inactive" and "a=maxptime" have been added.
+
+   RFC 2327 mandated that either "e=" or "p=" was required.  Both are
+   now optional, to reflect actual usage.
+
+   The significant limitations of the "k=" field are noted, and its use
+   is deprecated.
+
+   Most uses of the "x-" prefix notation for experimental parameters are
+   disallowed and the other uses are deprecated.
+
+
+
+Handley, et al.             Standards Track                    [Page 44]
+
+RFC 4566                          SDP                          July 2006
+
+
+11.  Acknowledgements
+
+   Many people in the IETF Multiparty Multimedia Session Control
+   (MMUSIC) working group have made comments and suggestions
+   contributing to this document.  In particular, we would like to thank
+   Eve Schooler, Steve Casner, Bill Fenner, Allison Mankin, Ross
+   Finlayson, Peter Parnes, Joerg Ott, Carsten Bormann, Steve Hanna,
+   Jonathan Lennox, Keith Drage, Sean Olson, Bernie Hoeneisen, Jonathan
+   Rosenberg, John Elwell, Flemming Andreasen, Jon Peterson, and Spencer
+   Dawkins.
+
+12.  References
+
+12.1.  Normative References
+
+   [1]   Mockapetris, P., "Domain names - concepts and facilities", STD
+         13, RFC 1034, November 1987.
+
+   [2]   Mockapetris, P., "Domain names - implementation and
+         specification", STD 13, RFC 1035, November 1987.
+
+   [3]   Bradner, S., "Key words for use in RFCs to Indicate Requirement
+         Levels", BCP 14, RFC 2119, March 1997.
+
+   [4]   Crocker, D., Ed. and P. Overell, "Augmented BNF for Syntax
+         Specifications: ABNF", RFC 4234, October 2005.
+
+   [5]   Yergeau, F., "UTF-8, a transformation format of ISO 10646", STD
+         63, RFC 3629, November 2003.
+
+   [6]   Handley, M. and V. Jacobson, "SDP: Session Description
+         Protocol", RFC 2327, April 1998.
+
+   [7]   Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+         Resource Identifier (URI): Generic Syntax", STD 66, RFC 3986,
+         January 2005.
+
+   [8]   Narten, T. and H. Alvestrand, "Guidelines for Writing an IANA
+         Considerations Section in RFCs", BCP 26, RFC 2434, October
+         1998.
+
+   [9]   Alvestrand, H., "Tags for the Identification of Languages", BCP
+         47, RFC 3066, January 2001.
+
+   [10]  Olson, S., Camarillo, G., and A. Roach, "Support for IPv6 in
+         Session Description Protocol (SDP)", RFC 3266, June 2002.
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 45]
+
+RFC 4566                          SDP                          July 2006
+
+
+   [11]  Faltstrom, P., Hoffman, P., and A. Costello,
+         "Internationalizing Domain Names in Applications (IDNA)", RFC
+         3490, March 2003.
+
+   [12]  Josefsson, S., "The Base16, Base32, and Base64 Data Encodings",
+         RFC 3548, July 2003.
+
+12.2.  Informative References
+
+   [13]  Mills, D., "Network Time Protocol (Version 3) Specification,
+         Implementation", RFC 1305, March 1992.
+
+   [14]  Handley, M., Perkins, C., and E. Whelan, "Session Announcement
+         Protocol", RFC 2974, October 2000.
+
+   [15]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston, A.,
+         Peterson, J., Sparks, R., Handley, M., and E. Schooler, "SIP:
+         Session Initiation Protocol", RFC 3261, June 2002.
+
+   [16]  Schulzrinne, H., Rao, A., and R. Lanphier, "Real Time Streaming
+         Protocol (RTSP)", RFC 2326, April 1998.
+
+   [17]  Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model with
+         Session Description Protocol (SDP)", RFC 3264, June 2002.
+
+   [18]  Camarillo, G., Eriksson, G., Holler, J., and H. Schulzrinne,
+         "Grouping of Media Lines in the Session Description Protocol
+         (SDP)", RFC 3388, December 2002.
+
+   [19]  Schulzrinne, H., Casner, S., Frederick, R., and V. Jacobson,
+         "RTP: A Transport Protocol for Real-Time Applications", STD 64,
+         RFC 3550, July 2003.
+
+   [20]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and Video
+         Conferences with Minimal Control", STD 65, RFC 3551, July 2003.
+
+   [21]  Casner, S., "Session Description Protocol (SDP) Bandwidth
+         Modifiers for RTP Control Protocol (RTCP) Bandwidth", RFC 3556,
+         July 2003.
+
+   [22]  Huitema, C., "Real Time Control Protocol (RTCP) attribute in
+         Session Description Protocol (SDP)", RFC 3605, October 2003.
+
+   [23]  Baugher, M., McGrew, D., Naslund, M., Carrara, E., and K.
+         Norrman, "The Secure Real-time Transport Protocol (SRTP)", RFC
+         3711, March 2004.
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 46]
+
+RFC 4566                          SDP                          July 2006
+
+
+   [24]  Rosenberg, J., Schulzrinne, H., and P. Kyzivat, "Indicating
+         User Agent Capabilities in the Session Initiation Protocol
+         (SIP)", RFC 3840, August 2004.
+
+   [25]  Westerlund, M., "A Transport Independent Bandwidth Modifier for
+         the Session Description Protocol (SDP)", RFC 3890, September
+         2004.
+
+   [26]  International Telecommunication Union, "H.323 extended for
+         loosely coupled conferences", ITU Recommendation H.332,
+         September 1998.
+
+   [27]  Arkko, J., Carrara, E., Lindholm, F., Naslund, M., and K.
+         Norrman, "Key Management Extensions for Session Description
+         Protocol (SDP) and Real Time Streaming Protocol (RTSP)", RFC
+         4567, July 2006.
+
+   [28]  Andreasen, F., Baugher, M., and D. Wing, "Session Description
+         Protocol (SDP) Security Descriptions for Media Streams", RFC
+         4568, July 2006.
+
+   [29]  Resnick, P., "Internet Message Format", RFC 2822, April 2001.
+
+   [30]  Hinden, R. and S. Deering, "IP Version 6 Addressing
+         Architecture", RFC 2373, July 1998.
+
+   [31]  Freed, N. and J. Klensin, "Media Type Specifications and
+         Registration Procedures", BCP 13, RFC 4288, December 2005.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 47]
+
+RFC 4566                          SDP                          July 2006
+
+
+Authors' Addresses
+
+   Mark Handley
+   University College London
+   Department of Computer Science
+   Gower Street
+   London  WC1E 6BT
+   UK
+
+   EMail: M.Handley@cs.ucl.ac.uk
+
+
+   Van Jacobson
+   Packet Design
+   2465 Latham Street
+   Mountain View, CA  94040
+   USA
+
+   EMail: van@packetdesign.com
+
+
+   Colin Perkins
+   University of Glasgow
+   Department of Computing Science
+   17 Lilybank Gardens
+   Glasgow  G12 8QQ
+   UK
+
+   EMail: csp@csperkins.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 48]
+
+RFC 4566                          SDP                          July 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Handley, et al.             Standards Track                    [Page 49]
+


### PR DESCRIPTION
## Summary

- Vendor 7 SIP/RTP/SDP RFC text files (`rfcs/`) with download script
- Add Claude skill that dispatches parallel agents to look up protocol details by section and line range

## Test plan

- [ ] Verify skill triggers on SIP/RTP protocol questions