### PR TITLE
Add extension-based call routing

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,7 +24,7 @@ pre-commit:
 
     - name: vulture check
       glob: "*.py"
-      run: uv run vulture {staged_files} vulture_whitelist.py
+      run: uv run vulture {staged_files}
 
     - name: squawk check
       glob: "migrations/*.sql"

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import signal
 from frizzle_phone.rtp.pcmu import pcm_to_ulaw
 from frizzle_phone.rtp.stream import SAMPLES_PER_PACKET
 from frizzle_phone.sip.server import get_server_ip, start_server
-from frizzle_phone.synth import generate_rhythm_pcm
+from frizzle_phone.synth import generate_beeps_pcm, generate_rhythm_pcm
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -19,14 +19,21 @@ logger = logging.getLogger(__name__)
 async def main() -> None:
     loop = asyncio.get_running_loop()
     server_ip = get_server_ip()
-    audio_buf = await loop.run_in_executor(
+    silence_prefix = b"\xff" * (SAMPLES_PER_PACKET * 4)
+
+    techno_buf = await loop.run_in_executor(
         None, lambda: pcm_to_ulaw(generate_rhythm_pcm(60.0))
     )
-    # Prepend 80ms of µ-law silence so the phone's jitter buffer can fill
-    # before meaningful audio begins (avoids first-call distortion)
-    audio_buf = b"\xff" * (SAMPLES_PER_PACKET * 4) + audio_buf
+    techno_buf = silence_prefix + techno_buf
+
+    beeps_buf = await loop.run_in_executor(
+        None, lambda: pcm_to_ulaw(generate_beeps_pcm())
+    )
+    beeps_buf = silence_prefix + beeps_buf
+
+    audio_routes = {"111": techno_buf, "222": beeps_buf}
     transport, server = await start_server(
-        "0.0.0.0", 5060, server_ip=server_ip, audio_buf=audio_buf
+        "0.0.0.0", 5060, server_ip=server_ip, audio_routes=audio_routes
     )
     shutdown = asyncio.Event()
     for sig in (signal.SIGINT, signal.SIGTERM):

--- a/src/frizzle_phone/sip/message.py
+++ b/src/frizzle_phone/sip/message.py
@@ -206,6 +206,18 @@ def parse_via_params(via: str) -> dict[str, str]:
     return params
 
 
+def extract_extension(uri: str) -> str:
+    """Extract the user part from a SIP URI.
+
+    RFC 3261 §19.1.1: SIP URI = sip:user@host[:port][;params][?headers]
+    """
+    # Strip "sip:" scheme prefix
+    user_host = uri.split(":", 1)[1] if ":" in uri else uri
+    if "@" in user_host:
+        return user_host.split("@", 1)[0]
+    return user_host
+
+
 def extract_branch(msg: SipMessage) -> str | None:
     """Extract the Via branch parameter for transaction matching.
 

--- a/src/frizzle_phone/synth.py
+++ b/src/frizzle_phone/synth.py
@@ -143,6 +143,39 @@ def reese_note(freq: float, duration_s: float) -> list[float]:
     return out
 
 
+def generate_beeps_pcm(
+    freq: float = 880.0,
+    beep_s: float = 0.2,
+    gap_s: float = 0.2,
+    count: int = 3,
+) -> list[float]:
+    """Generate a series of sine-wave beeps with gaps.
+
+    Returns float PCM samples at SAMPLE_RATE. Uses a 5ms raised-cosine
+    envelope at the edges of each beep to avoid clicks.
+    """
+    beep_n = int(SAMPLE_RATE * beep_s)
+    gap_n = int(SAMPLE_RATE * gap_s)
+    fade_n = int(SAMPLE_RATE * 0.005)  # 5ms fade
+
+    out: list[float] = []
+    for i in range(count):
+        for j in range(beep_n):
+            t = j / SAMPLE_RATE
+            # Raised-cosine fade in/out
+            if j < fade_n:
+                env = 0.5 * (1.0 - math.cos(math.pi * j / fade_n))
+            elif j > beep_n - fade_n:
+                env = 0.5 * (1.0 - math.cos(math.pi * (beep_n - j) / fade_n))
+            else:
+                env = 1.0
+            out.append(env * math.sin(2.0 * math.pi * freq * t))
+        # Add gap after each beep (except the last)
+        if i < count - 1:
+            out.extend([0.0] * gap_n)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Mixing helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_sip_message.py
+++ b/tests/test_sip_message.py
@@ -1,4 +1,9 @@
-from frizzle_phone.sip.message import build_request, build_response, parse_message
+from frizzle_phone.sip.message import (
+    build_request,
+    build_response,
+    extract_extension,
+    parse_message,
+)
 
 
 def _make_register() -> bytes:
@@ -235,6 +240,18 @@ def test_build_request_custom_content_type():
     text = data.decode()
     assert "Content-Type: text/plain" in text
     assert "application/sdp" not in text
+
+
+def test_extract_extension_basic():
+    assert extract_extension("sip:111@10.0.0.2") == "111"
+
+
+def test_extract_extension_with_port():
+    assert extract_extension("sip:frizzle@10.0.0.2:5060") == "frizzle"
+
+
+def test_extract_extension_no_user():
+    assert extract_extension("sip:10.0.0.2") == "10.0.0.2"
 
 
 def test_build_request_no_body():

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -2,6 +2,7 @@ from frizzle_phone.synth import (
     SAMPLE_RATE,
     _saw,
     generate_bass_pattern,
+    generate_beeps_pcm,
     generate_rhythm_pcm,
     hihat,
     kick,
@@ -68,6 +69,28 @@ def test_generate_bass_pattern_length():
 def test_generate_rhythm_pcm_length():
     pcm = generate_rhythm_pcm(1.0)
     assert len(pcm) == SAMPLE_RATE
+
+
+def test_generate_beeps_pcm_length():
+    samples = generate_beeps_pcm()
+    # 3 beeps × 200ms + 2 gaps × 200ms = 1000ms
+    expected = int(SAMPLE_RATE * 0.2) * 3 + int(SAMPLE_RATE * 0.2) * 2
+    assert len(samples) == expected
+
+
+def test_generate_beeps_pcm_has_silence_gaps():
+    samples = generate_beeps_pcm()
+    beep_n = int(SAMPLE_RATE * 0.2)
+    gap_n = int(SAMPLE_RATE * 0.2)
+    # Middle of first gap should be silent
+    gap_start = beep_n
+    mid_gap = gap_start + gap_n // 2
+    assert samples[mid_gap] == 0.0
+
+
+def test_generate_beeps_pcm_range():
+    samples = generate_beeps_pcm()
+    assert all(-1.1 <= s <= 1.1 for s in samples)
 
 
 def test_generate_rhythm_pcm_not_silent():


### PR DESCRIPTION
## Summary
- Parse dialed extension from INVITE Request-URI and route to different audio: **111** → techno beat, **222** → 3 beeps then hangup, **anything else** → 404 Not Found (RFC 3261 §8.2.2.1)
- Add `extract_extension()` SIP URI parser and `generate_beeps_pcm()` audio synthesizer
- Replace single `audio_buf` with `audio_routes: dict[str, bytes]` throughout server pipeline
- Fix lefthook vulture hook referencing nonexistent `vulture_whitelist.py`

## Test plan
- [x] `just` — all lint/format/types/vulture checks pass
- [x] `just test` — 76 tests pass (includes new tests for extract_extension, generate_beeps_pcm, and 404 routing)
- [ ] `./dev` — dial 111 from phone → techno beat plays
- [ ] Dial 222 → 3 beeps then auto-hangup
- [ ] Dial 999 → phone gets 404, no audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)