### PR TITLE
Fix stale calls blocking new INVITEs after container restart

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import asyncpg
 from dotenv import load_dotenv
 
 from frizzle_phone.bot import create_bot, set_hangup_handler
-from frizzle_phone.database import run_migrations
+from frizzle_phone.database import cleanup_stale_calls, run_migrations
 from frizzle_phone.discord_patches import apply_discord_patches
 from frizzle_phone.rtp.pcmu import pcm_to_ulaw
 from frizzle_phone.rtp.stream import SAMPLES_PER_PACKET
@@ -43,6 +43,7 @@ async def main() -> None:
     if pool is None:
         raise RuntimeError("Failed to create database connection pool")
     await run_migrations(pool)
+    await cleanup_stale_calls(pool)
 
     # Create Discord bot
     bot = create_bot()

--- a/src/frizzle_phone/database.py
+++ b/src/frizzle_phone/database.py
@@ -72,3 +72,16 @@ async def run_migrations(pool: asyncpg.Pool) -> int:
     else:
         logger.info("No pending migrations")
     return count
+
+
+async def cleanup_stale_calls(pool: asyncpg.Pool) -> int:
+    """Mark any ringing/active calls as failed (stale from prior crash)."""
+    result = await pool.execute(
+        "UPDATE calls SET status = 'failed', ended_at = now()"
+        " WHERE status IN ('ringing', 'active')"
+    )
+    # asyncpg returns "UPDATE N"
+    count = int(result.split()[-1])
+    if count:
+        logger.warning("Cleaned up %d stale call(s) from previous run", count)
+    return count

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,46 @@
+"""Tests for database utility functions."""
+
+import asyncpg
+import pytest
+
+from frizzle_phone.database import cleanup_stale_calls
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_calls(pool: asyncpg.Pool) -> None:
+    """Stale ringing/active calls are marked failed; completed calls are untouched."""
+    await pool.execute(
+        "INSERT INTO calls (sip_call_id, extension, caller_addr, status)"
+        " VALUES ('call-1', 'ext1', '10.0.0.1:5060', 'active')"
+    )
+    await pool.execute(
+        "INSERT INTO calls (sip_call_id, extension, caller_addr, status)"
+        " VALUES ('call-2', 'ext2', '10.0.0.2:5060', 'ringing')"
+    )
+    await pool.execute(
+        "INSERT INTO calls (sip_call_id, extension, caller_addr, status,"
+        " ended_at) VALUES ('call-3', 'ext3', '10.0.0.3:5060', 'completed', now())"
+    )
+
+    count = await cleanup_stale_calls(pool)
+    assert count == 2
+
+    rows = await pool.fetch(
+        "SELECT sip_call_id, status, ended_at FROM calls ORDER BY sip_call_id"
+    )
+    by_id = {r["sip_call_id"]: r for r in rows}
+
+    assert by_id["call-1"]["status"] == "failed"
+    assert by_id["call-1"]["ended_at"] is not None
+
+    assert by_id["call-2"]["status"] == "failed"
+    assert by_id["call-2"]["ended_at"] is not None
+
+    assert by_id["call-3"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_calls_noop(pool: asyncpg.Pool) -> None:
+    """Returns 0 when there are no stale calls."""
+    count = await cleanup_stale_calls(pool)
+    assert count == 0


### PR DESCRIPTION
## Summary
- Add `cleanup_stale_calls()` to mark any `ringing`/`active` call rows as `failed` on startup
- Called right after migrations in `main.py`, before the SIP server starts
- Prevents 486 Busy responses caused by stale DB rows from a prior crash/restart

## Test plan
- [x] Unit test: stale `active`/`ringing` rows are marked `failed` with `ended_at` set
- [x] Unit test: `completed` rows are not affected
- [x] Unit test: returns 0 when no stale rows exist
- [x] All 165 tests pass, all CI checks green