### PR TITLE
Add PhoneCog for Discord voice state reconciliation

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,9 +11,10 @@ from pathlib import Path
 import aiosqlite
 from dotenv import load_dotenv
 
-from frizzle_phone.bot import create_bot, set_hangup_handler
+from frizzle_phone.bot import create_bot
 from frizzle_phone.database import cleanup_stale_calls, run_migrations
 from frizzle_phone.discord_patches import apply_discord_patches
+from frizzle_phone.phone_cog import PhoneCog
 from frizzle_phone.rtp.pcmu import pcm_to_ulaw
 from frizzle_phone.rtp.stream import SAMPLES_PER_PACKET
 from frizzle_phone.sip.server import get_server_ip, start_server
@@ -86,8 +87,8 @@ async def main() -> None:
         audio_buffers=audio_buffers,
         bot=bot,
     )
-    # Register hangup handler so bot voice-disconnect events send BYE
-    set_hangup_handler(server)
+    # Register PhoneCog for voice-disconnect events and reconciliation
+    await bot.add_cog(PhoneCog(bot, hangup_handler=server, call_state=server))
 
     # Start webapp
     app = create_app(db, bot, list(audio_buffers.keys()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ exclude = ["vulture_whitelist.py"]
 [tool.vulture]
 paths = ["src/frizzle_phone/", "main.py", "tests/", "vulture_whitelist.py"]
 min_confidence = 60
-ignore_names = ["clean_user_state", "datagram_received", "connection_made", "connection_lost", "error_received", "header_values", "event_loop", "FakeTransport", "sendto", "seeded_db", "voice_channels", "get_transport", "PhoneAudioSink", "is_opus", "cleanup", "wants_opus", "write", "row_factory", "rtp_send_loop", "_bot", "on_voice_state_update", "hangup_by_voice_channel", "_cleanup_hangup_handler"]
+ignore_names = ["clean_user_state", "datagram_received", "connection_made", "connection_lost", "error_received", "header_values", "event_loop", "FakeTransport", "sendto", "seeded_db", "voice_channels", "get_transport", "PhoneAudioSink", "is_opus", "cleanup", "wants_opus", "write", "row_factory", "rtp_send_loop", "_bot", "on_voice_state_update", "hangup_by_voice_channel", "get_bridged_calls", "cog_load", "cog_unload"]
 exclude = ["*_unit_test.py", "*_image_test.py"]
 
 [tool.ruff]

--- a/src/frizzle_phone/bot.py
+++ b/src/frizzle_phone/bot.py
@@ -1,31 +1,7 @@
 """Discord bot factory — provides guild/channel enumeration for the webapp."""
 
-import logging
-from typing import Protocol
-
 import discord
 from discord.ext import commands
-
-logger = logging.getLogger(__name__)
-
-
-class HangupHandler(Protocol):
-    def hangup_by_voice_channel(self, guild_id: int, channel_id: int) -> None: ...
-
-
-_hangup_handler: HangupHandler | None = None
-
-
-def set_hangup_handler(handler: HangupHandler) -> None:
-    """Register the hangup handler (called from main after server creation)."""
-    global _hangup_handler  # noqa: PLW0603
-    _hangup_handler = handler
-
-
-def clear_hangup_handler() -> None:
-    """Remove the hangup handler (useful for test teardown)."""
-    global _hangup_handler  # noqa: PLW0603
-    _hangup_handler = None
 
 
 def create_bot() -> commands.Bot:
@@ -33,25 +9,4 @@ def create_bot() -> commands.Bot:
     intents = discord.Intents.default()
     intents.guilds = True
     intents.voice_states = True
-    bot = commands.Bot(command_prefix="!", intents=intents)
-
-    @bot.listen("on_voice_state_update")
-    async def on_voice_state_update(
-        member: discord.Member,
-        before: discord.VoiceState,
-        after: discord.VoiceState,
-    ) -> None:
-        if bot.user is None or member.id != bot.user.id:
-            return
-        if before.channel is not None and after.channel is None:
-            if _hangup_handler is None:
-                return
-            logger.info(
-                "Bot disconnected from voice channel %s, sending BYE",
-                before.channel.id,
-            )
-            _hangup_handler.hangup_by_voice_channel(
-                before.channel.guild.id, before.channel.id
-            )
-
-    return bot
+    return commands.Bot(command_prefix="!", intents=intents)

--- a/src/frizzle_phone/phone_cog.py
+++ b/src/frizzle_phone/phone_cog.py
@@ -1,0 +1,80 @@
+"""Discord Cog for voice state reconciliation and hangup handling."""
+
+import logging
+from typing import Protocol
+
+import discord
+from discord.ext import commands, tasks
+
+logger = logging.getLogger(__name__)
+
+
+class CallStateProvider(Protocol):
+    def get_bridged_calls(self) -> list[tuple[int, int]]: ...
+
+
+class HangupHandler(Protocol):
+    def hangup_by_voice_channel(self, guild_id: int, channel_id: int) -> None: ...
+
+
+class PhoneCog(commands.Cog):
+    """Reconciles Discord voice state with SIP call state."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        hangup_handler: HangupHandler,
+        call_state: CallStateProvider,
+    ) -> None:
+        self.bot = bot
+        self._hangup_handler = hangup_handler
+        self._call_state = call_state
+
+    async def cog_load(self) -> None:
+        self._reconcile_loop.start()
+
+    async def cog_unload(self) -> None:
+        self._reconcile_loop.cancel()
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if self.bot.user is None or member.id != self.bot.user.id:
+            return
+        if before.channel is not None and after.channel is None:
+            logger.info(
+                "Bot disconnected from voice channel %s, sending BYE",
+                before.channel.id,
+            )
+            self._hangup_handler.hangup_by_voice_channel(
+                before.channel.guild.id, before.channel.id
+            )
+
+    @tasks.loop(seconds=30)
+    async def _reconcile_loop(self) -> None:
+        """Detect orphaned SIP calls whose Discord voice client is gone."""
+        connected: set[tuple[int, int]] = set()
+        for vc in self.bot.voice_clients:
+            if not isinstance(vc, discord.VoiceClient):
+                continue
+            if vc.guild is not None and vc.channel is not None:
+                connected.add((vc.guild.id, vc.channel.id))
+        bridged = self._call_state.get_bridged_calls()
+        for guild_id, channel_id in bridged:
+            if (guild_id, channel_id) not in connected:
+                logger.warning(
+                    "Orphaned call: guild=%s channel=%s "
+                    "not in voice_clients, sending BYE",
+                    guild_id,
+                    channel_id,
+                )
+                self._hangup_handler.hangup_by_voice_channel(guild_id, channel_id)
+
+    @_reconcile_loop.before_loop
+    async def _before_reconcile(self) -> None:
+        await self.bot.wait_until_ready()

--- a/src/frizzle_phone/sip/server.py
+++ b/src/frizzle_phone/sip/server.py
@@ -879,6 +879,19 @@ class SipServer(asyncio.DatagramProtocol):
         self._send(bye_msg, remote_addr)
         logger.info("Sent BYE for call %s", call_id)
 
+    def get_bridged_calls(self) -> list[tuple[int, int]]:
+        """Return (guild_id, channel_id) for all bridged calls."""
+        result: list[tuple[int, int]] = []
+        for call in self._calls.values():
+            ctx = call.discord_bridge
+            if ctx is not None:
+                result.append((ctx.guild_id, ctx.channel_id))
+                continue
+            pb = call.pending_bridge
+            if pb is not None:
+                result.append((pb.guild_id, pb.channel_id))
+        return result
+
     def hangup_by_voice_channel(self, guild_id: int, channel_id: int) -> None:
         """Hang up the SIP call bridged to a Discord voice channel."""
         for call in list(self._calls.values()):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,72 +1,9 @@
 """Tests for the Discord bot factory."""
 
-from unittest.mock import MagicMock
-
-import pytest
-
-from frizzle_phone.bot import clear_hangup_handler, create_bot, set_hangup_handler
-
-
-@pytest.fixture(autouse=True)
-def _cleanup_hangup_handler():
-    yield
-    clear_hangup_handler()
+from frizzle_phone.bot import create_bot
 
 
 def test_create_bot_intents():
     bot = create_bot()
     assert bot.intents.guilds is True
     assert bot.intents.voice_states is True
-
-
-@pytest.mark.asyncio
-async def test_voice_state_update_sends_bye_on_bot_disconnect():
-    """When bot is disconnected from voice, call hangup_by_voice_channel."""
-    bot = create_bot()
-    bot._connection.user = MagicMock(id=123)
-
-    mock_server = MagicMock()
-    set_hangup_handler(mock_server)
-
-    member = MagicMock(id=123)
-    before = MagicMock()
-    before.channel = MagicMock()
-    before.channel.guild.id = 1
-    before.channel.id = 2
-    after = MagicMock()
-    after.channel = None
-
-    # Call the handler directly
-    handler = None
-    for listener in bot.extra_events.get("on_voice_state_update", []):
-        handler = listener
-        break
-    assert handler is not None, "on_voice_state_update handler not registered"
-    await handler(member, before, after)
-
-    mock_server.hangup_by_voice_channel.assert_called_once_with(1, 2)
-
-
-@pytest.mark.asyncio
-async def test_voice_state_update_ignores_other_users():
-    """Voice state changes from non-bot users are ignored."""
-    bot = create_bot()
-    bot._connection.user = MagicMock(id=123)
-
-    mock_server = MagicMock()
-    set_hangup_handler(mock_server)
-
-    member = MagicMock(id=456)  # different user
-    before = MagicMock()
-    before.channel = MagicMock()
-    after = MagicMock()
-    after.channel = None
-
-    handler = None
-    for listener in bot.extra_events.get("on_voice_state_update", []):
-        handler = listener
-        break
-    assert handler is not None
-    await handler(member, before, after)
-
-    mock_server.hangup_by_voice_channel.assert_not_called()

--- a/tests/test_phone_cog.py
+++ b/tests/test_phone_cog.py
@@ -1,0 +1,111 @@
+"""Tests for the PhoneCog voice reconciliation cog."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from frizzle_phone.phone_cog import PhoneCog
+
+
+def _make_cog() -> tuple[PhoneCog, MagicMock, MagicMock]:
+    bot = MagicMock()
+    bot.user = MagicMock(id=123)
+    hangup = MagicMock()
+    call_state = MagicMock()
+    call_state.get_bridged_calls.return_value = []
+    cog = PhoneCog(bot, hangup_handler=hangup, call_state=call_state)
+    return cog, hangup, call_state
+
+
+def _make_voice_client(guild_id: int, channel_id: int) -> MagicMock:
+    vc = MagicMock()
+    vc.__class__ = discord.VoiceClient
+    vc.guild.id = guild_id
+    vc.channel.id = channel_id
+    return vc
+
+
+@pytest.mark.asyncio
+async def test_voice_state_update_sends_bye_on_bot_disconnect():
+    """When bot is disconnected from voice, call hangup_by_voice_channel."""
+    cog, hangup, _ = _make_cog()
+
+    member = MagicMock(id=123)
+    before = MagicMock()
+    before.channel = MagicMock()
+    before.channel.guild.id = 1
+    before.channel.id = 2
+    after = MagicMock()
+    after.channel = None
+
+    await cog.on_voice_state_update(member, before, after)
+
+    hangup.hangup_by_voice_channel.assert_called_once_with(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_voice_state_update_ignores_other_users():
+    """Voice state changes from non-bot users are ignored."""
+    cog, hangup, _ = _make_cog()
+
+    member = MagicMock(id=456)  # different user
+    before = MagicMock()
+    before.channel = MagicMock()
+    after = MagicMock()
+    after.channel = None
+
+    await cog.on_voice_state_update(member, before, after)
+
+    hangup.hangup_by_voice_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_detects_orphaned_call():
+    """Reconcile sends BYE for a bridged call with no matching voice_client."""
+    cog, hangup, call_state = _make_cog()
+    cog.bot.voice_clients = []  # type: ignore[assignment]
+    call_state.get_bridged_calls.return_value = [(1, 2)]
+
+    await cog._reconcile_loop.coro(cog)
+
+    hangup.hangup_by_voice_channel.assert_called_once_with(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_false_positives():
+    """Reconcile does not hang up when bot is in the correct voice channel."""
+    cog, hangup, call_state = _make_cog()
+
+    cog.bot.voice_clients = [_make_voice_client(1, 2)]  # type: ignore[assignment]
+    call_state.get_bridged_calls.return_value = [(1, 2)]
+
+    await cog._reconcile_loop.coro(cog)
+
+    hangup.hangup_by_voice_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_multiple_calls_only_orphans_get_bye():
+    """Only orphaned calls get BYE; connected calls are left alone."""
+    cog, hangup, call_state = _make_cog()
+
+    cog.bot.voice_clients = [_make_voice_client(1, 2)]  # type: ignore[assignment]
+
+    # Two bridged calls: one connected, one orphaned
+    call_state.get_bridged_calls.return_value = [(1, 2), (3, 4)]
+
+    await cog._reconcile_loop.coro(cog)
+
+    hangup.hangup_by_voice_channel.assert_called_once_with(3, 4)
+
+
+@pytest.mark.asyncio
+async def test_before_reconcile_waits_until_ready():
+    """_before_reconcile calls bot.wait_until_ready()."""
+    cog, _, _ = _make_cog()
+    cog.bot.wait_until_ready = AsyncMock()  # type: ignore[assignment]
+
+    await cog._before_reconcile()
+
+    cog.bot.wait_until_ready.assert_awaited_once()

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -8,7 +8,12 @@ import pytest
 
 from frizzle_phone.bridge_manager import BridgeHandle
 from frizzle_phone.sip.message import parse_message
-from frizzle_phone.sip.server import Call, DiscordBridgeContext, SipServer
+from frizzle_phone.sip.server import (
+    Call,
+    DiscordBridgeContext,
+    PendingBridge,
+    SipServer,
+)
 from frizzle_phone.sip.transaction import TxnState
 
 from .conftest import FakeTransport
@@ -187,3 +192,50 @@ async def test_voice_disconnect_sends_bye(db):
     assert call.terminated
     bye_messages = [d.decode() for d, _a in transport.sent if b"BYE" in d]
     assert len(bye_messages) == 1
+
+
+def _make_call(call_id: str = "test@10.0.0.1") -> Call:
+    return Call(
+        call_id=call_id,
+        from_tag="abc",
+        to_tag="xyz",
+        remote_addr=ADDR,
+        remote_contact=f"sip:phone@{ADDR[0]}:{ADDR[1]}",
+        remote_from="<sip:phone@10.0.0.1>",
+        remote_rtp_addr=("10.0.0.1", 20000),
+    )
+
+
+def test_get_bridged_calls_active_bridges(db):
+    """get_bridged_calls returns (guild_id, channel_id) for active bridges."""
+    server, _transport = _make_server(db)
+    call = _make_call()
+    call.discord_bridge = DiscordBridgeContext(
+        voice_client=MagicMock(),
+        guild_id=1,
+        channel_id=2,
+        handle=MagicMock(),
+    )
+    server._calls[call.call_id] = call
+
+    assert server.get_bridged_calls() == [(1, 2)]
+
+
+def test_get_bridged_calls_pending_bridges(db):
+    """get_bridged_calls includes pending bridges."""
+    server, _transport = _make_server(db)
+    call = _make_call()
+    call.pending_bridge = PendingBridge(
+        voice_client=MagicMock(),
+        guild_id=3,
+        channel_id=4,
+    )
+    server._calls[call.call_id] = call
+
+    assert server.get_bridged_calls() == [(3, 4)]
+
+
+def test_get_bridged_calls_empty(db):
+    """get_bridged_calls returns empty list when no bridges exist."""
+    server, _transport = _make_server(db)
+    assert server.get_bridged_calls() == []


### PR DESCRIPTION
## Summary
- Extract voice disconnect handling from `bot.py` into a `PhoneCog` (discord.py Cog) with `CallStateProvider` and `HangupHandler` protocols
- Add a 30s `@tasks.loop` reconciliation loop that detects orphaned SIP calls whose Discord voice client has disappeared (missed events, stale objects)
- Add `SipServer.get_bridged_calls()` to expose active/pending bridge state without leaking `_calls` internals
- Simplify `bot.py` to only export `create_bot()`

## Test plan
- [x] Voice state update sends BYE on bot disconnect (ported from test_bot.py)
- [x] Voice state update ignores other users (ported)
- [x] Reconcile detects orphaned call → sends BYE
- [x] Reconcile no false positives when bot is in channel
- [x] Reconcile handles multiple calls (only orphaned ones get BYE)
- [x] `get_bridged_calls` returns active and pending bridges
- [x] All 174 tests pass, lint/format/types/vulture clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)