### PR TITLE
Add RFCs 6026/3581/5626/4733/3389 and update lookup skill

### DIFF
--- a/.claude/skills/rfc-sip-lookup/SKILL.md
+++ b/.claude/skills/rfc-sip-lookup/SKILL.md
@@ -38,9 +38,27 @@ Combine the agents' findings into a concise answer:
 - Note any cross-references between RFCs (e.g., SIP→SDP, SIP→Digest Auth)
 - If the query is about implementation, connect the RFC requirements to what the code should do
 
+## ITU-T Recommendations
+
+Some topics reference ITU-T recs instead of IETF RFCs. These are not vendored locally but can be fetched on demand as PDFs from ITU's free access program:
+
+| Rec | Topic | Direct PDF URL |
+|-----|-------|----------------|
+| G.711 | μ-law / A-law PCM codec (8kHz, 8-bit), 9 pages | `https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-G.711-198811-I!!PDF-E&type=items` |
+| G.712 | Telephony passband (0–3.4kHz) | `https://www.itu.int/rec/T-REC-G.712/en` (landing page — find PDF link via WebFetch) |
+| G.114 | One-way delay budget (<150ms good, <400ms limit), 18 pages | `https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-G.114-200305-I!!PDF-E&type=items` |
+
+**To look up an ITU-T rec:**
+
+1. Download the PDF with curl: `curl -fsSL -o /tmp/g711.pdf "<url>"`
+2. Read it with the Read tool using the `pages` parameter (e.g., `pages: "1-9"`)
+3. Delete the PDF after use — do not vendor it: `rm /tmp/g711.pdf`
+
+The landing page URLs (`/rec/T-REC-G.xxx/en`) list versions but don't expose direct download links. Use WebFetch on the version-specific page (e.g., `/rec/T-REC-G.711-198811-I/en`) to find the `dologin_pub.asp` PDF URL if you need a rec not listed above.
+
 ## Tips
 
 - For broad queries ("how does INVITE work?"), focus on the primary sections and summarize rather than reading everything
 - For narrow queries ("what's Timer G's default value?"), target the exact line range and quote the text
 - RFC 3665 (call flow examples) is the best companion to RFC 3261 — check it for annotated message exchanges
-- The smaller RFCs (2617, 3264, 3551) can often be read in their entirety by a single agent
+- The smaller RFCs (2617, 3264, 3389, 3551, 3581) can often be read in their entirety by a single agent

--- a/.claude/skills/rfc-sip-lookup/rfc-index.md
+++ b/.claude/skills/rfc-sip-lookup/rfc-index.md
@@ -8,11 +8,16 @@ All files live in `rfcs/` relative to the project root.
 | File | RFC | Topic | Lines |
 |------|-----|-------|-------|
 | `rfc3261.txt` | 3261 | Core SIP | 15,067 |
+| `rfc6026.txt` | 6026 | INVITE Transaction Revision (Accepted state) | 1,123 |
+| `rfc3581.txt` | 3581 | rport / Symmetric Response Routing | 731 |
+| `rfc5626.txt` | 5626 | SIP Outbound / Keepalive | 2,803 |
 | `rfc2617.txt` | 2617 | HTTP Digest Authentication | 1,907 |
 | `rfc4566.txt` | 4566 | SDP (Session Description Protocol) | 2,747 |
 | `rfc3264.txt` | 3264 | SDP Offer/Answer Model | 1,403 |
 | `rfc3550.txt` | 3550 | RTP | 5,827 |
 | `rfc3551.txt` | 3551 | RTP Audio/Video Profile | 2,467 |
+| `rfc4733.txt` | 4733 | DTMF / Telephone-Event RTP Payload | 2,747 |
+| `rfc3389.txt` | 3389 | Comfort Noise RTP Payload | 451 |
 | `rfc3665.txt` | 3665 | SIP Basic Call Flow Examples | 5,267 |
 
 ---
@@ -58,6 +63,24 @@ All files live in `rfcs/` relative to the project root.
 | RFC 3261 §17.2 | `rfc3261.txt` | 7460–7867 | Server transaction overview |
 | RFC 3261 §17.2.1 | `rfc3261.txt` | 7471–7633 | INVITE server transaction state machine (Timer G/H/I) |
 | RFC 3261 §17.2.2 | `rfc3261.txt` | 7634–7678 | Non-INVITE server transaction state machine (Timer J) |
+| RFC 6026 §7 | `rfc6026.txt` | 252–566 | Change details — Accepted state for 2xx retransmission |
+| RFC 6026 §8 | `rfc6026.txt` | 567–994 | Exact changes to RFC 3261 (revised state machine figures) |
+
+## NAT Traversal & Response Routing
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3581 §3 | `rfc3581.txt` | 135–183 | Client behavior — sending rport in Via |
+| RFC 3581 §4 | `rfc3581.txt` | 184–230 | Server behavior — populating rport, response routing |
+| RFC 3581 §6 | `rfc3581.txt` | 244–296 | Example message exchange with rport |
+
+## Keepalive
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 5626 §3 | `rfc5626.txt` | 296–689 | Overview of outbound connection management |
+| RFC 5626 §4.4.1 | `rfc5626.txt` | 690–1221 | UA procedures (includes CRLF keepalive) |
+| RFC 5626 §8 | `rfc5626.txt` | 1543–1638 | STUN keep-alive processing |
 
 ## Transport
 
@@ -104,3 +127,22 @@ All files live in `rfcs/` relative to the project root.
 | RFC 3551 §4.5 | `rfc3551.txt` | 623–1630 | Audio encoding definitions |
 | RFC 3551 §4.5.14 | `rfc3551.txt` | 1538–1552 | PCMA and PCMU codec definitions |
 | RFC 3551 §6 | `rfc3551.txt` | 1756–1888 | Payload type definitions (static assignment table) |
+
+## DTMF / Telephone Events
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 4733 §2 | `rfc4733.txt` | 399–1275 | RTP payload format for named telephone events |
+| RFC 4733 §2.3 | `rfc4733.txt` | 449–600 | Payload format — header, duration, volume fields |
+| RFC 4733 §2.5 | `rfc4733.txt` | 700–900 | Redundancy and reliability of event packets |
+| RFC 4733 §3 | `rfc4733.txt` | 1276–1406 | Specification of event codes for DTMF (0-9, *, #, A-D) |
+| RFC 4733 §5 | `rfc4733.txt` | 1687–2078 | Examples (single DTMF digit, long press, multiple digits) |
+
+## Comfort Noise
+
+| Section | File | Lines | What's here |
+|---------|------|-------|-------------|
+| RFC 3389 §2 | `rfc3389.txt` | 40–77 | Introduction — CN purpose and overview |
+| RFC 3389 §3 | `rfc3389.txt` | 78–155 | CN payload definition (noise level, spectral info, packing) |
+| RFC 3389 §4 | `rfc3389.txt` | 156–179 | Usage of RTP — payload type, timestamp, marker bit |
+| RFC 3389 §5 | `rfc3389.txt` | 180–252 | Guidelines for use (VAD, transitions, SDP negotiation) |

--- a/rfcs/download.sh
+++ b/rfcs/download.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-rfcs=(3261 2617 4566 3264 3550 3551 3665)
+rfcs=(3261 2617 4566 3264 3550 3551 3665 6026 3581 5626 4733 3389)
 
 for rfc in "${rfcs[@]}"; do
     file="rfc${rfc}.txt"

--- a/rfcs/rfc3389.txt
+++ b/rfcs/rfc3389.txt
@@ -1,0 +1,451 @@
+
+
+
+
+
+
+Network Working Group                                            R. Zopf
+Request for Comments: 3389                           Lucent Technologies
+Category: Standards Track                                 September 2002
+
+
+   Real-time Transport Protocol (RTP) Payload for Comfort Noise (CN)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+Abstract
+
+   This document describes a Real-time Transport Protocol (RTP) payload
+   format for transporting comfort noise (CN).  The CN payload type is
+   primarily for use with audio codecs that do not support comfort noise
+   as part of the codec itself such as ITU-T Recommendations G.711,
+   G.726, G.727, G.728, and G.722.
+
+1. Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC-2119 [7].
+
+2. Introduction
+
+   This document describes a RTP [1] payload format for transporting
+   comfort noise.  The payload format is based on Appendix II of ITU-T
+   Recommendation G.711 [8] which defines a comfort noise payload format
+   (or bit-stream) for ITU-T G.711 [2] use in packet-based multimedia
+   communication systems.  The payload format is generic and may also be
+   used with other audio codecs without built-in Discontinuous
+   Transmission (DTX) capability such as ITU-T Recommendations G.726
+   [3], G.727 [4], G.728 [5], and G.722 [6].  The payload format
+   provides a minimum interoperability specification for communication
+   of comfort noise parameters.  The comfort noise analysis and
+   synthesis as well as the Voice Activity Detection (VAD) and DTX
+   algorithms are unspecified and left implementation-specific.
+
+
+
+
+Zopf                        Standards Track                     [Page 1]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+   However, an example solution for G.711 has been tested and is
+   described in the Appendix [8].  It uses the VAD and DTX of G.729
+   Annex B [9] and a comfort noise generation algorithm (CNG) which is
+   provided in the Appendix for information.
+
+   The comfort noise payload, which is also known as a Silence Insertion
+   Descriptor (SID) frame, consists of a single octet description of the
+   noise level and MAY contain spectral information in subsequent
+   octets.  An earlier version of the CN payload format consisting only
+   of the noise level byte was defined in draft revisions of the RFC
+   1890.  The extended payload format defined in this document should be
+   backward compatible with implementations of the earlier version
+   assuming that only the first byte is interpreted and any additional
+   spectral information bytes are ignored.
+
+3. CN Payload Definition
+
+   The comfort noise payload consists of a description of the noise
+   level and spectral information in the form of reflection coefficients
+   for an all-pole model of the noise.  The inclusion of spectral
+   information is OPTIONAL and the model order (number of coefficients)
+   is left unspecified.  The encoder may choose an appropriate model
+   order based on such considerations as quality, complexity, expected
+   environmental noise, and signal bandwidth.  The model order is not
+   explicitly transmitted since the number of coefficients can be
+   derived from the length of the payload at the receiver.  The decoder
+   may reduce the model order by setting higher order reflection
+   coefficients to zero if desired to reduce complexity or for other
+   reasons.
+
+3.1 Noise Level
+
+   The magnitude of the noise level is packed into the least significant
+   bits of the noise-level byte with the most significant bit unused and
+   always set to 0 as shown below in Figure 1.  The least significant
+   bit of the noise level magnitude is packed into the least significant
+   bit of the byte.
+
+   The noise level is expressed in -dBov, with values from 0 to 127
+   representing 0 to -127 dBov.  dBov is the level relative to the
+   overload of the system.  (Note: Representation relative to the
+   overload point of a system is particularly useful for digital
+   implementations, since one does not need to know the relative
+   calibration of the analog circuitry.)  For example, in the case of a
+   u-law system, the reference would be a square wave with values +/-
+   8031, and this square wave represents 0dBov.  This translates into
+   6.18dBm0.
+
+
+
+
+Zopf                        Standards Track                     [Page 2]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+                        0 1 2 3 4 5 6 7
+                       +-+-+-+-+-+-+-+-+
+                       |0|   level     |
+                       +-+-+-+-+-+-+-+-+
+
+                 Figure 1: Noise Level Packing
+
+3.2 Spectral Information
+
+   The spectral information is transmitted using reflection coefficients
+   [8].  Each reflection coefficient can have values between -1 and 1
+   and is quantized uniformly using 8 bits.  The quantized value is
+   represented by the 8 bit index N, where N=0..,254, and index N=255 is
+   reserved for future use.  Each index N is packed into a separate byte
+   with the MSB first.  The quantized value of each reflection
+   coefficient, k_i, can be obtained from its corresponding index using:
+
+        k_i(N_i) = 258*(N_i-127)     for N_i = 0...254; -1 < k_i < 1
+                   -------------
+                       32768
+
+3.3 Payload Packing
+
+   The first byte of the payload MUST contain the noise level as shown
+   in Figure 1.  Quantized reflection coefficients are packed in
+   subsequent bytes in ascending order as in Figure 2 where M is the
+   model order.  The total length of the payload is M+1 bytes.  Note
+   that a 0th order model (i.e., no spectral envelope information)
+   reduces to transmitting only the energy level.
+
+              Byte        1      2    3    ...   M+1
+                       +-----+-----+-----+-----+-----+
+                       |level|  N1 |  N2 | ... |  NM |
+                       +-----+-----+-----+-----+-----+
+
+                Figure 2: CN Payload Packing Format
+
+4. Usage of RTP
+
+   The RTP header for the comfort noise packet SHOULD be constructed as
+   if the comfort noise were an independent codec.  Thus, the RTP
+   timestamp designates the beginning of the comfort noise period.  When
+   this payload format is used under the RTP profile specified in RFC
+   1890 [10], a static payload type of 13 is assigned for RTP timestamp
+   clock rate of 8,000 Hz; if other rates are needed, they MUST be
+   defined through dynamic payload types.  The RTP packet SHOULD NOT
+   have the marker bit set.
+
+
+
+
+Zopf                        Standards Track                     [Page 3]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+   Each RTP packet containing comfort noise MUST contain exactly one CN
+   payload per channel.  This is required since the CN payload has a
+   variable length.  If multiple audio channels are used, each channel
+   MUST use the same spectral model order 'M'.
+
+5. Guidelines for Use
+
+   An audio codec with DTX capabilities generally includes VAD, DTX, and
+   CNG algorithms.  The job of the VAD is to discriminate between active
+   and inactive voice segments in the input signal.  During inactive
+   voice segments, the role of the CNG is to sufficiently describe the
+   ambient noise while minimizing the transmission rate.  A CN payload
+   (or SID frame) containing a description of the noise is sent to the
+   receiver to drive the CNG.  The DTX algorithm determines when a CN
+   payload is transmitted.  During active voice segments, packets of the
+   voice codec are transmitted and indicated in the RTP header by the
+   static or dynamic payload type for that codec.  At the beginning of
+   an inactive voice segment (silence period), a CN packet is
+   transmitted in the same RTP stream and indicated by the CN payload
+   type.  The CN packet update rate is left implementation specific. For
+   example, the CN packet may be sent periodically or only when there is
+   a significant change in the background noise characteristics.  The
+   CNG algorithm at the receiver uses the information in the CN payload
+   to update its noise generation model and then produce an appropriate
+   amount of comfort noise.
+
+   The CN payload format provides a minimum interoperability
+   specification for communication of comfort noise parameters.  The
+   comfort noise analysis and synthesis as well as the VAD and DTX
+   algorithms are unspecified and left implementation-specific.
+   However, an example solution for G.711 has been tested and is
+   described in Appendix II of ITU-T Recommendation G.711 [8].  It uses
+   the VAD and DTX of G.729 Annex B [9] and a comfort noise generation
+   algorithm (CNG), which is provided in the Appendix for information.
+   Additional guidelines for use such as the factors affecting system
+   performance in the design of the VAD/DTX/CNG algorithms are described
+   in the Appendix.
+
+5.1 Usage of SDP
+
+   When using the Session Description Protocol (SDP) [11] to specify RTP
+   payload information, the use of comfort noise is indicated by the
+   inclusion of a payload type for CN on the media description line.
+   When using CN with the RTP/AVP profile [10] and a codec whose RTP
+   timestamp clock rate is 8000 Hz, such as G.711 (PCMU, static payload
+   type 0), the static payload type 13 for CN can be used:
+
+         m=audio 49230 RTP/AVP 0 13
+
+
+
+Zopf                        Standards Track                     [Page 4]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+   When using CN with a codec that has a different RTP timestamp clock
+   rate, a dynamic payload type mapping (rtpmap attribute) is required.
+
+   This example shows CN used with the G.722.1 codec (see RFC 3047
+   [12]):
+
+         m=audio 49230 RTP/AVP 101 102
+         a=rtpmap:101 G7221/16000
+         a=fmtp:121 bitrate=24000
+         a=rtpmap:102 CN/16000
+
+   Omission of a payload type for CN on the media description line
+   implies that this comfort noise payload format will not be used, but
+   it does not imply that silence will not be suppressed.  RTP allows
+   discontinuous transmission (silence suppression) on any audio payload
+   format.  The receiver can detect silence suppression on the first
+   packet received after the silence by observing that the RTP timestamp
+   is not contiguous with the end of the interval covered by the
+   previous packet even though the RTP sequence number has incremented
+   only by one.  The RTP marker bit is also normally set on such a
+   packet.
+
+6. IANA Considerations
+
+   This section defines a new RTP payload name and associated MIME type,
+   CN (audio/CN).  The payload format specified in this document is also
+   assigned payload type 13 in the RTP Payload Types table of the RTP
+   Parameters registry maintained by the Internet Assigned Numbers
+   Authority (IANA).
+
+6.1 Registration of MIME media type audio/CN
+
+   MIME media type name: audio
+
+   MIME subtype name: CN
+
+   Required parameters: None
+
+   Optional parameters:
+   rate: specifies the RTP timestamp clock rate, which is usually (but
+   not always) equal to the sampling rate.  This parameter should have
+   the same value as the codec used in conjunction with comfort noise.
+   The default value is 8000.
+
+
+
+
+
+
+
+
+Zopf                        Standards Track                     [Page 5]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+   Encoding considerations:
+   This type is only defined for transfer via RTP [RFC 1889].
+
+   Security considerations: see Section 7 "Security Considerations".
+
+   Interoperability considerations: none
+
+   Published specification:
+   This document and Appendix II of ITU-T Recommendation G.711
+
+   Applications which use this media type:
+   Audio and video streaming and conferencing tools.
+
+   Additional information: none
+
+   Person & email address to contact for further information:
+   Robert Zopf
+   zopf@lucent.com
+
+   Intended usage: COMMON
+
+   Author/Change controller:
+   Author: Robert Zopf
+   Change controller: IETF AVT Working Group
+
+7. Security Considerations
+
+   RTP packets using the payload format defined in this specification
+   are subject to the security considerations discussed in the RTP
+   specification [1].  This implies that confidentiality of the media
+   streams is achieved by encryption.  Because the payload format is
+   arranged end-to-end, encryption MAY be performed after encapsulation
+   so there is no conflict between the two operations.
+
+   As this format transports background noise, there are no significant
+   security, confidentiality, or authentication concerns.
+
+8. References
+
+   [1]  Schulzrinne, H., Casner, S., Frederick, R. and V. Jacobson,
+        "RTP: A Transport Protocol for Real-Time Applications", RFC
+        1889, January 1996.
+
+   [2]  ITU Recommendation G.711 (11/88) - Pulse code modulation (PCM)
+        of voice frequencies.
+
+
+
+
+
+
+Zopf                        Standards Track                     [Page 6]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+   [3]  ITU Recommendation G.726 (12/90) - 40, 32, 24, 16 kbit/s
+        Adaptive Differential Pulse Code Modulation (ADPCM).
+
+   [4]  ITU Recommendation G.727 (12/90) - 5-, 4-, 3- and 2-bits sample
+        embedded adaptive differential pulse code modulation (ADPCM).
+
+   [5]  ITU Recommendation G.728 (09/92) - Coding of speech at 16
+        kbits/s using low-delay code excited linear prediction.
+
+   [6]  ITU Recommendation G.722 (11/88) - 7 kHz audio-coding within 64
+        kbit/s.
+
+   [7]  Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+   [8]  Appendix II to Recommendation G.711 (02/2000) - A comfort noise
+        payload definition for ITU-T G.711 use in packet-based
+        multimedia communication systems.
+
+   [9]  Annex B (08/97) to Recommendation G.729 - C source code and test
+        vectors for implementation verification of the algorithm of the
+        G.729 silence compression scheme.
+
+   [10] Schulzrinne, H., "RTP Profile for Audio and Video Conferences
+        with Minimal Control", RFC 1890, January 1996.
+
+   [11] Handley, M. and V. Jacobson, "SDP: Session Description
+        Protocol", RFC 2327, April 1998.
+
+   [12] Luthi, P., "RTP Payload Format for ITU-T Recommendation
+        G.722.1", RFC 3047, January 2001.
+
+9. Author's Address
+
+   Robert Zopf
+   Lucent Technologies
+   INS Access VoIP Networks
+   2G-234A
+   101 Crawfords Corner Rd
+   Holmdel, NJ  07733-3030  US
+
+   Phone:   1-732-949-1667
+   Fax:   1-732-949-7016
+   EMail: zopf@lucent.com
+
+
+
+
+
+
+
+Zopf                        Standards Track                     [Page 7]
+
+RFC 3389             RTP Payload for Comfort Noise        September 2002
+
+
+10. Full Copyright Statement
+
+   Copyright (C) The Internet Society (2002).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zopf                        Standards Track                     [Page 8]
+

--- a/rfcs/rfc3581.txt
+++ b/rfcs/rfc3581.txt
@@ -1,0 +1,731 @@
+
+
+
+
+
+
+Network Working Group                                       J. Rosenberg
+Request for Comments: 3581                                   dynamicsoft
+Category: Standards Track                                 H. Schulzrinne
+                                                     Columbia University
+                                                             August 2003
+
+
+       An Extension to the Session Initiation Protocol (SIP) for
+                       Symmetric Response Routing
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+Abstract
+
+   The Session Initiation Protocol (SIP) operates over UDP and TCP,
+   among others.  When used with UDP, responses to requests are returned
+   to the source address the request came from, and to the port written
+   into the topmost Via header field value of the request.  This
+   behavior is not desirable in many cases, most notably, when the
+   client is behind a Network Address Translator (NAT).  This extension
+   defines a new parameter for the Via header field, called "rport",
+   that allows a client to request that the server send the response
+   back to the source IP address and port from which the request
+   originated.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 1]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  Terminology  . . . . . . . . . . . . . . . . . . . . . . . . .  3
+   3.  Client Behavior  . . . . . . . . . . . . . . . . . . . . . . .  3
+   4.  Server Behavior  . . . . . . . . . . . . . . . . . . . . . . .  4
+   5.  Syntax . . . . . . . . . . . . . . . . . . . . . . . . . . . .  5
+   6.  Example  . . . . . . . . . . . . . . . . . . . . . . . . . . .  5
+   7.  Security Considerations  . . . . . . . . . . . . . . . . . . .  6
+   8.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . .  6
+   9.  IAB Considerations . . . . . . . . . . . . . . . . . . . . . .  6
+       9.1.  Problem Definition . . . . . . . . . . . . . . . . . . .  8
+       9.2.  Exit Strategy  . . . . . . . . . . . . . . . . . . . . .  8
+       9.3.  Brittleness Introduced by this Specification . . . . . .  9
+       9.4.  Requirements for a Long Term Solution  . . . . . . . . . 10
+       9.5.  Issues with Existing NAPT Boxes  . . . . . . . . . . . . 10
+   10. Acknowledgements . . . . . . . . . . . . . . . . . . . . . . . 10
+   11. References . . . . . . . . . . . . . . . . . . . . . . . . . . 11
+       11.1. Normative References . . . . . . . . . . . . . . . . . . 11
+       11.2. Informative References . . . . . . . . . . . . . . . . . 11
+   12. Intellectual Property and Copyright Statements . . . . . . . . 11
+   13. Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . 12
+   14. Full Copyright Statement . . . . . . . . . . . . . . . . . . . 13
+
+1.  Introduction
+
+   The Session Initiation Protocol (SIP) [1] operates over UDP and TCP.
+   When used with UDP, responses to requests are returned to the source
+   address the request came from, and to the port written into the
+   topmost Via header field value of the request.  This results in a
+   "hybrid" way of computing the destination of the response.  Half of
+   the information (specifically, the IP address) is taken from the IP
+   packet headers, and the other half (specifically, the port) from the
+   SIP message headers.  SIP operates in this manner so that a server
+   can listen for all messages, both requests and responses, on a single
+   IP address and port.  This helps improve scalability.  However, this
+   behavior is not desirable in many cases, most notably, when the
+   client is behind a NAT.  In that case, the response will not properly
+   traverse the NAT, since it will not match the binding established
+   with the request.
+
+   Furthermore, there is currently no way for a client to examine a
+   response and determine the source port that the server saw in the
+   corresponding request.  Currently, SIP provides the client with the
+   source IP address that the server saw in the request, but not the
+   port.  The source IP address is conveyed in the "received" parameter
+   in the topmost Via header field value of the response.  This
+   information has proved useful for basic NAT traversal, debugging
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 2]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+   purposes, and support of multi-homed hosts.  However, it is
+   incomplete without the port information.
+
+   This extension defines a new parameter for the Via header field,
+   called "rport", that allows a client to request that the server send
+   the response back to the source IP address and port where the request
+   came from.  The "rport" parameter is analogous to the "received"
+   parameter, except "rport" contains a port number, not the IP address.
+
+2.  Terminology
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+   and "OPTIONAL" are to be interpreted as described in BCP 14, RFC 2119
+   [2] and indicate requirement levels for compliant implementations.
+
+3.  Client Behavior
+
+   The client behavior specified here affects the transport processing
+   defined in Section 18.1 of SIP (RFC 3261) [1].
+
+   A client, compliant to this specification (clients include UACs and
+   proxies), MAY include an "rport" parameter in the top Via header
+   field value of requests it generates.  This parameter MUST have no
+   value; it serves as a flag to indicate to the server that this
+   extension is supported and requested for the transaction.
+
+   When the client sends the request, if the request is sent using UDP,
+   the client MUST be prepared to receive the response on the same IP
+   address and port it used to populate the source IP address and source
+   port of the request.  For backwards compatibility, the client MUST
+   still be prepared to receive a response on the port indicated in the
+   sent-by field of the topmost Via header field value, as specified in
+   Section 18.1.1 of SIP [1].
+
+   When there is a NAT between the client and server, the request will
+   create (or refresh) a binding in the NAT.  This binding must remain
+   in existence for the duration of the transaction in order for the
+   client to receive the response.  Most UDP NAT bindings appear to have
+   a timeout of about one minute.  This exceeds the duration of non-
+   INVITE transactions.  Therefore, responses to a non-INVITE request
+   will be received while the binding is still in existence.  INVITE
+   transactions can take an arbitrarily long amount of time to complete.
+   As a result, the binding may expire before a final response is
+   received.  To keep the binding fresh, the client SHOULD retransmit
+   its INVITE every 20 seconds or so.  These retransmissions will need
+   to take place even after receiving a provisional response.
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 3]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+   A UA MAY execute the binding lifetime discovery algorithm in Section
+   10.2 of RFC 3489 [4] to determine the actual binding lifetime in the
+   NAT.  If it is longer than 1 minute, the client SHOULD increase the
+   interval for request retransmissions up to half of the discovered
+   lifetime.  If it is shorter than one minute, it SHOULD decrease the
+   interval for request retransmissions to half of the discovered
+   lifetime.  Note that discovery of binding lifetimes can be
+   unreliable.  See Section 14.3 of RFC 3489 [4].
+
+4.  Server Behavior
+
+   The server behavior specified here affects the transport processing
+   defined in Section 18.2 of SIP [1].
+
+   When a server compliant to this specification (which can be a proxy
+   or UAS) receives a request, it examines the topmost Via header field
+   value.  If this Via header field value contains an "rport" parameter
+   with no value, it MUST set the value of the parameter to the source
+   port of the request.  This is analogous to the way in which a server
+   will insert the "received" parameter into the topmost Via header
+   field value.  In fact, the server MUST insert a "received" parameter
+   containing the source IP address that the request came from, even if
+   it is identical to the value of the "sent-by" component.  Note that
+   this processing takes place independent of the transport protocol.
+
+   When a server attempts to send a response, it examines the topmost
+   Via header field value of that response.  If the "sent-protocol"
+   component indicates an unreliable unicast transport protocol, such as
+   UDP, and there is no "maddr" parameter, but there is both a
+   "received" parameter and an "rport" parameter, the response MUST be
+   sent to the IP address listed in the "received" parameter, and the
+   port in the "rport" parameter.  The response MUST be sent from the
+   same address and port that the corresponding request was received on.
+   This effectively adds a new processing step between bullets two and
+   three in Section 18.2.2 of SIP [1].
+
+   The response must be sent from the same address and port that the
+   request was received on in order to traverse symmetric NATs.  When a
+   server is listening for requests on multiple ports or interfaces, it
+   will need to remember the one on which the request was received.  For
+   a stateful proxy, storing this information for the duration of the
+   transaction is not an issue.  However, a stateless proxy does not
+   store state between a request and its response, and therefore cannot
+   remember the address and port on which a request was received.  To
+   properly implement this specification, a stateless proxy can encode
+   the destination address and port of a request into the Via header
+   field value that it inserts.  When the response arrives, it can
+   extract this information and use it to forward the response.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 4]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+5.  Syntax
+
+   The syntax for the "rport" parameter is:
+
+   response-port = "rport" [EQUAL 1*DIGIT]
+
+   This extends the existing definition of the Via header field
+   parameters, so that its BNF now looks like:
+
+   via-params        =  via-ttl / via-maddr
+                        / via-received / via-branch
+                        / response-port / via-extension
+
+6.  Example
+
+   A client sends an INVITE to a proxy server which looks like, in part:
+
+   INVITE sip:user@example.com SIP/2.0
+   Via: SIP/2.0/UDP 10.1.1.1:4540;rport;branch=z9hG4bKkjshdyff
+
+   This INVITE is sent with a source port of 4540 and a source IP
+   address of 10.1.1.1.  The proxy is at 192.0.2.2 (proxy.example.com),
+   listening on both port 5060 and 5070.  The client sends the request
+   to port 5060.  The request passes through a NAT on the way to the
+   proxy, so that the source IP address appears as 192.0.2.1 and the
+   source port as 9988.  The proxy forwards the request, but not before
+   appending a value to the "rport" parameter in the proxied request:
+
+   INVITE sip:user@example.com SIP/2.0
+   Via: SIP/2.0/UDP proxy.example.com;branch=z9hG4bKkjsh77
+   Via: SIP/2.0/UDP 10.1.1.1:4540;received=192.0.2.1;rport=9988
+    ;branch=z9hG4bKkjshdyff
+
+   This request generates a response which arrives at the proxy:
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP proxy.example.com;branch=z9hG4bKkjsh77
+   Via: SIP/2.0/UDP 10.1.1.1:4540;received=192.0.2.1;rport=9988
+    ;branch=z9hG4bKkjshdyff
+
+   The proxy strips its top Via header field value, and then examines
+   the next one.  It contains both a "received" parameter and an "rport"
+   parameter.  The server follows the rules specified in Section 4 and
+   sends the response to IP address 192.0.2.1, port 9988, and sends it
+   from port 5060 on 192.0.2.2:
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 5]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/UDP 10.1.1.1:4540;received=192.0.2.1;rport=9988
+    ;branch=z9hG4bKkjshdyff
+
+   This packet matches the binding created by the initial request.
+   Therefore, the NAT rewrites the destination address of this packet
+   back to 10.1.1.1, and the destination port back to 4540.  It forwards
+   this response to the client, which is listening for the response on
+   that address and port.  The client properly receives the response.
+
+7.  Security Considerations
+
+   When a server uses this specification, responses that it sends will
+   now include the source port where the request came from.  In some
+   instances, the source address and port of a request are sensitive
+   information.  If they are sensitive, requests SHOULD be protected by
+   using SIP over TLS [1].  In such a case, this specification does not
+   provide any response routing functions (as these only work with TCP);
+   it merely provides the client with information about the source port
+   as seen by the server.
+
+   It is possible that an attacker might try to disrupt service to a
+   client by acting as a man-in-the-middle, modifying the "rport"
+   parameter in a Via header in a request sent by a client.  Removal of
+   this parameter will prevent clients from behind NATs from receiving
+   service.  The addition of the parameter will generally have no
+   impact.  Of course, if an attacker is capable of launching a man-in-
+   the-middle attack, there are many other ways of denying service, such
+   as merely discarding the request.  Therefore, this attack does not
+   seem significant.
+
+8.  IANA Considerations
+
+   There are no IANA considerations associated with this specification.
+
+9.  IAB Considerations
+
+   The IAB has studied a class of protocols referred to as Unilateral
+   Self Address Fixing (UNSAF) protocols [5].  These protocols allow a
+   client behind a NAT to learn the IP address and port that a NAT will
+   allocate for a particular request, in order to use this information
+   in application layer protocols.  An example of an UNSAF protocol is
+   the Simple Traversal of UDP Through NATs (STUN) [4].
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 6]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+   Any protocol is an UNSAF protocol if it reveals, to a client, the
+   source IP address and port of a packet sent through that NAT.
+   Although not designed for that purpose, this specification can be
+   used as an UNSAF protocol.  Using the "rport" parameter (defined
+   here) and the "received" parameter (defined in RFC 3261 [1]) in the
+   topmost Via header field value of a response, a client sending a
+   request can learn its address as it was seen by the server which sent
+   the response.
+
+   There are two uses of this information.  The first is for
+   registrations.  Consider a client behind a NAT wishing to register
+   with a proxy/registrar on the other side of the NAT.  The client must
+   provide, in its registration, the address at which it should receive
+   incoming SIP requests from the proxy.  However, since the client is
+   located behind a NAT, none of the addresses on any of its interfaces
+   will be reachable from the proxy.  If the client can provide the
+   proxy with an address that the proxy can reach, the client can
+   receive incoming requests.  Using this specification, a client behind
+   a NAT can learn its address and port as seen by the proxy which
+   receives a REGISTER request.  The client can then perform an
+   additional registration, using this address in a Contact header.
+   This would allow a client to receive incoming requests, such as
+   INVITE, on the IP address and port it used to populate the source IP
+   address and port of the registration it sent.  This approach will
+   only work when servers send requests to a UA from the same address
+   and port on which the REGISTER itself was received.
+
+   In many cases, the server to whom the registration is sent won't be
+   the registrar itself, but rather a proxy which then sends the request
+   to the registrar.  In such a case, any incoming requests for the
+   client must traverse the proxy to whom the registration was directly
+   sent.  The Path header extension to SIP [3] allows the proxy to
+   indicate that it must be on the path of such requests.
+
+   The second usage is for record routing, to address the same problem
+   as above, but between two proxies.  A proxy behind a NAT which
+   forwards a request to a server can use OPTIONS, for example, to learn
+   its address as seen by that server.  This address can be placed into
+   the Record-Route header field of requests sent to that server.  This
+   would allow the proxy to receive requests from that server on the
+   same IP address and port it used to populate the source IP address
+   and port of the OPTIONS request.
+
+   Because of this potential usage, this document must consider the
+   issues raised in [5].
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 7]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+9.1.  Problem Definition
+
+   From [5], any UNSAF proposal must provide:
+
+      Precise definition of a specific, limited-scope problem that is to
+      be solved with the UNSAF proposal.  A short term fix should not be
+      generalized to solve other problems; this is why "short term fixes
+      usually aren't".
+
+   This specification is primarily aimed at allowing SIP responses to be
+   received when a request is sent through a NAT.  In this primary
+   application, this specification is not an UNSAF proposal.  However,
+   as a side effect of this capability, this specification can be used
+   as an UNSAF protocol.  In that usage, it would address two issues:
+
+   o  Provide a client with an address that it could use in the Contact
+      header of a REGISTER request when it is behind a NAT.
+
+   o  Provide a proxy with an address that it could use in a Record-
+      Route header in a request, when it is behind a NAT.
+
+9.2.  Exit Strategy
+
+   From [5], any UNSAF proposal must provide:
+
+      Description of an exit strategy/transition plan.  The better short
+      term fixes are the ones that will naturally see less and less use
+      as the appropriate technology is deployed.
+
+   The SIP working group has recognized that the usage of this
+   specification to support registrations and record-routing through
+   NATs is not appropriate.  It has a number of known problems which are
+   documented below.  The way to eliminate potential usage of this
+   specification for address fixing is to provide a proper solution to
+   the problems that might motivate the usage of this specification for
+   address fixing.  Specifically, appropriate solutions for
+   registrations and record-routing in the presence of NATs need to be
+   developed.  These solutions would not rely on address fixing.
+
+   Requirements for such solutions are already under development [6].
+
+   Implementors of this specification are encouraged to follow this work
+   for better solutions for registrations and record-routing through
+   NAT.
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 8]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+9.3.  Brittleness Introduced by this Specification
+
+   From [5], any UNSAF proposal must provide:
+
+      Discussion of specific issues that may render systems more
+      "brittle".  For example, approaches that involve using data at
+      multiple network layers create more dependencies, increase
+      debugging challenges, and make it harder to transition.
+
+   This specification, if used for address fixing, introduces several
+   points of brittleness into a SIP system:
+
+   o  If used for UDP registrations, a client will need to frequently
+      re-register in order to keep the NAT bindings fresh.  In many
+      cases, these registrations will need to take place nearly one
+      hundred times more frequently than the typical refresh interval of
+      a registration.  This introduces load into the system and hampers
+      scalability.
+
+   o  A client cannot accurately determine the binding lifetime of a NAT
+      it is registering (or record-routing) through.  Therefore, there
+      may be periods of unreachability that occur between the time a
+      binding expires and the next registration or OPTIONS refresh is
+      sent.  This may result in missed calls, messages, or other
+      information.
+
+   o  If the NAT is of the symmetric variety [4], a client will only be
+      able to use its address to receive requests from the server it has
+      sent the request to.  If that server is one of many servers in a
+      cluster, the client may not be able to receive requests from other
+      servers in the cluster.  This may result in missed calls,
+      messages, or other information.
+
+   o  If the NAT is of the symmetric variety [4], a client will only be
+      able to use its address to receive requests if the server sends
+      requests to the client from the same address and port the server
+      received the registrations on.  This server behavior is not
+      mandated by RFC 3261 [1], although it appears to be common in
+      practice.
+
+   o  If the registrar and the server to whom the client sent its
+      REGISTER request are not the same, the approach will only work if
+      the server uses the Path header field [3].  There is not an easy
+      and reliable way for the server to determine that the Path header
+      should be used for a registration.  Using Path when the address in
+      the topmost Via header field is a private address will usually
+      work, but may result in usage of Path when it is not actually
+      needed.
+
+
+
+Rosenberg & Schulzrinne     Standards Track                     [Page 9]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+9.4.  Requirements for a Long Term Solution
+
+   From [5], any UNSAF proposal must provide:
+
+      Identify requirements for longer term, sound technical solutions
+      -- contribute to the process of finding the right longer term
+      solution.
+
+   The brittleness described in Section 9.3 has led us to the following
+   requirements for a long term solution:
+
+   The client should not need to specify its address.  Registrations and
+      record routing require the client to specify the address at which
+      it should receive requests.  A sound technical solution should
+      allow a client to explicitly specify that it wants to receive
+      incoming requests on the connection over which the outgoing
+      request was sent.  In this way, the client does not need to
+      specify its address.
+
+   The solution must deal with clusters of servers.  In many
+      commercially deployed SIP systems, there will be multiple servers,
+      each at different addresses and ports, handling incoming requests
+      for a client.  The solution must explicitly consider this case.
+
+   The solution must not require increases in network load.  There
+      cannot be a penalty for a sound technical solution.
+
+9.5.  Issues with Existing NAPT Boxes
+
+   From [5], any UNSAF proposal must provide:
+
+      Discussion of the impact of the noted practical issues with
+      existing, deployed NA[P]Ts and experience reports.
+
+   To our knowledge, at the time of writing, there is only very limited
+   usage of this specification for address fixing.  Therefore, no
+   specific practical issues have been raised.
+
+10.  Acknowledgements
+
+   The authors would like to thank Rohan Mahy and Allison Mankin for
+   their comments and contributions to this work.
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 10]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+11.  References
+
+11.1.  Normative References
+
+   [1] Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston, A.,
+       Peterson, J., Sparks, R., Handley, M. and E. Schooler, "SIP:
+       Session Initiation Protocol", RFC 3261, June 2002.
+
+   [2] Bradner, S., "Key words for use in RFCs to Indicate Requirement
+       Levels", BCP 14, RFC 2119, March 1997.
+
+   [3] Willis, D. and B. Hoeneisen, "Session Initiation Protocol (SIP)
+       Extension Header Field for Registering Non-Adjacent Contacts",
+       RFC 3327, December 2002.
+
+   [4] Rosenberg, J., Weinberger, J., Huitema, C. and R. Mahy, "STUN -
+       Simple Traversal of User Datagram Protocol (UDP) Through Network
+       Address Translators (NATs)", RFC 3489, March 2003.
+
+11.2.  Informative References
+
+   [5] Daigle, L., Ed., and IAB, "IAB Considerations for UNilateral
+       Self-Address Fixing (UNSAF) Across Network Address Translation",
+       RFC 3424, November 2002.
+
+   [6] Mahy, R., "Requirements for Connection Reuse in the Session
+       Initiation Protocol (SIP)", Work in Progress.
+
+12.  Intellectual Property Statement
+
+   The IETF takes no position regarding the validity or scope of any
+   intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; neither does it represent that it
+   has made any effort to identify any such rights.  Information on the
+   IETF's procedures with respect to rights in standards-track and
+   standards-related documentation can be found in BCP-11.  Copies of
+   claims of rights made available for publication and any assurances of
+   licenses to be made available, or the result of an attempt made to
+   obtain a general license or permission for the use of such
+   proprietary rights by implementors or users of this specification can
+   be obtained from the IETF Secretariat.
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 11]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights which may cover technology that may be required to practice
+   this standard.  Please address the information to the IETF Executive
+   Director.
+
+13.  Authors' Addresses
+
+   Jonathan Rosenberg
+   dynamicsoft
+   600 Lanidex Plaza
+   Parsippany, NJ  07054
+   US
+
+   Phone: +1 973 952-5000
+   EMail: jdrosen@dynamicsoft.com
+   URI:   http://www.jdrosen.net
+
+
+   Henning Schulzrinne
+   Columbia University
+   M/S 0401
+   1214 Amsterdam Ave.
+   New York, NY  10027
+   US
+
+   EMail: schulzrinne@cs.columbia.edu
+   URI:   http://www.cs.columbia.edu/~hgs
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 12]
+
+RFC 3581               Symmetric Response Routing            August 2003
+
+
+14.  Full Copyright Statement
+
+   Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assignees.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rosenberg & Schulzrinne     Standards Track                    [Page 13]
+

--- a/rfcs/rfc4733.txt
+++ b/rfcs/rfc4733.txt
@@ -1,0 +1,2747 @@
+
+
+
+
+
+
+Network Working Group                                     H. Schulzrinne
+Request for Comments: 4733                                   Columbia U.
+Obsoletes: 2833                                                T. Taylor
+Category: Standards Track                                         Nortel
+                                                           December 2006
+
+
+  RTP Payload for DTMF Digits, Telephony Tones, and Telephony Signals
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The IETF Trust (2006).
+
+Abstract
+
+   This memo describes how to carry dual-tone multifrequency (DTMF)
+   signalling, other tone signals, and telephony events in RTP packets.
+   It obsoletes RFC 2833.
+
+   This memo captures and expands upon the basic framework defined in
+   RFC 2833, but retains only the most basic event codes.  It sets up an
+   IANA registry to which other event code assignments may be added.
+   Companion documents add event codes to this registry relating to
+   modem, fax, text telephony, and channel-associated signalling events.
+   The remainder of the event codes defined in RFC 2833 are
+   conditionally reserved in case other documents revive their use.
+
+   This document provides a number of clarifications to the original
+   document.  However, it specifically differs from RFC 2833 by removing
+   the requirement that all compliant implementations support the DTMF
+   events.  Instead, compliant implementations taking part in
+   out-of-band negotiations of media stream content indicate what events
+   they support.  This memo adds three new procedures to the RFC 2833
+   framework: subdivision of long events into segments, reporting of
+   multiple events in a single packet, and the concept and reporting of
+   state events.
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 1]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+      1.1. Terminology ................................................4
+      1.2. Overview ...................................................4
+      1.3. Potential Applications .....................................5
+      1.4. Events, States, Tone Patterns, and Voice-Encoded Tones .....6
+   2. RTP Payload Format for Named Telephone Events ...................8
+      2.1. Introduction ...............................................8
+      2.2. Use of RTP Header Fields ...................................8
+           2.2.1. Timestamp ...........................................8
+           2.2.2. Marker Bit ..........................................8
+      2.3. Payload Format .............................................8
+           2.3.1. Event Field .........................................9
+           2.3.2. E ("End") Bit .......................................9
+           2.3.3. R Bit ...............................................9
+           2.3.4. Volume Field ........................................9
+           2.3.5. Duration Field ......................................9
+      2.4. Optional Media Type Parameters ............................10
+           2.4.1. Relationship to SDP ................................10
+      2.5. Procedures ................................................11
+           2.5.1. Sending Procedures .................................11
+           2.5.2. Receiving Procedures ...............................16
+      2.6. Congestion and Performance ................................19
+           2.6.1. Performance Requirements ...........................20
+           2.6.2. Reliability Mechanisms .............................20
+           2.6.3. Adjusting to Congestion ............................22
+   3. Specification of Event Codes for DTMF Events ...................23
+      3.1. DTMF Applications .........................................23
+      3.2. DTMF Events ...............................................25
+      3.3. Congestion Considerations .................................25
+   4. RTP Payload Format for Telephony Tones .........................26
+      4.1. Introduction ..............................................26
+      4.2. Examples of Common Telephone Tone Signals .................27
+      4.3. Use of RTP Header Fields ..................................27
+           4.3.1. Timestamp ..........................................27
+           4.3.2. Marker Bit .........................................27
+           4.3.3. Payload Format .....................................28
+           4.3.4. Optional Media Type Parameters .....................29
+      4.4. Procedures ................................................29
+           4.4.1. Sending Procedures .................................29
+           4.4.2. Receiving Procedures ...............................30
+           4.4.3. Handling of Congestion .............................30
+   5. Examples .......................................................31
+   6. Security Considerations ........................................38
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 2]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   7. IANA Considerations ............................................38
+      7.1. Media Type Registrations ..................................40
+           7.1.1. Registration of Media Type audio/telephone-event ...40
+           7.1.2. Registration of Media Type audio/tone ..............42
+   8. Acknowledgements ...............................................43
+   9. References .....................................................43
+      9.1. Normative References ......................................43
+      9.2. Informative References ....................................44
+   Appendix A. Summary of Changes from RFC 2833 ......................46
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 3]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+1.  Introduction
+
+1.1.  Terminology
+
+   In this document, the key words "MUST", "MUST NOT", "REQUIRED",
+   "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+   and "OPTIONAL" are to be interpreted as described in RFC 2119 [1].
+
+   This document uses the following abbreviations:
+
+   ANSam   Answer tone (amplitude modulated) [24]
+
+   DTMF    Dual-Tone Multifrequency [10]
+
+   IVR     Interactive Voice Response unit
+
+   PBX     Private branch exchange (telephone system)
+
+   PSTN    Public Switched (circuit) Telephone Network
+
+   RTP     Real-time Transport Protocol [5]
+
+   SDP     Session Description Protocol [9]
+
+1.2.  Overview
+
+   This memo defines two RTP [5] payload formats, one for carrying
+   dual-tone multifrequency (DTMF) digits and other line and trunk
+   signals as events (Section 2), and a second one to describe general
+   multifrequency tones in terms only of their frequency and cadence
+   (Section 4).  Separate RTP payload formats for telephony tone signals
+   are desirable since low-rate voice codecs cannot be guaranteed to
+   reproduce these tone signals accurately enough for automatic
+   recognition.  In addition, tone properties such as the phase
+   reversals in the ANSam tone will not survive speech coding.  Defining
+   separate payload formats also permits higher redundancy while
+   maintaining a low bit rate.  Finally, some telephony events such as
+   "on-hook" occur out-of-band and cannot be transmitted as tones.
+
+   The remainder of this section provides the motivation for defining
+   the payload types described in this document.  Section 2 defines the
+   payload format and associated procedures for use of named events.
+   Section 3 describes the events for which event codes are defined in
+   this document.  Section 4 describes the payload format and associated
+   procedures for tone representations.  Section 5 provides some
+   examples of encoded events, tones, and combined payloads.  Section 6
+   deals with security considerations.  Section 7 defines the IANA
+   requirements for registration of event codes for named telephone
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 4]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   events, establishes the initial content of that registry, and
+   provides the media type registrations for the two payload formats.
+   Appendix A describes the changes from RFC 2833 [12] and in particular
+   indicates the disposition of the event codes defined in [12].
+
+1.3.  Potential Applications
+
+   The payload formats described here may be useful in a number of
+   different scenarios.
+
+   On the sending side, there are two basic possibilities: either the
+   sending side is an end system that originates the signals itself, or
+   it is a gateway with the task of propagating incoming telephone
+   signals into the Internet.
+
+   On the receiving side, there are more possibilities.  The first is
+   that the receiver must propagate tone signalling accurately into the
+   PSTN for machine consumption.  One example of this is a gateway
+   passing DTMF tones to an IVR.  In this scenario, frequencies,
+   amplitudes, tone durations, and the durations of pauses between tones
+   are all significant, and individual tone signals must be delivered
+   reliably and in order.
+
+   In a second receiving scenario, the receiver must play out tones for
+   human consumption.  Typically, rather than a series of tone signals
+   each with its own meaning, the content will consist of a single tone
+   played out continuously or a single sequence of tones and possibly
+   silence, repeated cyclically for some period of time.  Often the end
+   of the tone playout will be triggered by an event fed back in the
+   other direction, using either in- or out-of-band means.  Examples of
+   this are dial tone or busy tone.
+
+   The relationship between position in the network and the tones to be
+   played out is a complicating factor in this scenario.  In the phone
+   network, tones are generated at different places, depending on the
+   switching technology and the nature of the tone.  This determines,
+   for example, whether a person making a call to a foreign country
+   hears her local tones she is familiar with or the tones as used in
+   the country called.
+
+   For analog lines, dial tone is always generated by the local switch.
+   Integrated Services Digital Network (ISDN) terminals may generate
+   dial tone locally and then send a Q.931 [22] SETUP message containing
+   the dialed digits.  If the terminal just sends a SETUP message
+   without any Called Party digits, then the switch does digit
+   collection (provided by the terminal as KEYPAD key press digit
+   information within Called Party or Keypad Facility Information
+   Elements (IEs) of INFORMATION messages), and provides dial tone over
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 5]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   the B-channel.  The terminal can either use the audio signal on the
+   B-channel or use the Q.931 messages to trigger locally generated dial
+   tone.
+
+   Ringing tone (also called ringback tone) is generated by the local
+   switch at the callee, with a one-way voice path opened up as soon as
+   the callee's phone rings.  (This reduces the chance of clipping the
+   called party's response just after answer.  It also permits pre-
+   answer announcements or in-band call-progress indications to reach
+   the caller before or in lieu of a ringing tone.)  Congestion tone and
+   special information tones can be generated by any of the switches
+   along the way, and may be generated by the caller's switch based on
+   ISDN User Part (ISUP) messages received.  Busy tone is generated by
+   the caller's switch, triggered by the appropriate ISUP message, for
+   analog instruments, or the ISDN terminal.
+
+   In the third scenario, an end system is directly connected to the
+   Internet and processes the incoming media stream directly.  There is
+   no need to regenerate tone signals, so that time alignment and power
+   levels are not relevant.  These systems rely on sending systems to
+   generate events in place of tones and do not perform their own audio
+   waveform analysis.  An example of such a system is an Internet
+   interactive voice response (IVR) system.
+
+   In circumstances where exact timing alignment between the audio
+   stream and the DTMF digits or other events is not important and data
+   is sent unicast, as in the IVR example, it may be preferable to use a
+   reliable control protocol rather than RTP packets.  In those
+   circumstances, this payload format would not be used.
+
+   Note that in a number of these cases it is possible that the gateway
+   or end system will be both a sender and receiver of telephone
+   signals.  Sometimes the same class of signals will be sent as
+   received -- in the case of "RTP trunking" or voice-band data, for
+   instance.  In other cases, such as that of an end system serving
+   analogue lines, the signals sent will be in a different class from
+   those received.
+
+1.4.  Events, States, Tone Patterns, and Voice-Encoded Tones
+
+   This document provides the means for in-band transport over the
+   Internet of two broad classes of signalling information: in-band
+   tones or tone sequences, and signals sent out-of-band in the PSTN.
+   Tone signals can be carried using any of the three methods listed
+   below.  Depending on the application, it may be desirable to carry
+   the signalling information in more than one form at once.
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 6]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   1.  The gateway or end system can change to a higher-bandwidth codec
+       such as G.711 [19] when tone signals are to be conveyed.  See new
+       ITU-T Recommendation V.152 [26] for a formal treatment of this
+       approach.  Alternatively, for fax, text, or modem signals
+       respectively, a specialized transport such as T.38 [23], RFC 4103
+       [15], or V.150.1 modem relay [25] may be used.  Finally, 64
+       kbit/s channels may be carried transparently using the RFC 4040
+       Clearmode payload type [14].  These methods are out of scope of
+       the present document, but may be used along with the payload
+       types defined here.
+
+   2.  The sending gateway can simply measure the frequency components
+       of the voice-band signals and transmit this information to the
+       RTP receiver using the tone representation defined in this
+       document (Section 4).  In this mode, the gateway makes no attempt
+       to discern the meaning of the tones, but simply distinguishes
+       tones from speech signals.  An end system may use the same
+       approach using configured rather than measured frequencies.
+
+       All tone signals in use in the PSTN and meant for human
+       consumption are sequences of simple combinations of sine waves,
+       either added or modulated.  (However, some modem signals such as
+       the ANSam tone [24] or systems dependent on phase shift keying
+       cannot be conveyed so simply.)
+
+   3.  As a third option, a sending gateway can recognize tones such as
+       ringing or busy tone or DTMF digit '0', and transmit a code that
+       identifies them using the telephone-event payload defined in this
+       document (Section 2).  The receiver then produces a tone signal
+       or other indication appropriate to the signal.  Generally, since
+       the recognition of signals at the sender often depends on their
+       on/off pattern or the sequence of several tones, this recognition
+       can take several seconds.  On the other hand, the gateway may
+       have access to the actual signalling information that generates
+       the tones and thus can generate the RTP packet immediately,
+       without the detour through acoustic signals.
+
+   The third option (use of named events) is the only feasible method
+   for transmitting out-of-band PSTN signals as content within RTP
+   sessions.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 7]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.  RTP Payload Format for Named Telephone Events
+
+2.1.  Introduction
+
+   The RTP payload format for named telephone events is designated as
+   "telephone-event", the media type as "audio/telephone-event".  In
+   accordance with current practice, this payload format does not have a
+   static payload type number, but uses an RTP payload type number
+   established dynamically and out-of-band.  The default clock frequency
+   is 8000 Hz, but the clock frequency can be redefined when assigning
+   the dynamic payload type.
+
+   Named telephone events are carried as part of the audio stream and
+   MUST use the same sequence number and timestamp base as the regular
+   audio channel to simplify the generation of audio waveforms at a
+   gateway.  The named telephone-event payload type can be considered to
+   be a very highly-compressed audio codec and is treated the same as
+   other codecs.
+
+2.2.  Use of RTP Header Fields
+
+2.2.1.  Timestamp
+
+   The event duration described in Section 2.5 begins at the time given
+   by the RTP timestamp.  For events that span multiple RTP packets, the
+   RTP timestamp identifies the beginning of the event, i.e., several
+   RTP packets may carry the same timestamp.  For long-lasting events
+   that have to be split into segments (see below, Section 2.5.1.3), the
+   timestamp indicates the beginning of the segment.
+
+2.2.2.  Marker Bit
+
+   The RTP marker bit indicates the beginning of a new event.  For long-
+   lasting events that have to be split into segments (see below,
+   Section 2.5.1.3), only the first segment will have the marker bit
+   set.
+
+2.3.  Payload Format
+
+   The payload format for named telephone events is shown in Figure 1.
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     event     |E|R| volume    |          duration             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                 Figure 1: Payload Format for Named Events
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 8]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.3.1.  Event Field
+
+   The event field is a number between 0 and 255 identifying a specific
+   telephony event.  An IANA registry of event codes for this field has
+   been established (see IANA Considerations, Section 7).  The initial
+   content of this registry consists of the events defined in Section 3.
+
+2.3.2.  E ("End") Bit
+
+   If set to a value of one, the "end" bit indicates that this packet
+   contains the end of the event.  For long-lasting events that have to
+   be split into segments (see below, Section 2.5.1.3), only the final
+   packet for the final segment will have the E bit set.
+
+2.3.3.  R Bit
+
+   This field is reserved for future use.  The sender MUST set it to
+   zero, and the receiver MUST ignore it.
+
+2.3.4.  Volume Field
+
+   For DTMF digits and other events representable as tones, this field
+   describes the power level of the tone, expressed in dBm0 after
+   dropping the sign.  Power levels range from 0 to -63 dBm0.  Thus,
+   larger values denote lower volume.  This value is defined only for
+   events for which the documentation indicates that volume is
+   applicable.  For other events, the sender MUST set volume to zero and
+   the receiver MUST ignore the value.
+
+2.3.5.  Duration Field
+
+   The duration field indicates the duration of the event or segment
+   being reported, in timestamp units, expressed as an unsigned integer
+   in network byte order.  For a non-zero value, the event or segment
+   began at the instant identified by the RTP timestamp and has so far
+   lasted as long as indicated by this parameter.  The event may or may
+   not have ended.  If the event duration exceeds the maximum
+   representable by the duration field, the event is split into several
+   contiguous segments as described below (Section 2.5.1.3).
+
+   The special duration value of zero is reserved to indicate that the
+   event lasts "forever", i.e., is a state and is considered to be
+   effective until updated.  A sender MUST NOT transmit a zero duration
+   for events other than those defined as states.  The receiver SHOULD
+   ignore an event report with zero duration if the event is not a
+   state.
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                     [Page 9]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Events defined as states MAY contain a non-zero duration, indicating
+   that the sender intends to refresh the state before the time duration
+   has elapsed ("soft state").
+
+      For a sampling rate of 8000 Hz, the duration field is sufficient
+      to express event durations of up to approximately 8 seconds.
+
+2.4.  Optional Media Type Parameters
+
+   As indicated in the media type registration for named events in
+   Section 7.1.1, the telephone-event media type supports two optional
+   parameters: the "events" parameter and the "rate" parameter.
+
+   The "events" parameter lists the events supported by the
+   implementation.  Events are listed as one or more comma-separated
+   elements.  Each element can be either a single integer providing the
+   value of an event code or an integer followed by a hyphen and a
+   larger integer, presenting a range of consecutive event code values.
+   The list does not have to be sorted.  No white space is allowed in
+   the argument.  The union of all of the individual event codes and
+   event code ranges designates the complete set of event numbers
+   supported by the implementation.
+
+   The "rate" parameter describes the sampling rate, in Hertz, and hence
+   the units for the RTP timestamp and event duration fields.  The
+   number is written as an integer.  If omitted, the default value is
+   8000 Hz.
+
+2.4.1.  Relationship to SDP
+
+   The recommended mapping of media type optional parameters to SDP is
+   given in Section 3 of RFC 3555 [6].  The "rate" media type parameter
+   for the named event payload type follows this convention: it is
+   expressed as usual as the <clock rate> component of the a=rtpmap:
+   attribute line.
+
+   The "events" media type parameter deviates from the convention
+   suggested in RFC 3555 because it omits the string "events=" before
+   the list of supported events.
+
+      a=fmtp:<format> <list of values>
+
+   The list of values has the format and meaning described above.
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 10]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   For example, if the payload format uses the payload type number 100,
+   and the implementation can handle the DTMF tones (events 0 through
+   15) and the dial and ringing tones (assuming as an example that these
+   were defined as events with codes 66 and 70, respectively), it would
+   include the following description in its SDP message:
+
+      m=audio 12346 RTP/AVP 100
+      a=rtpmap:100 telephone-event/8000
+      a=fmtp:100 0-15,66,70
+
+   The following sample media type definition corresponds to the SDP
+   example above:
+
+      audio/telephone-event;events="0-15,66,70";rate="8000"
+
+2.5.  Procedures
+
+   This section defines the procedures associated with the named event
+   payload type.  Additional procedures may be specified in the
+   documentation associated with specific event codes.
+
+2.5.1.  Sending Procedures
+
+2.5.1.1.  Negotiation of Payloads
+
+   Events are usually sent in combination with or alternating with other
+   payload types.  Payload negotiation may specify separate event and
+   other payload streams, or it may specify a combined stream that mixes
+   other payload types with events using RFC 2198 [2] redundancy
+   headers.  The purpose of using a combined stream may be for debugging
+   or to ease the transition between general audio and events.
+
+   Negotiation of payloads between sender and receiver is achieved by
+   out-of-band means, using SDP, for example.
+
+   The sender SHOULD indicate what events it supports, using the
+   optional "events" parameter associated with the telephone-event media
+   type.  If the sender receives an "events" parameter from the
+   receiver, it MUST restrict the set of events it sends to those listed
+   in the received "events" parameter.  For backward compatibility, if
+   no "events" parameter is received, the sender SHOULD assume support
+   for the DTMF events 0-15 but for no other events.
+
+   Events MAY be sent in combination with older events using RFC 2198
+   [2] redundancy.  Section 2.5.1.4 describes how this can be used to
+   avoid packet and RTP header overheads when retransmitting final event
+   reports.  Section 2.6 discusses the use of additional levels of RFC
+   2198 redundancy to increase the probability that at least one copy of
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 11]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   the report of the end of an event reaches the receiver.  The
+   following SDP shows an example of such usage, where G.711 audio
+   appears in a separate stream, and the primary component of the
+   redundant payload is events.
+
+      m=audio 12344 RTP/AVP 99
+      a=rtpmap:99 pcmu/8000
+      m=audio 12346 RTP/AVP 100 101
+      a=rtpmap:100 red/8000/1
+      a=fmtp:100 101/101/101
+      a=rtpmap:101 telephone-event/8000
+      a=fmtp:101 0-15
+
+   When used in accordance with the offer-answer model (RFC 3264 [4]),
+   the SDP a=ptime: attribute indicates the packetization period that
+   the author of the session description expects when receiving media.
+   This value does not have to be the same in both directions.  The
+   appropriate period may vary with the application, since increased
+   packetization periods imply increased end-to-end response times in
+   instances where one end responds to events reported from the other.
+
+   Negotiation of telephone-events sessions using SDP MAY specify such
+   differences by separating events corresponding to different
+   applications into different streams.  In the example below, events
+   0-15 are DTMF events, which have a fairly wide tolerance on timing.
+   Events 32-49 and 52-60 are events related to data transmission and
+   are subject to end-to-end response time considerations.  As a result,
+   they are assigned a smaller packetization period than the DTMF
+   events.
+
+      m=audio 12344 RTP/AVP 99
+      a=rtpmap:99 telephone-event/8000
+      a=fmtp:99 0-15
+      a=ptime:50
+      m=audio 12346 RTP/AVP 100
+      a=rtpmap:100 telephone-event/8000
+      a=fmtp:100 32-49,52-60
+      a=ptime:30
+
+   For further discussion of packetization periods see Section 2.6.3.
+
+2.5.1.2.  Transmission of Event Packets
+
+   DTMF digits and other named telephone events are carried as part of
+   the audio stream, and they MUST use the same sequence number and
+   timestamp base as the regular audio channel to simplify the
+   generation of audio waveforms at a gateway.
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 12]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   An audio source SHOULD start transmitting event packets as soon as it
+   recognizes an event and continue to send updates until the event has
+   ended.  The update packets MUST have the same RTP timestamp value as
+   the initial packet for the event, but the duration MUST be increased
+   to reflect the total cumulative duration since the beginning of the
+   event.
+
+   The first packet for an event MUST have the M bit set.  The final
+   packet for an event MUST have the E bit set, but setting of the "E"
+   bit MAY be deferred until the final packet is retransmitted (see
+   Section 2.5.1.4).  Intermediate packets for an event MUST NOT have
+   either the M bit or the E bit set.
+
+   Sending of a packet with the E bit set is OPTIONAL if the packet
+   reports two events that are defined as mutually exclusive states, or
+   if the final packet for one state is immediately followed by a packet
+   reporting a mutually exclusive state.  (For events defined as states,
+   the appearance of a mutually exclusive state implies the end of the
+   previous state.)
+
+   A source has wide latitude as to how often it sends event updates.  A
+   natural interval is the spacing between non-event audio packets.
+   (Recall that a single RTP packet can contain multiple audio frames
+   for frame-based codecs and that the packet interval can vary during a
+   session.)  Alternatively, a source MAY decide to use a different
+   spacing for event updates, with a value of 50 ms RECOMMENDED.
+
+   Timing information is contained in the RTP timestamp, allowing
+   precise recovery of inter-event times.  Thus, the sender does not in
+   theory need to maintain precise or consistent time intervals between
+   event packets.  However, the sender SHOULD minimize the need for
+   buffering at the receiving end by sending event reports at constant
+   intervals.
+
+      DTMF digits and other tone events are sent incrementally to avoid
+      having the receiver wait for the completion of the event.  In some
+      cases (for example, data session startup protocols), waiting until
+      the end of a tone before reporting it will cause the session to
+      fail.  In other cases, it will simply cause undesirable delays in
+      playout at the receiving end.
+
+   For robustness, the sender SHOULD retransmit "state" events
+   periodically.
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 13]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.5.1.3.  Long-Duration Events
+
+   If an event persists beyond the maximum duration expressible in the
+   duration field (0xFFFF), the sender MUST send a packet reporting this
+   maximum duration but MUST NOT set the E bit in this packet.  The
+   sender MUST then begin reporting a new "segment" with the RTP
+   timestamp set to the time at which the previous segment ended and the
+   duration set to the cumulative duration of the new segment.  The M
+   bit of the first packet reporting the new segment MUST NOT be set.
+   The sender MUST repeat this procedure as required until the end of
+   the complete event has been reached.  The final packet for the
+   complete event MUST have the E bit set (either on initial
+   transmission or on retransmission as described below).
+
+2.5.1.3.1.  Exceptional Procedure for Combined Payloads
+
+   If events are combined as a redundant payload with another payload
+   type using RFC 2198 [2] redundancy, the above procedure SHALL be
+   applied, but using a maximum duration that ensures that the timestamp
+   offset of the oldest generation of events in an RFC 2198 packet never
+   exceeds 0x3FFF.  If the sender is using a constant packetization
+   period, the maximum segment duration can be calculated from the
+   following formula:
+
+      maximum duration = 0x3FFF - (R-1)*(packetization period in
+      timestamp units)
+
+   where R is the highest redundant layer number consisting of event
+   payload.
+
+      The RFC 2198 redundancy header timestamp offset value is only 14
+      bits, compared with the 16 bits in the event payload duration
+      field.  Since with other payloads the RTP timestamp typically
+      increments for each new sample, the timestamp offset value becomes
+      limiting on reported event duration.  The limit becomes more
+      constraining when older generations of events are also included in
+      the combined payload.
+
+2.5.1.4.  Retransmission of Final Packet
+
+   The final packet for each event and for each segment SHOULD be sent a
+   total of three times at the interval used by the source for updates.
+   This ensures that the duration of the event or segment can be
+   recognized correctly even if an instance of the last packet is lost.
+
+   A sender MAY use RFC 2198 [2] with up to two levels of redundancy to
+   combine retransmissions with reports of new events, thus saving on
+   header overheads.  In this usage, the primary payload is new event
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 14]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   reports, while the first and (if necessary) second levels of
+   redundancy report first and second retransmissions of final event
+   reports.  Within a session negotiated to allow such usage, packets
+   containing the RFC 2198 payload SHOULD NOT be sent except when both
+   primary and retransmitted reports are to be included.  All other
+   packets of the session SHOULD contain only the simple, non-redundant
+   telephone-event payload.  Note that the expected proportion of simple
+   versus redundant packets affects the order in which they should be
+   specified on an SDP m= line.
+
+      There is little point in sending initial or interim event reports
+      redundantly because each succeeding packet describes the event
+      fully (except for typically irrelevant variations in volume).
+
+   A sender MAY delay setting the E bit until retransmitting the last
+   packet for a tone, rather than setting the bit on its first
+   transmission.  This avoids having to wait to detect whether the tone
+   has indeed ended.  Once the sender has set the E bit for a packet, it
+   MUST continue to set the E bit for any further retransmissions of
+   that packet.
+
+2.5.1.5.  Packing Multiple Events into One Packet
+
+   Multiple named events can be packed into a single RTP packet if and
+   only if the events are consecutive and contiguous, i.e., occur
+   without overlap and without pause between them, and if the last event
+   packed into a packet occurs quickly enough to avoid excessive delays
+   at the receiver.
+
+   This approach is similar to having multiple frames of frame-based
+   audio in one RTP packet.
+
+   The constraint that packed events not overlap implies that events
+   designated as states can be followed in a packet only by other state
+   events that are mutually exclusive to them.  The constraint itself is
+   needed so that the beginning time of each event can be calculated at
+   the receiver.
+
+   In a packet containing events packed in this way, the RTP timestamp
+   MUST identify the beginning of the first event or segment in the
+   packet.  The M bit MUST be set if the packet records the beginning of
+   at least one event.  (This will be true except when the packet
+   carries the end of one segment and the beginning of the next segment
+   of the same long-lasting event.)  The E bit and duration for each
+   event in the packet MUST be set using the same rules as if that event
+   were the only event contained in the packet.
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 15]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.5.1.6.  RTP Sequence Number
+
+   The RTP sequence number MUST be incremented by one in each successive
+   RTP packet sent.  Incrementing applies to retransmitted as well as
+   initial instances of event reports, to permit the receiver to detect
+   lost packets for RTP Control Protocol (RTCP) receiver reports.
+
+2.5.2.  Receiving Procedures
+
+2.5.2.1.  Indication of Receiver Capabilities Using SDP
+
+   Receivers can indicate which named events they can handle, for
+   example, by using the Session Description Protocol (RFC 4566 [9]).
+   SDP descriptions using the event payload MUST contain an fmtp format
+   attribute that lists the event values that the receiver can process.
+
+2.5.2.2.  Playout of Tone Events
+
+   In the gateway scenario, an Internet telephony gateway connecting a
+   packet voice network to the PSTN re-creates the DTMF or other tones
+   and injects them into the PSTN.  Since, for example, DTMF digit
+   recognition takes several tens of milliseconds, the first few
+   milliseconds of a digit will arrive as regular audio packets.  Thus,
+   careful time and power (volume) alignment between the audio samples
+   and the events is needed to avoid generating spurious digits at the
+   receiver.  The receiver may also choose to delay playout of the tones
+   by some small interval after playout of the preceding audio has
+   ended, to ensure that downstream equipment can discriminate the tones
+   properly.
+
+   Some implementations send events and encoded audio packets (e.g.,
+   PCMU or the codec used for speech signals) for the same time instant
+   for the duration of the event.  It is RECOMMENDED that gateways
+   render only the telephone-event payload once it is received, since
+   the audio may contain spurious tones introduced by the audio
+   compression algorithm.  However, it is anticipated that these extra
+   tones in general should not interfere with recognition at the far
+   end.
+
+   Receiver implementations MAY use different algorithms to create
+   tones, including the two described here.  (Note that not all
+   implementations have the need to re-create a tone; some may only care
+   about recognizing the events.)  With either algorithm, a receiver may
+   impose a playout delay to provide robustness against packet loss or
+   delay.  The tradeoff between playout delay and other factors is
+   discussed further in Section 2.6.3.
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 16]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   In the first algorithm, the receiver simply places a tone of the
+   given duration in the audio playout buffer at the location indicated
+   by the timestamp.  As additional packets are received that extend the
+   same tone, the waveform in the playout buffer is extended
+   accordingly.  (Care has to be taken if audio is mixed, i.e., summed,
+   in the playout buffer rather than simply copied.)  Thus, if a packet
+   in a tone lasting longer than the packet interarrival time gets lost
+   and the playout delay is short, a gap in the tone may occur.
+
+   Alternatively, the receiver can start a tone and play it until one of
+   the following occurs:
+
+   o  it receives a packet with the E bit set;
+
+   o  it receives the next tone, distinguished by a different timestamp
+      value (noting that new segments of long-duration events also
+      appear with a new timestamp value);
+
+   o  it receives an alternative non-event media stream (assuming none
+      was being received while the event stream was active); or
+
+   o  a given time period elapses.
+
+   This is more robust against packet loss, but may extend the tone
+   beyond its original duration if all retransmissions of the last
+   packet in an event are lost.  Limiting the time period of extending
+   the tone is necessary to avoid that a tone "gets stuck".  This
+   algorithm is not a license for senders to set the duration field to
+   zero; it MUST be set to the current duration as described, since this
+   is needed to create accurate events if the first event packet is
+   lost, among other reasons.
+
+   Regardless of the algorithm used, the tone SHOULD NOT be extended by
+   more than three packet interarrival times.  A slight extension of
+   tone durations and shortening of pauses is generally harmless.
+
+   A receiver SHOULD NOT restart a tone once playout has stopped.  It
+   MAY do so if the tone is of a type meant for human consumption or is
+   one for which interruptions will not cause confusion at the receiving
+   device.
+
+   If a receiver receives an event packet for an event that it is not
+   currently playing out and the packet does not have the M bit set,
+   earlier packets for that event have evidently been lost.  This can be
+   confirmed by gaps in the RTP sequence number.  The receiver MAY
+   determine on the basis of retained history and the timestamp and
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 17]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   event code of the current packet that it corresponds to an event
+   already played out and lapsed.  In that case, further reports for the
+   event MUST be ignored, as indicated in the previous paragraph.
+
+   If, on the other hand, the event has not been played out at all, the
+   receiver MAY attempt to play the event out to the complete duration
+   indicated in the event report.  The appropriate behavior will depend
+   on the event type, and requires consideration of the relationship of
+   the event to audio media flows and whether correct event duration is
+   essential to the correct operation of the media session.
+
+   A receiver SHOULD NOT rely on a particular event packet spacing, but
+   instead MUST use the event timestamps and durations to determine
+   timing and duration of playout.
+
+   The receiver MUST calculate jitter for RTCP receiver reports based on
+   all packets with a given timestamp.  Note: The jitter value should
+   primarily be used as a means for comparing the reception quality
+   between two users or two time periods, not as an absolute measure.
+
+   If a zero volume is indicated for an event for which the volume field
+   is defined, then the receiver MAY reconstruct the volume from the
+   volume of non-event audio or MAY use the nominal value specified by
+   the ITU Recommendation or other document defining the tone.  This
+   ensures backwards compatibility with RFC 2833 [12], where the volume
+   field was defined only for DTMF events.
+
+2.5.2.3.  Long-Duration Events
+
+   If an event report is received with duration equal to the maximum
+   duration expressible in the duration field (0xFFFF) and the E bit for
+   the report is not set, the event report may mark the end of a segment
+   generated according to the procedures of Section 2.5.1.3.  If another
+   report for the same event type is received, the receiver MUST compare
+   the RTP timestamp for the new event with the sum of the RTP timestamp
+   of the previous report plus the duration (0xFFFF).  The receiver uses
+   the absence of a gap between the events to detect that it is
+   receiving a single long-duration event.
+
+   The total duration of a long-duration event is (obviously) the sum of
+   the durations of the segments used to report it.  This is equal to
+   the duration of the final segment (as indicated in the final packet
+   for that segment), plus 0xFFFF multiplied by the number of segments
+   preceding the final segment.
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 18]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.5.2.3.1.  Exceptional Procedure for Combined Payloads
+
+   If events are combined as a redundant payload with another payload
+   type using RFC 2198 [2] redundancy, segments are generated at
+   intervals of 0x3FFF or less, rather than 0xFFFF, as required by the
+   procedures of Section 2.5.1.3.1 in this case.  If a receiver is using
+   the events component of the payload, event duration may be only an
+   approximate indicator of division into segments, but the lack of an E
+   bit and the adjacency of two reports with the same event code are
+   strong indicators in themselves.
+
+2.5.2.4.  Multiple Events in a Packet
+
+   The procedures of Section 2.5.1.5 require that if multiple events are
+   reported in the same packet, they are contiguous and non-overlapping.
+   As a result, it is not strictly necessary for the receiver to know
+   the start times of the events following the first one in order to
+   play them out -- it needs only to respect the duration reported for
+   each event.  Nevertheless, if knowledge of the start time for a given
+   event after the first one is required, it is equal to the sum of the
+   start time of the preceding event plus the duration of the preceding
+   event.
+
+2.5.2.5.  Soft States
+
+   If the duration of a soft state event expires, the receiver SHOULD
+   consider the value of the state to be "unknown" unless otherwise
+   indicated in the event documentation.
+
+2.6.  Congestion and Performance
+
+   Packet transmission through the Internet is marked by occasional
+   periods of congestion lasting on the order of second, during which
+   network delay, jitter, and packet loss are all much higher than they
+   are in between these periods.  Reference [28] characterizes this
+   phenomenon.  Well-behaved applications are expected, preferably, to
+   reduce their demands on the network during such periods of
+   congestion.  At the least, they should not increase their demands.
+   This section explores both application performance and the
+   possibilities for good behavior in the face of congestion.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 19]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+2.6.1.  Performance Requirements
+
+   Typically, an implementation of the telephone-event payload will aim
+   to limit the rate at which each of the following impairments occurs:
+
+   a.  an event encoded at the sender fails to be played out at the
+       receiver, either because the event report is lost or because it
+       arrives after playout of later content has started;
+
+   b.  the start of playout of an event at the receiver is delayed
+       relative to other events or other media operating on the same
+       timestamp base;
+
+   c.  the duration of playout of a given event differs from the correct
+       duration as detected at the sender by more than a given amount;
+
+   d.  gaps occur in playout of a given event;
+
+   e.  end-to-end delay for the media stream exceeds a given value.
+
+   The relative importance of these constraints varies between
+   applications.
+
+2.6.2.  Reliability Mechanisms
+
+   To improve reliability, all payload types including telephone-events
+   can use a jitter buffer, i.e., impose a playout delay, at the
+   receiving end.  This mechanism addresses the first four requirements
+   listed above, but at the expense of the last one.
+
+   The named event procedures provide two complementary redundancy
+   mechanisms to deal with lost packets:
+
+   a.  Intra-event updates:
+
+       Events that last longer than one packetization period (e.g., 50
+       ms) are updated periodically, so that the receiver can
+       reconstruct the event and its duration if it receives any of the
+       update packets, albeit with delay.
+
+       During an event, the RTP event payload format provides
+       incremental updates on the event.  The error resiliency afforded
+       by this mechanism depends on whether the first or second
+       algorithm in Section 2.5.2.2 is used and on the playout delay at
+       the receiver.  For example, if the receiver uses the first
+       algorithm and only places the current duration of tone signal in
+       the playout buffer, for a playout delay of 120 ms and a
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 20]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+       packetization interval of 50 ms, two packets in a row can get
+       lost without causing a premature end of the tone generated.
+
+   b.  Repeat last event packet:
+
+       As described in Section 2.5.1.4, the last report for an event is
+       transmitted a total of three times.  This mechanism adds
+       robustness to the reporting of the end of an event.
+
+       It may be necessary to extend the level of redundancy to achieve
+       requirement a) (in Section 2.6.1) in a specific network
+       environment.  Taking the 25-30% loss rate during congestion
+       periods illustrated in [28] as typical, and setting an objective
+       that at least 99% of end-of-event reports will eventually get
+       through to the receiver under these conditions, simple
+       probability calculations indicate that each event completion has
+       to be reported four times.  This is one more level of redundancy
+       than required by the basic "Repeat last event packet" algorithm.
+       Of course, the objective is probably unrealistically stringent;
+       it was chosen to make a point.
+
+       Where Section 2.5.1.4 indicates that it is appropriate to use the
+       RFC 2198 [2] audio redundancy mechanism to carry retransmissions
+       of final event reports, this mechanism MAY also be used to extend
+       the number of final report retransmissions.  This is done by
+       using more than two levels of redundancy when necessary.  The use
+       of RFC 2198 helps to mitigate the extra bandwidth demands that
+       would be imposed simply by retransmitting final event packets
+       more than three times.
+
+   These two redundancy mechanisms clearly address requirement a) in the
+   previous section.  They also help meet requirement c), to the extent
+   that the redundant packets arrive before playout of the events they
+   report is due to expire.  They are not helpful in meeting the other
+   requirements, although they do not directly cause impairments
+   themselves in the way that a large jitter buffer increases end-to-end
+   delay.
+
+   The playout algorithm is an additional mechanism for meeting the
+   performance requirements.  In particular, using the second algorithm
+   in Section 2.5.2.2 will meet requirement d) of the previous section
+   by preventing gaps in playout, but at the potential cost of increases
+   in duration (requirement c)).
+
+   Finally, there is an interaction between the packetization period
+   used by a sender, the playout delay used by the receiver, and the
+   vulnerability of an event flow to packet losses.  Assuming packet
+   losses are independent, a shorter packetization interval means that
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 21]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   the receiver can use a smaller playout delay to recover from a given
+   number of consecutive packet losses, at any stage of event playout.
+   This improves end-to-end delays in applications where that matters.
+
+   In view of the tradeoffs between the different reliability
+   mechanisms, documentation of specific events SHOULD include a
+   discussion of the appropriate design decisions for the applications
+   of those events.  This mandate is repeated in the section on IANA
+   considerations.
+
+2.6.3.  Adjusting to Congestion
+
+   So far, the discussion has been about meeting performance
+   requirements.  However, there is also the question of whether
+   applications of events can adapt to congestion to the point that they
+   reduce their demands on the networks during congestion.  In theory
+   this can be done for events by increasing the packetization interval,
+   so that fewer packets are sent per second.  This has to be
+   accompanied by an increased playout delay at the receiving end.
+   Coordination between the two ends for this purpose is an interesting
+   issue in itself.  If it is done, however, such an action implies a
+   one-time gap or extended playout of an event when the packetization
+   interval is first extended, as well as increased end-to-end delay
+   during the whole period of increased playout delay.
+
+   The benefit from such a measure varies primarily depending on the
+   average duration of the events being handled.  In the worst case, as
+   a first example shows, the reduction in aggregate bandwidth usage due
+   to an increased packetization interval may be quite modest.  Suppose
+   the average event duration is 3.33 ms (V.21 bits, for instance).
+   Suppose further that four transmissions in total are required for a
+   given event report to meet the loss objective.  Table 1 shows the
+   impact of varying packetization intervals on the aggregate bit rate
+   of the media stream.
+
+   +--------------------+-----------+---------------+------------------+
+   | Packetization      | Packets/s |     IP Packet |     Total IP Bit |
+   | Interval (ms)      |           |   Size (bits) |    Rate (bits/s) |
+   +--------------------+-----------+---------------+------------------+
+   | 50                 |        20 |          2440 |            48800 |
+   | 33.3               |        30 |          1800 |            54000 |
+   | 25                 |        40 |          1480 |            59200 |
+   | 20                 |        50 |          1288 |            64400 |
+   +--------------------+-----------+---------------+------------------+
+
+     Table 1: Data Rate at the IP Level versus Packetization Interval
+                (three retransmissions, 3.33 ms per event)
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 22]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   As can be seen, a doubling of the interval (from 25 to 50 ms) drops
+   aggregate bit rate by about 20% while increasing end-to-end delay by
+   25 ms and causing a one-time gap of the same amount.  (Extending the
+   playout of a specific V.21 tone event is out of the question, so the
+   first algorithm of Section 2.5.2.2 must be used in this application.)
+   The reduction in number of packets per second with longer
+   packetization periods is countered by the increase in packet size due
+   to the increase in number of events per packet.
+
+   For events of longer duration, the reduction in bandwidth is more
+   proportional to the increase in packetization interval.  The loss of
+   final event reports may also be less critical, so that lower
+   redundancy levels are acceptable.  Table 2 shows similar data to
+   Table 1, but assuming 70-ms events separated by 50 ms of silence (as
+   in an idealized DTMF-based text messaging session) with only the
+   basic two retransmissions for event completions.
+
+   +--------------------+-----------+---------------+------------------+
+   | Packetization      | Packets/s |     IP Packet |     Total IP Bit |
+   | Interval (ms)      |           |   Size (bits) |    Rate (bits/s) |
+   +--------------------+-----------+---------------+------------------+
+   | 50                 |        20 |       448/520 |            10040 |
+   | 33.3               |        30 |       448/520 |            14280 |
+   | 25                 |        40 |       448/520 |            18520 |
+   | 20                 |        50 |           448 |            22400 |
+   +--------------------+-----------+---------------+------------------+
+
+     Table 2: Data Rate at the IP Level versus Packetization Interval
+       (two retransmissions, 70 ms per event, 50 ms between events)
+
+   In the third column of the table, the packet size is 448 bits when
+   only one event is being reported and 520 bits when the previous event
+   is also included.  No more than one level of redundancy is needed up
+   to a packetization interval of 50 ms, although at that point most
+   packets are reporting two events.  Longer intervals require a second
+   level of redundancy in at least some packets.
+
+3.  Specification of Event Codes for DTMF Events
+
+   This document defines one class of named events: DTMF tones.
+
+3.1.  DTMF Applications
+
+   DTMF signalling [10] is typically generated by a telephone set or
+   possibly by a PBX (Private branch telephone exchange).  DTMF digits
+   may be consumed by entities such as gateways or application servers
+   in the IP network, or by entities such as telephone switches or IVRs
+   in the circuit switched network.
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 23]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   The DTMF events support two possible applications at the sending end:
+
+   1.  The Internet telephony gateway detects DTMF on the incoming
+       circuits and sends the RTP payload described here instead of
+       regular audio packets.  The gateway likely has the necessary
+       digital signal processors and algorithms, as it often needs to
+       detect DTMF, e.g., for two-stage dialing.  Having the gateway
+       detect tones relieves the receiving Internet end system from
+       having to do this work and also avoids having low bit-rate codecs
+       like G.723.1 [20] render DTMF tones unintelligible.
+
+   2.  An Internet end system such as an "Internet phone" can emulate
+       DTMF functionality without concerning itself with generating
+       precise tone pairs and without imposing the burden of tone
+       recognition on the receiver.
+
+   A similar distinction occurs at the receiving end.
+
+   1.  In the gateway scenario, an Internet telephony gateway connecting
+       a packet voice network to the PSTN re-creates the DTMF tones or
+       other telephony events and injects them into the PSTN.
+
+   2.  In the end system scenario, the DTMF events are consumed by the
+       receiving entity itself.
+
+   In the most common application, DTMF tones are sent in one direction
+   only, typically from the calling end.  The consuming device is most
+   commonly an IVR.  DTMF may alternate with voice from either end.  In
+   most cases, the only constraint on tone duration is that it exceed a
+   minimum value.  However, in some cases a long-duration tone (in
+   excess of 1-2 seconds) has special significance.
+
+      ITU-T Recommendation Q.24 [11], Table A-1, indicates that the
+      legacy switching equipment in the countries surveyed expects a
+      minimum recognizable signal duration of 40 ms, a minimum pause
+      between signals of 40 ms, and a maximum signalling rate of 8 to 10
+      digits per second depending on the country.  Human-generated DTMF
+      signals, of course, are generally longer with larger pauses
+      between them.
+
+   DTMF tones may also be used for text telephony.  This application is
+   documented in ITU-T Recommendation V.18 [27] Annex B.  In this case,
+   DTMF is sent alternately from either end (half-duplex mode), with a
+   minimum 300-ms turn-around time.  The only constraints on tone
+   durations in this application are that they and the pauses between
+   them must exceed specified minimum values.  It is RECOMMENDED that a
+   gateway at the sending end be capable of detecting DTMF signals as
+   specified by V.18 Annex B (tones and pauses >=40 ms), but should send
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 24]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   event durations corresponding to those of a V.18 DTMF sender (tones
+   >=70 ms, pauses >=50 ms).  This may occasionally imply some degree of
+   buffering of outgoing events, but if the source terminal conforms to
+   V.18 Annex B, this should not get out of hand.
+
+   Since minor increases in tone duration are harmless for all
+   applications of DTMF, but unintended breaks in playout of a DTMF
+   digit can confuse the receiving endpoint by creating the appearance
+   of extra digits, receiving applications that are converting DTMF
+   events back to tones SHOULD use the second playout algorithm rather
+   than the first one in Section 2.5.2.2.  This provides some robustness
+   against packet loss or congestion.
+
+3.2.  DTMF Events
+
+   Table 3 shows the DTMF-related event codes within the telephone-event
+   payload format.  The DTMF digits 0-9 and * and # are commonly
+   supported.  DTMF digits A through D are less frequently encountered,
+   typically in special applications such as military networks.
+
+                    +-------+--------+------+---------+
+                    | Event | Code   | Type | Volume? |
+                    +-------+--------+------+---------+
+                    | 0--9  | 0--9   | tone | yes     |
+                    | *     | 10     | tone | yes     |
+                    | #     | 11     | tone | yes     |
+                    | A--D  | 12--15 | tone | yes     |
+                    +-------+--------+------+---------+
+
+                        Table 3: DTMF Named Events
+
+3.3.  Congestion Considerations
+
+   The key considerations for the delivery of DTMF events are
+   reliability and avoidance of unintended breaks within the playout of
+   a given tone.  End-to-end round-trip delay is not a major
+   consideration except in the special case where DTMF tones are being
+   used for text telephony.  Assuming that, as recommended in
+   Section 3.1 above, the second playout algorithm of Section 2.5.2.2 is
+   in use, a temporary increase in packetization interval to as much as
+   100 ms or double the normal interval, whichever is less, should be
+   harmless.
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 25]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+4.  RTP Payload Format for Telephony Tones
+
+4.1.  Introduction
+
+   As an alternative to describing tones and events by name, as
+   described in Section 2, it is sometimes preferable to describe them
+   by their waveform properties.  In particular, recognition is faster
+   than for naming signals since it does not depend on recognizing
+   durations or pauses.
+
+   There is no single international standard for telephone tones such as
+   dial tone, ringing (ringback), busy, congestion ("fast-busy"),
+   special announcement tones, or some of the other special tones, such
+   as payphone recognition, call waiting or record tone.  However, ITU-T
+   Recommendation E.180 [18] notes that across all countries, these
+   tones share a number of characteristics:
+
+   o  Telephony tones consist of either a single tone, the addition of
+      two or three tones or the modulation of two tones.  (Almost all
+      tones use two frequencies; only the Hungarian "special dial tone"
+      has three.)  Tones that are mixed have the same amplitude and do
+      not decay.
+
+   o  In-band tones for telephony events are in the range of 25 Hz
+      (ringing tone in Angola) to 2600 Hz (the tone used for line
+      signalling in SS No. 5 and R1).  The in-band telephone frequency
+      range is limited to 3400 Hz.  R2 defines a 3825 Hz out-of-band
+      tone for line signalling on analogue trunks.  (The piano has a
+      range from 27.5 to 4186 Hz.)
+
+   o  Modulation frequencies range between 15 (ANSam tone) to 480 Hz
+      (Jamaica).  Non-integer frequencies are used only for frequencies
+      of 16 2/3 and 33 1/3 Hz.
+
+   o  Tones that are not continuous have durations of less than four
+      seconds.
+
+   o  ITU Recommendation E.180 [18] notes that different telephone
+      companies require a tone accuracy of between 0.5 and 1.5%.  The
+      Recommendation suggests a frequency tolerance of 1%.
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 26]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+4.2.  Examples of Common Telephone Tone Signals
+
+   As an aid to the implementor, Table 4 summarizes some common tones.
+   The rows labeled "ITU ..." refer to ITU-T Recommendation E.180 [18].
+   In these rows, the on and off durations are suggested ranges within
+   which local standards would set specific values.  The symbol "+" in
+   the table indicates addition of the tones, without modulation, while
+   "*" indicates amplitude modulation.
+
+   +-------------------------+-------------------+----------+----------+
+   | Tone Name               | Frequency         | On Time  | Off Time |
+   |                         |                   | (s)      | (s)      |
+   +-------------------------+-------------------+----------+----------+
+   | CNG                     | 1100              | 0.5      | 3.0      |
+   | V.25 CT                 | 1300              | 0.5      | 2.0      |
+   | CED                     | 2100              | 3.3      | --       |
+   | ANS                     | 2100              | 3.3      | --       |
+   | ANSam                   | 2100*15           | 3.3      | --       |
+   | V.21 bit                | 980 or 1180 or    | 0.00333  | --       |
+   |                         | 1650 or 1850      |          |          |
+   | -------------           | ----------        | -------- | -------- |
+   | ITU dial tone           | 425               | --       | --       |
+   | U.S. dial tone          | 350+440           | --       | --       |
+   | ITU ringing tone        | 425               | 0.67-1.5 | 3-5      |
+   | U.S. ringing tone       | 440+480           | 2.0      | 4.0      |
+   | ITU busy tone           | 425               | 0.1-0.6  | 0.1-0.7  |
+   | U.S. busy tone          | 480+620           | 0.5      | 0.5      |
+   | ITU congestion tone     | 425               | 0.1-0.6  | 0.1-0.7  |
+   | U.S. congestion tone    | 480+620           | 0.25     | 0.25     |
+   +-------------------------+-------------------+----------+----------+
+
+                   Table 4: Examples of Telephony Tones
+
+4.3.  Use of RTP Header Fields
+
+4.3.1.  Timestamp
+
+   The RTP timestamp reflects the measurement point for the current
+   packet.  The event duration described in Section 4.3.3 begins at that
+   time.
+
+4.3.2.  Marker Bit
+
+   The tone payload type uses the marker bit to distinguish the first
+   RTP packet reporting a given instance of a tone from succeeding
+   packets for that tone.  The marker bit SHOULD be set to 1 for the
+   first packet, and to 0 for all succeeding packets relating to the
+   same tone.
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 27]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+4.3.3.  Payload Format
+
+   Based on the characteristics described above, this document defines
+   an RTP payload format called "tone" that can represent tones
+   consisting of one or more frequencies.  (The corresponding media type
+   is "audio/tone".)  The default timestamp rate is 8000 Hz, but other
+   rates may be defined.  Note that the timestamp rate does not affect
+   the interpretation of the frequency, just the durations.
+
+   In accordance with current practice, this payload format does not
+   have a static payload type number, but uses an RTP payload type
+   number established dynamically and out-of-band.
+
+   The payload format is shown in Figure 2.
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |    modulation   |T|  volume   |          duration             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |R R R R|       frequency       |R R R R|       frequency       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |R R R R|       frequency       |R R R R|       frequency       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+           ......
+
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |R R R R|       frequency       |R R R R|      frequency        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                    Figure 2: Payload Format for Tones
+
+   The payload contains the following fields:
+
+   modulation:
+      The modulation frequency, in Hz.  The field is a 9-bit unsigned
+      integer, allowing modulation frequencies up to 511 Hz.  If there
+      is no modulation, this field has a value of zero.  Note that the
+      amplitude of modulation is not indicated in the payload and must
+      be determined by out-of-band means.
+
+   T:
+      If the T bit is set (one), the modulation frequency is to be
+      divided by three.  Otherwise, the modulation frequency is taken as
+      is.
+
+      This bit allows frequencies accurate to 1/3 Hz, since modulation
+      frequencies such as 16 2/3 Hz are in practical use.
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 28]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   volume:
+      The power level of the tone, expressed in dBm0 after dropping the
+      sign, with range from 0 to -63 dBm0.  (Note: A preferred level
+      range for digital tone generators is -8 dBm0 to -3 dBm0.)
+
+   duration:
+      The duration of the tone, measured in timestamp units and
+      presented in network byte order.  The tone begins at the instant
+      identified by the RTP timestamp and lasts for the duration value.
+      The value of zero is not permitted, and tones with such a duration
+      SHOULD be ignored.
+
+      The definition of duration corresponds to that for sample-based
+      codecs, where the timestamp represents the sampling point for the
+      first sample.
+
+   frequency:
+      The frequencies of the tones to be added, measured in Hz and
+      represented as a 12-bit unsigned integer.  The field size is
+      sufficient to represent frequencies up to 4095 Hz, which exceeds
+      the range of telephone systems.  A value of zero indicates
+      silence.  A single tone can contain any number of frequencies.  If
+      no frequencies are specified, the packet reports a period of
+      silence.
+
+   R:
+      This field is reserved for future use.  The sender MUST set it to
+      zero, and the receiver MUST ignore it.
+
+4.3.4.  Optional Media Type Parameters
+
+   The "rate" parameter describes the sampling rate, in Hertz.  The
+   number is written as an integer.  If omitted, the default value is
+   8000 Hz.
+
+4.4.  Procedures
+
+   This section defines the procedures associated with the tone payload
+   type.
+
+4.4.1.  Sending Procedures
+
+   The sender MAY send an initial tones packet as soon as a tone is
+   recognized, or MAY wait until a pre-negotiated packetization period
+   has elapsed.  The first RTP packet for a tone SHOULD have the marker
+   bit set to 1.
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 29]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   In the case of longer-duration tones, the sender SHOULD generate
+   multiple RTP packets for the same tone instance.  The RTP timestamp
+   MUST be updated for each packet generated (in contrast, for instance,
+   to the timestamp for packets carrying telephone events).  Subsequent
+   packets for the same tone SHOULD have the marker bit set to 0, and
+   the RTP timestamp in each subsequent packet MUST equal the sum of the
+   timestamp and the duration in the preceding packet.
+
+   A final RTP packet MAY be generated as soon as the end of the tone is
+   detected, without waiting for the latest packetization period to
+   elapse.
+
+   The telephone-event payload described in Section 2 is inherently
+   redundant, in that later packets for the same event carry all of the
+   earlier history of the event except for variations in volume.  In
+   contrast, each packet for the tone payload type stands alone; a lost
+   packet means a gap in the information available at the receiving end.
+   Thus, for increased reliability, the sender SHOULD combine new and
+   old tone reports in the same RTP packet using RFC 2198 [2] audio
+   redundancy.
+
+4.4.2.  Receiving Procedures
+
+   Receiving implementations play out the tones as received, typically
+   with a playout delay to allow for lost packets.  When playing out
+   successive tone reports for the same tone (marker bit is zero, the
+   RTP timestamp is contiguous with that of the previous RTP packet, and
+   payload content is identical), the receiving implementation SHOULD
+   continue the tone without change or a break.
+
+4.4.3.  Handling of Congestion
+
+   If the sender determines that packets are being lost due to
+   congestion (e.g., through RTCP receiver reports), it SHOULD increase
+   the packetization interval for initial and interim tone reports so as
+   to reduce traffic volume to the receiver.  The degree to which this
+   is possible without causing damaging consequences at the receiving
+   end depends both upon the playout delay used at that end and upon the
+   specific application associated with the tones.  Both the maximum
+   packetization interval and maximum increase in packetization interval
+   at any one time are therefore a matter of configuration or out-of-
+   band negotiation.
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 30]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+5.  Examples
+
+   Consider a DTMF dialling sequence, where the user dials the digits
+   "911" and a sending gateway detects them.  The first digit is 200 ms
+   long (1600 timestamp units) and starts at time 0; the second digit
+   lasts 250 ms (2000 timestamp units) and starts at time 880 ms (7040
+   timestamp units); the third digit is pressed at time 1.4 s (11,200
+   timestamp units) and lasts 220 ms (1760 timestamp units).  The frame
+   duration is 50 ms.
+
+   Table 5 shows the complete sequence of events assuming that only the
+   telephone-event payload type is being reported.  For simplicity: the
+   timestamp is assumed to begin at 0, the RTP sequence number at 1, and
+   volume settings are omitted.
+
+   +-------+-----------+------+--------+------+--------+--------+------+
+   |  Time | Event     |   M  |  Time- |  Seq |  Event |  Dura- |   E  |
+   |  (ms) |           |  bit |  stamp |   No |  Code  |   tion |  bit |
+   +-------+-----------+------+--------+------+--------+--------+------+
+   |     0 | "9"       |      |        |      |        |        |      |
+   |       | starts    |      |        |      |        |        |      |
+   |    50 | RTP       |  "1" |      0 |    1 |    9   |    400 |  "0" |
+   |       | packet 1  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   100 | RTP       |  "0" |      0 |    2 |    9   |    800 |  "0" |
+   |       | packet 2  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   150 | RTP       |  "0" |      0 |    3 |    9   |   1200 |  "0" |
+   |       | packet 3  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   200 | RTP       |  "0" |      0 |    4 |    9   |   1600 |  "0" |
+   |       | packet 4  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   200 | "9" ends  |      |        |      |        |        |      |
+   |   250 | RTP       |  "0" |      0 |    5 |    9   |   1600 |  "1" |
+   |       | packet 4  |      |        |      |        |        |      |
+   |       | first     |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   |   300 | RTP       |  "0" |      0 |    6 |    9   |   1600 |  "1" |
+   |       | packet 4  |      |        |      |        |        |      |
+   |       | second    |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   |   880 | First "1" |      |        |      |        |        |      |
+   |       | starts    |      |        |      |        |        |      |
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 31]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   |   930 | RTP       |  "1" |   7040 |    7 |    1   |    400 |  "0" |
+   |       | packet 5  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   ... | ...       |  ... |    ... |  ... |   ...  |    ... |  ... |
+   |  1130 | RTP       |  "0" |   7040 |   11 |    1   |   2000 |  "0" |
+   |       | packet 9  |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |  1130 | First "1" |      |        |      |        |        |      |
+   |       | ends      |      |        |      |        |        |      |
+   |  1180 | RTP       |  "0" |   7040 |   12 |    1   |   2000 |  "1" |
+   |       | packet 9  |      |        |      |        |        |      |
+   |       | first     |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   |  1230 | RTP       |  "0" |   7040 |   13 |    1   |   2000 |  "1" |
+   |       | packet 9  |      |        |      |        |        |      |
+   |       | second    |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   |  1400 | Second    |      |        |      |        |        |      |
+   |       | "1"       |      |        |      |        |        |      |
+   |       | starts    |      |        |      |        |        |      |
+   |  1450 | RTP       |  "1" |  11200 |   14 |    1   |    400 |  "0" |
+   |       | packet 10 |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |   ... | ...       |  ... |    ... |  ... |   ...  |    ... |  ... |
+   |  1620 | Second    |      |        |      |        |        |      |
+   |       | "1" ends  |      |        |      |        |        |      |
+   |  1650 | RTP       |  "0" |  11200 |   18 |    1   |   1760 |  "1" |
+   |       | packet 14 |      |        |      |        |        |      |
+   |       | sent      |      |        |      |        |        |      |
+   |  1700 | RTP       |  "0" |  11200 |   19 |    1   |   1760 |  "1" |
+   |       | packet 14 |      |        |      |        |        |      |
+   |       | first     |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   |  1750 | RTP       |  "0" |  11200 |   20 |    1   |   1760 |  "1" |
+   |       | packet 14 |      |        |      |        |        |      |
+   |       | second    |      |        |      |        |        |      |
+   |       | retrans-  |      |        |      |        |        |      |
+   |       | mission   |      |        |      |        |        |      |
+   +-------+-----------+------+--------+------+--------+--------+------+
+
+                    Table 5: Example of Event Reporting
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 32]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Table 6 shows the same sequence assuming that only the tone payload
+   type is being reported.  This looks somewhat different.  For
+   simplicity: the timestamp is assumed to begin at 0, the sequence
+   number at 1.  Volume, the T bit, and the modulation frequency are
+   omitted.  The latter two are always 0.
+
+   +-------+-----------+-----+--------+------+--------+-------+--------+
+   |  Time | Event     |  M  |  Time- |  Seq | Dura-  | Freq 1| Freq 2 |
+   |  (ms) |           | bit |  stamp |   No | tion   | (Hz)  | (Hz)   |
+   +-------+-----------+-----+--------+------+--------+-------+--------+
+   |     0 | "9"       |     |        |      |        |       |        |
+   |       | starts    |     |        |      |        |       |        |
+   |    50 | RTP       | "1" |      0 |    1 | 400    | 852   | 1477   |
+   |       | packet 1  |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   100 | RTP       | "0" |    400 |    2 | 400    | 852   | 1477   |
+   |       | packet 2  |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   ... | ...       | ... |    ... |  ... | ...    | ...   | ...    |
+   |   200 | RTP       | "0" |   1200 |    4 | 400    | 852   | 1477   |
+   |       | packet 4  |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   200 | "9" ends  |     |        |      |        |       |        |
+   |   880 | First "1" |     |        |      |        |       |        |
+   |       | starts    |     |        |      |        |       |        |
+   |   930 | RTP       | "1" |   7040 |    5 | 400    | 697   | 1209   |
+   |       | packet 5  |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   980 | RTP       | "0" |   7440 |    6 | 400    | 697   | 1209   |
+   |       | packet 6  |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   ... | ...       | ... |    ... |  ... | ...    | ...   | ...    |
+   |  1130 | First "1" |     |        |      |        |       |        |
+   |       | ends      |     |        |      |        |       |        |
+   |  1400 | Second    |     |        |      |        |       |        |
+   |       | "1"       |     |        |      |        |       |        |
+   |       | starts    |     |        |      |        |       |        |
+   |  1450 | RTP       | "1" |  11200 |   10 | 400    | 697   | 1209   |
+   |       | packet 10 |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   |   ... | ...       | ... |    ... |  ... | ...    | ...   | ...    |
+   |  1620 | Second    |     |        |      |        |       |        |
+   |       | "1" ends  |     |        |      |        |       |        |
+   |  1650 | RTP       | "0" |  12800 |   14 | 160    | 697   | 1209   |
+   |       | packet 14 |     |        |      |        |       |        |
+   |       | sent      |     |        |      |        |       |        |
+   +-------+-----------+-----+--------+------+--------+-------+--------+
+                    Table 6: Example of Tone Reporting
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 33]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Now consider a combined payload, where the tone payload is the
+   primary payload type and the event payload is treated as a redundant
+   encoding (one level of redundancy).  Because the primary payload is
+   tones, the tone payload rules determine the setting of the RTP header
+   fields.  This means that the RTP timestamp always advances.  As a
+   corollary, the timestamp offset for the events payload in the RFC
+   2198 header increases by the same amount.
+
+   One issue that has to be considered in a combined payload is how to
+   handle retransmissions of final event reports.  The tone payload
+   specification does not recommend retransmissions of final packets, so
+   it is unclear what to put in the primary payload fields of the
+   combined packet.  In the interests of simplicity, it is suggested
+   that the retransmitted packets copy the fields relating to the
+   primary payload (including the RTP timestamp) from the original
+   packet.  The same principle can be applied if the packet includes
+   multiple levels of event payload redundancy.
+
+   The figures below all illustrate "RTP packet 14" in the above tables.
+   Figure 3 shows an event-only payload, corresponding to Table 5.
+   Figure 4 shows a tone-only payload, corresponding to Table 6.
+   Finally, Figure 5 shows a combined payload, with tones primary and
+   events as a single redundant layer.  Note that the combined payload
+   has the RTP sequence numbers shown in Table 5, because the
+   transmitted sequence includes the retransmitted packets.
+
+   Figure 3 assumes that the following SDP specification was used.  This
+   session description provides for separate streams of G.729 [21] audio
+   and events.  Packets reported within the G.729 stream are not
+   considered here.
+
+      m=audio 12344 RTP/AVP 99
+      a=rtpmap:99 G729/8000
+      a=ptime:20
+      m=audio 12346 RTP/AVP 100
+      a=rtpmap:100 telephone-event/8000
+      a=fmtp:100 0-15
+      a=ptime:50
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 34]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+      | 2 |0|0|   0   |0|    100      |            18                 |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           timestamp                           |
+      |                             11200                             |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |           synchronization source (SSRC) identifier            |
+      |                            0x5234a8                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     event     |E R| volume    |          duration             |
+      |       1       |1 0|    20     |             1760              |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+              Figure 3: Example RTP Packet for Event Payload
+
+   Figure 4 assumes that an SDP specification similar to that of the
+   previous case was used.
+
+      m=audio 12344 RTP/AVP 99
+      a=rtpmap:99 G729/8000
+      a=ptime:20
+      m=audio 12346 RTP/AVP 101
+      a=rtpmap:101 tone/8000
+      a=ptime:50
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+      | 2 |0|0|   0   |0|    101      |             14                |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           timestamp                           |
+      |                             12800                             |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |           synchronization source (SSRC) identifier            |
+      |                            0x5234a8                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |    modulation   |T|  volume   |          duration             |
+      |        0        |0|    20     |             160               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |R R R R|       frequency       |R R R R|       frequency       |
+      |0 0 0 0|          697          |0 0 0 0|         1209          |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+               Figure 4: Example RTP Packet for Tone Payload
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 35]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Figure 5, for the combined payload, assumes the following SDP session
+   description:
+
+      m=audio 12344 RTP/AVP 99
+      a=rtpmap:99 G729/8000
+      a=ptime:20
+      m=audio 12346 RTP/AVP 102 101 100
+      a=rtpmap:102 red/8000/1
+      a=fmtp:102 101/100
+      a=rtpmap:101 tone/8000
+      a=rtpmap:100 telephone-event/8000
+      a=fmtp:100 0-15
+      a=ptime:50
+
+   For ease of presentation, Figure 5 presents the actual payloads as if
+   they began on 32-bit boundaries.  In the actual packet, they follow
+   immediately after the end of the RFC 2198 header, and thus are
+   displaced one octet into successive words.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 36]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+      | 2 |0|0|   0   |0|    102      |             18                |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           timestamp                           |
+      |                             12800                             |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |           synchronization source (SSRC) identifier            |
+      |                            0x5234a8                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |F|   block PT  |  timestamp offset         |   block length    |
+      |1|      100    |       1600                |        4          |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |F|   block PT  |   event payload begins ...                    /
+      |0|      101    |                                               \
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+          Event payload
+
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     event     |E R| volume    |          duration             |
+      |       1       |1 0|    20     |             1760              |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+          Tone payload
+
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |    modulation   |T|  volume   |          duration             |
+      |        0        |0|    20     |             160               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |R R R R|       frequency       |R R R R|       frequency       |
+      |0 0 0 0|          697          |0 0 0 0|         1209          |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+     Figure 5: Example RTP Packet for Combined Tone and Event Payloads
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 37]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+6.  Security Considerations
+
+   RTP packets using the payload formats defined in this specification
+   are subject to the security considerations discussed in the RTP
+   specification (RFC 3550 [5]), and any appropriate RTP profile (for
+   example, RFC 3551 [13]).  The RFC 3550 discussion focuses on
+   requirements for confidentiality.  Additional security considerations
+   relating to implementation are described in RFC 2198 [2].
+
+   The telephone-event payload defined in this specification is highly
+   compressed.  A change in value of just one bit can result in a major
+   change in meaning as decoded at the receiver.  Thus, message
+   integrity MUST be provided for the telephone-event payload type.
+
+   To meet the need for protection both of confidentiality and
+   integrity, compliant implementations SHOULD implement the Secure
+   Real-time Transport Protocol (SRTP) [7].
+
+      Note that the appropriate method of key distribution for SRTP may
+      vary with the specific application.
+
+      In some deployments, it may be preferable to use other means to
+      provide protection equivalent to that provided by SRTP.
+
+   Provided that gateway design includes robust, low-overhead tone
+   generation, this payload type does not exhibit any significant non-
+   uniformity in the receiver side computational complexity for packet
+   processing to cause a potential denial-of-service threat.
+
+7.  IANA Considerations
+
+   This document updates the descriptions of two RTP payload formats,
+   'telephone-event' and 'tone', and associated Internet media types,
+   audio/telephone-event and audio/tone.  It also documents the event
+   codes for DTMF tone events.
+
+   Within the audio/telephone-event type, events MUST be registered with
+   IANA.  Registrations are subject to the policies "Specification
+   Required" and "Expert Review" as defined in RFC 2434 [3].  The IETF-
+   appointed expert must ensure that:
+
+   a.  the meaning and application of the proposed events are clearly
+       documented;
+
+   b.  the events cannot be represented by existing event codes,
+       possibly with some minor modification of event definitions;
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 38]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   c.  the number of events is the minimum necessary to fulfill the
+       purpose of their application(s).
+
+   The expert is further responsible for providing guidance on the
+   allocation of event codes to the proposed events.  Specifically, the
+   expert must indicate whether the event appears to be the same as one
+   defined in RFC 2833 but not specified in any new document.  In this
+   case, the event code specified in RFC 2833 for that event SHOULD be
+   assigned to the proposed event.  Otherwise, event codes MUST be
+   assigned from the set of available event codes listed below.  If this
+   set is exhausted, the criterion for assignment from the reserved set
+   of event codes is to first assign those that appear to have the
+   lowest probability of being revived in their RFC 2833 meaning in a
+   new specification.
+
+   The documentation for each event MUST indicate whether the event is a
+   state, tone, or other type of event (e.g., an out-of-band electrical
+   event such as on-hook or an indication that will not itself be played
+   out as tones at the receiving end).  For tone events, the
+   documentation MUST indicate whether the volume field is applicable or
+   must be set to 0.
+
+   In view of the tradeoffs between the different reliability mechanisms
+   discussed in Section 2.6, documentation of specific events SHOULD
+   include a discussion of the appropriate design decisions for the
+   applications of those events.
+
+   Legal event codes range from 0 to 255.  The initial registry content
+   is shown in Table 7, and consists of the sixteen events defined in
+   Section 3 of this document.  The remaining codes have the following
+   disposition:
+
+   o  codes 17-22, 50-51, 90-95, 113-120, 169, and 206-255 are available
+      for assignment;
+
+   o  codes 23-40, 49, and 52-63 are reserved for events defined in
+      [16];
+
+   o  codes 121-137 and 174-205 are reserved for events defined in [17];
+
+   o  codes 16, 41-48, 64-88, 96-112, 138-168, and 170-173 are reserved
+      in the first instance for specifications reviving the
+      corresponding RFC 2833 events, and in the second instance for
+      general assignment after all other codes have been assigned.
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 39]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+        +------------+--------------------------------+-----------+
+        | Event Code | Event Name                     | Reference |
+        +------------+--------------------------------+-----------+
+        |          0 | DTMF digit "0"                 |  RFC 4733 |
+        |          1 | DTMF digit "1"                 |  RFC 4733 |
+        |          2 | DTMF digit "2"                 |  RFC 4733 |
+        |          3 | DTMF digit "3"                 |  RFC 4733 |
+        |          4 | DTMF digit "4"                 |  RFC 4733 |
+        |          5 | DTMF digit "5"                 |  RFC 4733 |
+        |          6 | DTMF digit "6"                 |  RFC 4733 |
+        |          7 | DTMF digit "7"                 |  RFC 4733 |
+        |          8 | DTMF digit "8"                 |  RFC 4733 |
+        |          9 | DTMF digit "9"                 |  RFC 4733 |
+        |         10 | DTMF digit "*"                 |  RFC 4733 |
+        |         11 | DTMF digit "#"                 |  RFC 4733 |
+        |         12 | DTMF digit "A"                 |  RFC 4733 |
+        |         13 | DTMF digit "B"                 |  RFC 4733 |
+        |         14 | DTMF digit "C"                 |  RFC 4733 |
+        |         15 | DTMF digit "D"                 |  RFC 4733 |
+        +------------+--------------------------------+-----------+
+
+            Table 7: audio/telephone-event Event Code Registry
+
+7.1.  Media Type Registrations
+
+7.1.1.  Registration of Media Type audio/telephone-event
+
+   This registration is done in accordance with [6] and [8].
+
+   Type name: audio
+
+   Subtype name: telephone-event
+
+   Required parameters: none.
+
+   Optional parameters:
+
+      The "events" parameter lists the events supported by the
+      implementation.  Events are listed as one or more comma-separated
+      elements.  Each element can be either a single integer providing
+      the value of an event code or an integer followed by a hyphen and
+      a larger integer, presenting a range of consecutive event code
+      values.  The list does not have to be sorted.  No white space is
+      allowed in the argument.  The union of all of the individual event
+      codes and event code ranges designates the complete set of event
+      numbers supported by the implementation.  If the "events"
+      parameter is omitted, support for events 0-15 (the DTMF tones) is
+      assumed.
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 40]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+      The "rate" parameter describes the sampling rate, in Hertz.  The
+      number is written as an integer.  If omitted, the default value is
+      8000 Hz.
+
+   Encoding considerations:
+
+      In the terminology defined by [8] section 4.8, this type is framed
+      and binary.
+
+   Security considerations:
+
+      See Section 6, "Security Considerations", in this document.
+
+   Interoperability considerations: none.
+
+   Published specification: this document.
+
+   Applications which use this media:
+
+      The telephone-event audio subtype supports the transport of events
+      occurring in telephone systems over the Internet.
+
+   Additional information:
+
+      Magic number(s): N/A.
+      File extension(s): N/A.
+      Macintosh file type code(s): N/A.
+
+   Person & email address to contact for further information:
+
+      Tom Taylor, taylor@nortel.com.
+      IETF AVT Working Group.
+
+   Intended usage: COMMON.
+
+   Restrictions on usage:
+
+      This type is defined only for transfer via RTP [5].
+
+   Author: IETF Audio/Video Transport Working Group.
+
+   Change controller:
+
+      IETF Audio/Video Transport Working Group as delegated from the
+      IESG.
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 41]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+7.1.2.  Registration of Media Type audio/tone
+
+   This registration is done in accordance with [6] and [8].
+
+   Type name: audio
+
+   Subtype name: tone
+
+   Required parameters: none
+
+   Optional parameters:
+
+      The "rate" parameter describes the sampling rate, in Hertz.  The
+      number is written as an integer.  If omitted, the default value is
+      8000 Hz.
+
+   Encoding considerations:
+
+      In the terminology defined by [8] section 4.8, this type is framed
+      and binary.
+
+   Security considerations:
+
+      See Section 6, "Security Considerations", in this document.
+
+   Interoperability considerations: none
+
+   Published specification: this document.
+
+   Applications which use this media:
+
+      The tone audio subtype supports the transport of pure composite
+      tones, for example, those commonly used in the current telephone
+      system to signal call progress.
+
+   Additional information:
+
+      Magic number(s): N/A.
+      File extension(s): N/A.
+      Macintosh file type code(s): N/A.
+
+   Person & email address to contact for further information:
+
+      Tom Taylor, taylor@nortel.com.
+      IETF AVT Working Group.
+
+   Intended usage: COMMON.
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 42]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Restrictions on usage:
+
+      This type is defined only for transfer via RTP [5].
+
+   Author: IETF Audio/Video Transport Working Group.
+
+   Change controller:
+
+      IETF Audio/Video Transport Working Group as delegated from the
+      IESG.
+
+8.  Acknowledgements
+
+   Scott Petrack was the original author of RFC 2833.  Henning
+   Schulzrinne later loaned his expertise to complete the document, but
+   Scott must be credited with the energy behind the idea of a compact
+   encoding of tones over IP.
+
+   In RFC 2833, the suggestions of the Megaco working group were
+   acknowledged.  Colin Perkins and Magnus Westerland, Chairs of the AVT
+   Working Group, provided helpful advice in the formation of the
+   present document.  Over the years, detailed advice and comments for
+   RFC 2833, this document, or both were provided by Hisham Abdelhamid,
+   Flemming Andreasen, Fred Burg, Steve Casner, Dan Deliberato, Fatih
+   Erdin, Bill Foster, Mike Fox, Mehryar Garakani, Gunnar Hellstrom,
+   Rajesh Kumar, Terry Lyons, Steve Magnell, Zarko Markov, Tim
+   Melanchuk, Kai Miao, Satish Mundra, Kevin Noll, Vern Paxson, Oren
+   Peleg, Raghavendra Prabhu, Moshe Samoha, Todd Sherer, Adrian Soncodi,
+   Yaakov Stein, Mira Stevanovic, Alex Urquizo, and Herb Wildfeur.
+
+9.  References
+
+9.1.  Normative References
+
+   [1]   Bradner, S., "Key words for use in RFCs to Indicate Requirement
+         Levels", BCP 14, RFC 2119, March 1997.
+
+   [2]   Perkins, C., Kouvelas, I., Hodson, O., Hardman, V., Handley,
+         M., Bolot, J., Vega-Garcia, A., and S. Fosse-Parisis, "RTP
+         Payload for Redundant Audio Data", RFC 2198, September 1997.
+
+   [3]   Narten, T. and H. Alvestrand, "Guidelines for Writing an IANA
+         Considerations Section in RFCs", BCP 26, RFC 2434,
+         October 1998.
+
+   [4]   Rosenberg, J. and H. Schulzrinne, "An Offer/Answer Model with
+         Session Description Protocol (SDP)", RFC 3264, June 2002.
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 43]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   [5]   Schulzrinne, H., Casner, S., Frederick, R., and V. Jacobson,
+         "RTP: A Transport Protocol for Real-Time Applications", STD 64,
+         RFC 3550, July 2003.
+
+   [6]   Casner, S. and P. Hoschka, "MIME Type Registration of RTP
+         Payload Formats", RFC 3555, July 2003.
+
+   [7]   Baugher, M., McGrew, D., Naslund, M., Carrara, E., and K.
+         Norrman, "The Secure Real-time Transport Protocol (SRTP)",
+         RFC 3711, March 2004.
+
+   [8]   Freed, N. and J. Klensin, "Media Type Specifications and
+         Registration Procedures", BCP 13, RFC 4288, December 2005.
+
+   [9]   Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
+         Description Protocol", RFC 4566, July 2006.
+
+   [10]  International Telecommunication Union, "Technical features of
+         push-button telephone sets", ITU-T Recommendation Q.23,
+         November 1988.
+
+   [11]  International Telecommunication Union, "Multifrequency push-
+         button signal reception", ITU-T Recommendation Q.24,
+         November 1988.
+
+9.2.  Informative References
+
+   [12]  Schulzrinne, H. and S. Petrack, "RTP Payload for DTMF Digits,
+         Telephony Tones and Telephony Signals", RFC 2833, May 2000.
+
+   [13]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and Video
+         Conferences with Minimal Control", STD 65, RFC 3551, July 2003.
+
+   [14]  Kreuter, R., "RTP Payload Format for a 64 kbit/s Transparent
+         Call", RFC 4040, April 2005.
+
+   [15]  Hellstrom, G. and P. Jones, "RTP Payload for Text
+         Conversation", RFC 4103, June 2005.
+
+   [16]  Schulzrinne, H. and T. Taylor, "Definition of Events for Modem,
+         Fax, and Text Telephony Signals", RFC 4734, December 2006.
+
+   [17]  Schulzrinne, H. and T. Taylor, "Definition of Events For
+         Channel-Oriented Telephony Signalling", Work In Progress ,
+         November 2005.
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 44]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   [18]  International Telecommunication Union, "Technical
+         characteristics of tones for the telephone service", ITU-T
+         Recommendation E.180/Q.35, March 1998.
+
+   [19]  International Telecommunication Union, "Pulse code modulation
+         (PCM) of voice frequencies", ITU-T Recommendation G.711,
+         November 1988.
+
+   [20]  International Telecommunication Union, "Speech coders : Dual
+         rate speech coder for multimedia communications transmitting at
+         5.3 and 6.3 kbit/s", ITU-T Recommendation G.723.1, March 1996.
+
+   [21]  International Telecommunication Union, "Coding of speech at 8
+         kbit/s using conjugate-structure algebraic-code-excited linear-
+         prediction (CS-ACELP)", ITU-T Recommendation G.729, March 1996.
+
+   [22]  International Telecommunication Union, "ISDN user-network
+         interface layer 3 specification for basic call control", ITU-T
+         Recommendation Q.931, May 1998.
+
+   [23]  International Telecommunication Union, "Procedures for real-
+         time Group 3 facsimile communication over IP networks", ITU-T
+         Recommendation T.38, July 2003.
+
+   [24]  International Telecommunication Union, "Procedures for starting
+         sessions of data transmission over the public switched
+         telephone network", ITU-T Recommendation V.8, November 2000.
+
+   [25]  International Telecommunication Union, "Modem-over-IP networks:
+         Procedures for the end-to-end connection of V-series DCEs",
+         ITU-T Recommendation V.150.1, January 2003.
+
+   [26]  International Telecommunication Union, "Procedures for
+         supporting Voice-Band Data over IP Networks", ITU-T
+         Recommendation V.152, January 2005.
+
+   [27]  International Telecommunication Union, "Operational and
+         interworking requirements for {DCEs operating in the text
+         telephone mode", ITU-T Recommendation V.18, November 2000.
+
+         See also Recommendation V.18 Amendment 1, Nov. 2002.
+   [28]  VOIP Troubleshooter LLC, "Indepth: Packet Loss Burstiness",
+         2005,
+         <http://www.voiptroubleshooter.com/indepth/burstloss.html>.
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 45]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+Appendix A.  Summary of Changes from RFC 2833
+
+   The memo has been significantly restructured, incorporating a large
+   number of clarifications to the specification.  With the exception of
+   those items noted below, the changes to the memo are intended to be
+   backwards-compatible clarifications.  However, due to inconsistencies
+   and unclear definitions in RFC 2833 [12] it is likely that some
+   implementations interpreted that memo in ways that differ from this
+   version.
+
+   RFC 2833 required that all implementations be capable of receiving
+   the DTMF events (event codes 0-15).  Section 2.5.1.1 of the present
+   document requires that a sender transmit only the events that the
+   receiver is capable of receiving.  In the absence of a knowledge of
+   receiver capabilities, the sender SHOULD assume support of the DTMF
+   events but of no other events.  The sender SHOULD indicate what
+   events it can send.  Section 2.5.2.1 requires that a receiver
+   signalling its capabilities using SDP MUST indicate which events it
+   can receive.
+
+   Non-zero values in the volume field of the payload were applicable
+   only to DTMF tones in RFC 2833, and for other events the receiver was
+   required to ignore them.  The present memo requires that the
+   definition of each event indicate whether the volume field is
+   applicable to that event.  The last paragraph of Section 2.5.2.2
+   indicates what a receiver may do if it receives volumes with zero
+   values for events to which the volume field is applicable.  Along
+   with the RFC 2833 receiver rule, this ensures backward compatibility
+   in both directions of transmission.
+
+   Section 2.5.1.3 and Section 2.5.2.3 introduce a new procedure for
+   reporting and playing out events whose duration exceeds the capacity
+   of the payload duration field.  This procedure may cause momentary
+   confusion at an old (RFC 2833) receiver, because the timestamp is
+   updated without setting the E bit of the preceding event report and
+   without setting the M bit of the new one.
+
+   Section 2.5.1.5 and Section 2.5.2.4 introduce a new procedure whereby
+   a sequence of short-duration events may be packed into a single event
+   report.  If an old (RFC 2833) receiver receives such a report, it may
+   discard the packet as invalid, since the packet holds more content
+   than the receiver was expecting.  In any event, the additional events
+   in the packet will be lost.
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 46]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+   Section 2.3.5 introduces the possibility of "state" events and
+   defines procedures for setting the duration field for reports of such
+   events.  Section 2.5.1.2 defines special exemptions from the setting
+   of the E bit for state events.  Three more sections mention
+   procedures related to these events.
+
+   The Security Considerations section is updated to mention the
+   requirement for protection of integrity.  More importantly, it makes
+   implementation of SRTP [7] mandatory for compliant implementations,
+   without specifying a mandatory-to-implement method of key
+   distribution.
+
+   Finally, this document establishes an IANA registry for event codes
+   and establishes criteria for their documentation.  This document
+   provides an initial population for the new registry, consisting
+   solely of the sixteen DTMF events.  Two companion documents [16] and
+   [17] describe events related to modems, fax, and text telephony and
+   to channel-associated telephony signalling, respectively.  Some
+   changes were made to the latter because of errors and redundancies in
+   the RFC 2833 assignments.  The remaining events defined in RFC 2833
+   are deprecated because they do not appear to have been implemented,
+   but their codes have been conditionally reserved in case any of them
+   is needed in the future.  Table 8 indicates the disposition of the
+   event codes in detail.  Event codes not mentioned in this table were
+   not allocated by RFC 2833 and continue to be unused.
+
+   +-------------+---------------------------------------+-------------+
+   | Event Codes | RFC 2833 Description                  | Disposition |
+   +-------------+---------------------------------------+-------------+
+   |        0-15 | DTMF digits                           | RFC 4733    |
+   |          16 | Line flash (deprecated)               | Reserved    |
+   |       23-31 | Unused                                | [16]        |
+   |       32-40 | Data and fax                          | [16]        |
+   |       41-48 | Data and fax (V.8bis, deprecated)     | Reserved    |
+   |       52-63 | Unused                                | [16]        |
+   |       64-89 | E.182 line events (deprecated)        | Reserved    |
+   |      96-112 | Country-specific line events          | Reserved    |
+   |             | (deprecated)                          |             |
+   |     121-127 | Unused                                | [17]        |
+   |     128-137 | Trunks: MF 0-9                        | [17]        |
+   |     138-143 | Trunks: other MF (deprecated)         | Reserved    |
+   |     144-159 | Trunks: ABCD signalling               | [17]        |
+   |     160-168 | Trunks: various (deprecated)          | Reserved    |
+   |     170-173 | Trunks: various (deprecated)          | Reserved    |
+   |     174-205 | Unused                                | [17]        |
+   +-------------+---------------------------------------+-------------+
+
+           Table 8: Disposition of RFC 2833-defined Event Codes
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 47]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+Authors' Addresses
+
+   Henning Schulzrinne
+   Columbia U.
+   Dept. of Computer Science
+   Columbia University
+   1214 Amsterdam Avenue
+   New York, NY  10027
+   US
+
+   EMail: schulzrinne@cs.columbia.edu
+
+
+   Tom Taylor
+   Nortel
+   1852 Lorraine Ave
+   Ottawa, Ontario  K1H 6Z8
+   Canada
+
+   EMail: taylor@nortel.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 48]
+
+RFC 4733               Telephony Events and Tones          December 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST,
+   AND THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT
+   THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY
+   IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+   PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+Schulzrinne & Taylor        Standards Track                    [Page 49]
+

--- a/rfcs/rfc5626.txt
+++ b/rfcs/rfc5626.txt
@@ -1,0 +1,2803 @@
+
+
+
+
+
+
+Network Working Group                                   C. Jennings, Ed.
+Request for Comments: 5626                                 Cisco Systems
+Updates: 3261, 3327                                         R. Mahy, Ed.
+Category: Standards Track                                   Unaffiliated
+                                                           F. Audet, Ed.
+                                                              Skype Labs
+                                                            October 2009
+
+
+                 Managing Client-Initiated Connections
+                in the Session Initiation Protocol (SIP)
+
+Abstract
+
+   The Session Initiation Protocol (SIP) allows proxy servers to
+   initiate TCP connections or to send asynchronous UDP datagrams to
+   User Agents in order to deliver requests.  However, in a large number
+   of real deployments, many practical considerations, such as the
+   existence of firewalls and Network Address Translators (NATs) or the
+   use of TLS with server-provided certificates, prevent servers from
+   connecting to User Agents in this way.  This specification defines
+   behaviors for User Agents, registrars, and proxy servers that allow
+   requests to be delivered on existing connections established by the
+   User Agent.  It also defines keep-alive behaviors needed to keep NAT
+   bindings open and specifies the usage of multiple connections from
+   the User Agent to its registrar.
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 1]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   the Trust Legal Provisions and are provided without warranty as
+   described in the BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  4
+   2.  Conventions and Terminology  . . . . . . . . . . . . . . . . .  5
+     2.1.  Definitions  . . . . . . . . . . . . . . . . . . . . . . .  5
+   3.  Overview . . . . . . . . . . . . . . . . . . . . . . . . . . .  6
+     3.1.  Summary of Mechanism . . . . . . . . . . . . . . . . . . .  6
+     3.2.  Single Registrar and UA  . . . . . . . . . . . . . . . . .  7
+     3.3.  Multiple Connections from a User Agent . . . . . . . . . .  8
+     3.4.  Edge Proxies . . . . . . . . . . . . . . . . . . . . . . . 10
+     3.5.  Keep-Alive Technique . . . . . . . . . . . . . . . . . . . 11
+       3.5.1.  CRLF Keep-Alive Technique  . . . . . . . . . . . . . . 12
+       3.5.2.  STUN Keep-Alive Technique  . . . . . . . . . . . . . . 12
+   4.  User Agent Procedures  . . . . . . . . . . . . . . . . . . . . 13
+     4.1.  Instance ID Creation . . . . . . . . . . . . . . . . . . . 13
+     4.2.  Registrations  . . . . . . . . . . . . . . . . . . . . . . 14
+       4.2.1.  Initial Registrations  . . . . . . . . . . . . . . . . 14
+       4.2.2.  Subsequent REGISTER Requests . . . . . . . . . . . . . 16
+       4.2.3.  Third-Party Registrations  . . . . . . . . . . . . . . 17
+     4.3.  Sending Non-REGISTER Requests  . . . . . . . . . . . . . . 17
+     4.4.  Keep-Alives and Detecting Flow Failure . . . . . . . . . . 18
+       4.4.1.  Keep-Alive with CRLF . . . . . . . . . . . . . . . . . 19
+       4.4.2.  Keep-Alive with STUN . . . . . . . . . . . . . . . . . 21
+     4.5.  Flow Recovery  . . . . . . . . . . . . . . . . . . . . . . 21
+   5.  Edge Proxy Procedures  . . . . . . . . . . . . . . . . . . . . 22
+     5.1.  Processing Register Requests . . . . . . . . . . . . . . . 22
+     5.2.  Generating Flow Tokens . . . . . . . . . . . . . . . . . . 23
+     5.3.  Forwarding Non-REGISTER Requests . . . . . . . . . . . . . 23
+       5.3.1.  Processing Incoming Requests . . . . . . . . . . . . . 24
+       5.3.2.  Processing Outgoing Requests . . . . . . . . . . . . . 24
+     5.4.  Edge Proxy Keep-Alive Handling . . . . . . . . . . . . . . 25
+   6.  Registrar Procedures . . . . . . . . . . . . . . . . . . . . . 25
+   7.  Authoritative Proxy Procedures: Forwarding Requests  . . . . . 27
+
+
+
+Jennings, et al.            Standards Track                     [Page 2]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   8.  STUN Keep-Alive Processing . . . . . . . . . . . . . . . . . . 28
+     8.1.  Use with SigComp . . . . . . . . . . . . . . . . . . . . . 29
+   9.  Example Message Flow . . . . . . . . . . . . . . . . . . . . . 30
+     9.1.  Subscription to Configuration Package  . . . . . . . . . . 30
+     9.2.  Registration . . . . . . . . . . . . . . . . . . . . . . . 32
+     9.3.  Incoming Call and Proxy Crash  . . . . . . . . . . . . . . 34
+     9.4.  Re-Registration  . . . . . . . . . . . . . . . . . . . . . 37
+     9.5.  Outgoing Call  . . . . . . . . . . . . . . . . . . . . . . 38
+   10. Grammar  . . . . . . . . . . . . . . . . . . . . . . . . . . . 40
+   11. IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 40
+     11.1. Flow-Timer Header Field  . . . . . . . . . . . . . . . . . 40
+     11.2. "reg-id" Contact Header Field Parameter  . . . . . . . . . 40
+     11.3. SIP/SIPS URI Parameters  . . . . . . . . . . . . . . . . . 41
+     11.4. SIP Option Tag . . . . . . . . . . . . . . . . . . . . . . 41
+     11.5. 430 (Flow Failed) Response Code  . . . . . . . . . . . . . 41
+     11.6. 439 (First Hop Lacks Outbound Support) Response Code . . . 42
+     11.7. Media Feature Tag  . . . . . . . . . . . . . . . . . . . . 42
+   12. Security Considerations  . . . . . . . . . . . . . . . . . . . 43
+   13. Operational Notes on Transports  . . . . . . . . . . . . . . . 44
+   14. Requirements . . . . . . . . . . . . . . . . . . . . . . . . . 44
+   15. Acknowledgments  . . . . . . . . . . . . . . . . . . . . . . . 45
+   16. References . . . . . . . . . . . . . . . . . . . . . . . . . . 45
+     16.1. Normative References . . . . . . . . . . . . . . . . . . . 45
+     16.2. Informative References . . . . . . . . . . . . . . . . . . 47
+   Appendix A.  Default Flow Registration Backoff Times . . . . . . . 49
+   Appendix B.  ABNF  . . . . . . . . . . . . . . . . . . . . . . . . 49
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 3]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+1.  Introduction
+
+   There are many environments for SIP [RFC3261] deployments in which
+   the User Agent (UA) can form a connection to a registrar or proxy but
+   in which connections in the reverse direction to the UA are not
+   possible.  This can happen for several reasons, but the most likely
+   is a NAT or a firewall in between the SIP UA and the proxy.  Many
+   such devices will only allow outgoing connections.  This
+   specification allows a SIP User Agent behind such a firewall or NAT
+   to receive inbound traffic associated with registrations or dialogs
+   that it initiates.
+
+   Most IP phones and personal computers get their network
+   configurations dynamically via a protocol such as the Dynamic Host
+   Configuration Protocol (DHCP) [RFC2131].  These systems typically do
+   not have a useful name in the Domain Name System (DNS) [RFC1035], and
+   they almost never have a long-term, stable DNS name that is
+   appropriate for use in the subjectAltName of a certificate, as
+   required by [RFC3261].  However, these systems can still act as a
+   Transport Layer Security (TLS) [RFC5246] client and form outbound
+   connections to a proxy or registrar that authenticates with a server
+   certificate.  The server can authenticate the UA using a shared
+   secret in a digest challenge (as defined in Section 22 of RFC 3261)
+   over that TLS connection.  This specification allows a SIP User Agent
+   who has to initiate the TLS connection to receive inbound traffic
+   associated with registrations or dialogs that it initiates.
+
+   The key idea of this specification is that when a UA sends a REGISTER
+   request or a dialog-forming request, the proxy can later use this
+   same network "flow" -- whether this is a bidirectional stream of UDP
+   datagrams, a TCP connection, or an analogous concept in another
+   transport protocol -- to forward any incoming requests that need to
+   go to this UA in the context of the registration or dialog.
+
+   For a UA to receive incoming requests, the UA has to connect to a
+   server.  Since the server can't connect to the UA, the UA has to make
+   sure that a flow is always active.  This requires the UA to detect
+   when a flow fails.  Since such detection takes time and leaves a
+   window of opportunity for missed incoming requests, this mechanism
+   allows the UA to register over multiple flows at the same time.  This
+   specification also defines two keep-alive schemes.  The keep-alive
+   mechanism is used to keep NAT bindings fresh, and to allow the UA to
+   detect when a flow has failed.
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 4]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+2.  Conventions and Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.1.  Definitions
+
+   Authoritative Proxy:  A proxy that handles non-REGISTER requests for
+      a specific Address-of-Record (AOR), performs the logical Location
+      Server lookup described in [RFC3261], and forwards those requests
+      to specific Contact URIs.  (In [RFC3261], the role that is
+      authoritative for REGISTER requests for a specific AOR is a
+      Registration Server.)
+
+   Edge Proxy:  An edge proxy is any proxy that is located topologically
+      between the registering User Agent and the Authoritative Proxy.
+      The "first" edge proxy refers to the first edge proxy encountered
+      when a UA sends a request.
+
+   Flow:  A Flow is a transport-layer association between two hosts that
+      is represented by the network address and port number of both ends
+      and by the transport protocol.  For TCP, a flow is equivalent to a
+      TCP connection.  For UDP a flow is a bidirectional stream of
+      datagrams between a single pair of IP addresses and ports of both
+      peers.  With TCP, a flow often has a one-to-one correspondence
+      with a single file descriptor in the operating system.
+
+   Flow Token:  An identifier that uniquely identifies a flow which can
+      be included in a SIP URI (Uniform Resource Identifier [RFC3986]).
+
+   reg-id:  This refers to the value of a new header field parameter
+      value for the Contact header field.  When a UA registers multiple
+      times, each for a different flow, each concurrent registration
+      gets a unique reg-id value.
+
+   instance-id:  This specification uses the word instance-id to refer
+      to the value of the "sip.instance" media feature tag which appears
+      as a "+sip.instance" Contact header field parameter.  This is a
+      Uniform Resource Name (URN) that uniquely identifies this specific
+      UA instance.
+
+   "ob" Parameter:  The "ob" parameter is a SIP URI parameter that has a
+      different meaning depending on context.  In a Path header field
+      value, it is used by the first edge proxy to indicate that a flow
+      token was added to the URI.  In a Contact or Route header field
+      value, it indicates that the UA would like other requests in the
+      same dialog to be routed over the same flow.
+
+
+
+Jennings, et al.            Standards Track                     [Page 5]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   outbound-proxy-set:  A set of SIP URIs (Uniform Resource Identifiers)
+      that represents each of the outbound proxies (often edge proxies)
+      with which the UA will attempt to maintain a direct flow.  The
+      first URI in the set is often referred to as the primary outbound
+      proxy and the second as the secondary outbound proxy.  There is no
+      difference between any of the URIs in this set, nor does the
+      primary/secondary terminology imply that one is preferred over the
+      other.
+
+3.  Overview
+
+   The mechanisms defined in this document are useful in several
+   scenarios discussed below, including the simple co-located registrar
+   and proxy, a User Agent desiring multiple connections to a resource
+   (for redundancy, for example), and a system that uses edge proxies.
+
+   This entire section is non-normative.
+
+3.1.  Summary of Mechanism
+
+   Each UA has a unique instance-id that stays the same for this UA even
+   if the UA reboots or is power cycled.  Each UA can register multiple
+   times over different flows for the same SIP Address of Record (AOR)
+   to achieve high reliability.  Each registration includes the
+   instance-id for the UA and a reg-id label that is different for each
+   flow.  The registrar can use the instance-id to recognize that two
+   different registrations both correspond to the same UA.  The
+   registrar can use the reg-id label to recognize whether a UA is
+   creating a new flow or refreshing or replacing an old one, possibly
+   after a reboot or a network failure.
+
+   When a proxy goes to route a message to a UA for which it has a
+   binding, it can use any one of the flows on which a successful
+   registration has been completed.  A failure to deliver a request on a
+   particular flow can be tried again on an alternate flow.  Proxies can
+   determine which flows go to the same UA by comparing the instance-id.
+   Proxies can tell that a flow replaces a previously abandoned flow by
+   looking at the reg-id.
+
+   When sending a dialog-forming request, a UA can also ask its first
+   edge proxy to route subsequent requests in that dialog over the same
+   flow.  This is necessary whether the UA has registered or not.
+
+   UAs use a simple periodic message as a keep-alive mechanism to keep
+   their flow to the proxy or registrar alive.  For connection-oriented
+   transports such as TCP this is based on carriage-return and line-feed
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 6]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   sequences (CRLF), while for transports that are not connection
+   oriented, this is accomplished by using a SIP-specific usage profile
+   of STUN (Session Traversal Utilities for NAT) [RFC5389].
+
+3.2.  Single Registrar and UA
+
+   In the topology shown below, a single server is acting as both a
+   registrar and proxy.
+
+      +-----------+
+      | Registrar |
+      | Proxy     |
+      +-----+-----+
+            |
+            |
+       +----+--+
+       | User  |
+       | Agent |
+       +-------+
+
+   User Agents that form only a single flow continue to register
+   normally but include the instance-id as described in Section 4.1.
+   The UA also includes a "reg-id" Contact header field parameter that
+   is used to allow the registrar to detect and avoid keeping invalid
+   contacts when a UA reboots or reconnects after its old connection has
+   failed for some reason.
+
+   For clarity, here is an example.  Bob's UA creates a new TCP flow to
+   the registrar and sends the following REGISTER request.
+
+   REGISTER sip:example.com SIP/2.0
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bK-bad0ce-11-1036
+   Max-Forwards: 70
+   From: Bob <sip:bob@example.com>;tag=d879h76
+   To: Bob <sip:bob@example.com>
+   Call-ID: 8921348ju72je840.204
+   CSeq: 1 REGISTER
+   Supported: path, outbound
+   Contact: <sip:line1@192.0.2.2;transport=tcp>; reg-id=1;
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-000A95A0E128>"
+   Content-Length: 0
+
+   The registrar challenges this registration to authenticate Bob.  When
+   the registrar adds an entry for this contact under the AOR for Bob,
+   the registrar also keeps track of the connection over which it
+   received this registration.
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 7]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The registrar saves the instance-id
+   ("urn:uuid:00000000-0000-1000-8000-000A95A0E128") and reg-id ("1")
+   along with the rest of the Contact header field.  If the instance-id
+   and reg-id are the same as a previous registration for the same AOR,
+   the registrar replaces the old Contact URI and flow information.
+   This allows a UA that has rebooted to replace its previous
+   registration for each flow with minimal impact on overall system
+   load.
+
+   When Alice sends a request to Bob, his authoritative proxy selects
+   the target set.  The proxy forwards the request to elements in the
+   target set based on the proxy's policy.  The proxy looks at the
+   target set and uses the instance-id to understand if two targets both
+   end up routing to the same UA.  When the proxy goes to forward a
+   request to a given target, it looks and finds the flows over which it
+   received the registration.  The proxy then forwards the request over
+   an existing flow, instead of resolving the Contact URI using the
+   procedures in [RFC3263] and trying to form a new flow to that
+   contact.
+
+   As described in the next section, if the proxy has multiple flows
+   that all go to this UA, the proxy can choose any one of the
+   registration bindings for this AOR that has the same instance-id as
+   the selected UA.
+
+3.3.  Multiple Connections from a User Agent
+
+   There are various ways to deploy SIP to build a reliable and scalable
+   system.  This section discusses one such design that is possible with
+   the mechanisms in this specification.  Other designs are also
+   possible.
+
+   In the example system below, the logical outbound proxy/registrar for
+   the domain is running on two hosts that share the appropriate state
+   and can both provide registrar and outbound proxy functionality for
+   the domain.  The UA will form connections to two of the physical
+   hosts that can perform the authoritative proxy/registrar function for
+   the domain.  Reliability is achieved by having the UA form two TCP
+   connections to the domain.
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 8]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+       +-------------------+
+       | Domain            |
+       | Logical Proxy/Reg |
+       |                   |
+       |+-----+     +-----+|
+       ||Host1|     |Host2||
+       |+-----+     +-----+|
+       +---\------------/--+
+            \          /
+             \        /
+              \      /
+               \    /
+              +------+
+              | User |
+              | Agent|
+              +------+
+
+   The UA is configured with multiple outbound proxy registration URIs.
+   These URIs are configured into the UA through whatever the normal
+   mechanism is to configure the proxy address and AOR in the UA.  If
+   the AOR is alice@example.com, the outbound-proxy-set might look
+   something like "sip:primary.example.com" and "sip:
+   secondary.example.com".  Note that each URI in the outbound-proxy-set
+   could resolve to several different physical hosts.  The
+   administrative domain that created these URIs should ensure that the
+   two URIs resolve to separate hosts.  These URIs are handled according
+   to normal SIP processing rules, so mechanisms like DNS SRV [RFC2782]
+   can be used to do load-balancing across a proxy farm.  The approach
+   in this document does not prevent future extensions, such as the SIP
+   UA configuration framework [CONFIG-FMWK], from adding other ways for
+   a User Agent to discover its outbound-proxy-set.
+
+   The domain also needs to ensure that a request for the UA sent to
+   Host1 or Host2 is then sent across the appropriate flow to the UA.
+   The domain might choose to use the Path header approach (as described
+   in the next section) to store this internal routing information on
+   Host1 or Host2.
+
+   When a single server fails, all the UAs that have a flow through it
+   will detect a flow failure and try to reconnect.  This can cause
+   large loads on the server.  When large numbers of hosts reconnect
+   nearly simultaneously, this is referred to as the avalanche restart
+   problem, and is further discussed in Section 4.5.  The multiple flows
+   to many servers help reduce the load caused by the avalanche restart.
+   If a UA has multiple flows, and one of the servers fails, the UA
+   delays a recommended amount of time before trying to form a new
+
+
+
+
+
+Jennings, et al.            Standards Track                     [Page 9]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   connection to replace the flow to the server that failed.  By
+   spreading out the time used for all the UAs to reconnect to a server,
+   the load on the server farm is reduced.
+
+   Scalability is achieved by using DNS SRV [RFC2782] to load-balance
+   the primary connection across a set of machines that can service the
+   primary connection, and also using DNS SRV to load-balance across a
+   separate set of machines that can service the secondary connection.
+   The deployment here requires that DNS is configured with one entry
+   that resolves to all the primary hosts and another entry that
+   resolves to all the secondary hosts.  While this introduces
+   additional DNS configuration, the approach works and requires no
+   additional SIP extensions to [RFC3263].
+
+   Another motivation for maintaining multiple flows between the UA and
+   its registrar is related to multihomed UAs.  Such UAs can benefit
+   from multiple connections from different interfaces to protect
+   against the failure of an individual access link.
+
+3.4.  Edge Proxies
+
+   Some SIP deployments use edge proxies such that the UA sends the
+   REGISTER to an edge proxy that then forwards the REGISTER to the
+   registrar.  There could be a NAT or firewall between the UA and the
+   edge proxy.
+
+                +---------+
+                |Registrar|
+                |Proxy    |
+                +---------+
+                 /      \
+                /        \
+               /          \
+            +-----+     +-----+
+            |Edge1|     |Edge2|
+            +-----+     +-----+
+               \           /
+                \         /
+        ----------------------------NAT/FW
+                  \     /
+                   \   /
+                  +------+
+                  |User  |
+                  |Agent |
+                  +------+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 10]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The edge proxy includes a Path header [RFC3327] so that when the
+   proxy/registrar later forwards a request to this UA, the request is
+   routed through the edge proxy.
+
+   These systems can use effectively the same mechanism as described in
+   the previous sections but need to use the Path header.  When the edge
+   proxy receives a registration, it needs to create an identifier value
+   that is unique to this flow (and not a subsequent flow with the same
+   addresses) and put this identifier in the Path header URI.  This
+   identifier has two purposes.  First, it allows the edge proxy to map
+   future requests back to the correct flow.  Second, because the
+   identifier will only be returned if the user authenticates with the
+   registrar successfully, it allows the edge proxy to indirectly check
+   the user's authentication information via the registrar.  The
+   identifier is placed in the user portion of a loose route in the Path
+   header.  If the registration succeeds, the edge proxy needs to map
+   future requests (that are routed to the identifier value from the
+   Path header) to the associated flow.
+
+   The term edge proxy is often used to refer to deployments where the
+   edge proxy is in the same administrative domain as the registrar.
+   However, in this specification we use the term to refer to any proxy
+   between the UA and the registrar.  For example, the edge proxy may be
+   inside an enterprise that requires its use, and the registrar could
+   be from a service provider with no relationship to the enterprise.
+   Regardless of whether they are in the same administrative domain,
+   this specification requires that registrars and edge proxies support
+   the Path header mechanism in [RFC3327].
+
+3.5.  Keep-Alive Technique
+
+   This document describes two keep-alive mechanisms: a CRLF keep-alive
+   and a STUN keep-alive.  Each of these mechanisms uses a client-to-
+   server "ping" keep-alive and a corresponding server-to-client "pong"
+   message.  This ping-pong sequence allows the client, and optionally
+   the server, to tell if its flow is still active and useful for SIP
+   traffic.  The server responds to pings by sending pongs.  If the
+   client does not receive a pong in response to its ping (allowing for
+   retransmission for STUN as described in Section 4.4.2), it declares
+   the flow dead and opens a new flow in its place.
+
+   This document also suggests timer values for these client keep-alive
+   mechanisms.  These timer values were chosen to keep most NAT and
+   firewall bindings open, to detect unresponsive servers within 2
+   minutes, and to mitigate against the avalanche restart problem.
+   However, the client may choose different timer values to suit its
+   needs, for example to optimize battery life.  In some environments,
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 11]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   the server can also keep track of the time since a ping was received
+   over a flow to guess the likelihood that the flow is still useful for
+   delivering SIP messages.
+
+   When the UA detects that a flow has failed or that the flow
+   definition has changed, the UA needs to re-register and will use the
+   back-off mechanism described in Section 4.5 to provide congestion
+   relief when a large number of agents simultaneously reboot.
+
+   A keep-alive mechanism needs to keep NAT bindings refreshed; for
+   connections, it also needs to detect failure of a connection; and for
+   connectionless transports, it needs to detect flow failures including
+   changes to the NAT public mapping.  For connection-oriented
+   transports such as TCP [RFC0793] and SCTP [RFC4960], this
+   specification describes a keep-alive approach based on sending CRLFs.
+   For connectionless transport, such as UDP [RFC0768], this
+   specification describes using STUN [RFC5389] over the same flow as
+   the SIP traffic to perform the keep-alive.
+
+   UAs and Proxies are also free to use native transport keep-alives;
+   however, the application may not be able to set these timers on a
+   per-connection basis, and the server certainly cannot make any
+   assumption about what values are used.  Use of native transport
+   keep-alives is outside the scope of this document.
+
+3.5.1.  CRLF Keep-Alive Technique
+
+   This approach can only be used with connection-oriented transports
+   such as TCP or SCTP.  The client periodically sends a double-CRLF
+   (the "ping") then waits to receive a single CRLF (the "pong").  If
+   the client does not receive a "pong" within an appropriate amount of
+   time, it considers the flow failed.
+
+      Note: Sending a CRLF over a connection-oriented transport is
+      backwards compatible (because of requirements in Section 7.5 of
+      [RFC3261]), but only implementations which support this
+      specification will respond to a "ping" with a "pong".
+
+3.5.2.  STUN Keep-Alive Technique
+
+   This approach can only be used for connection-less transports, such
+   as UDP.
+
+   For connection-less transports, a flow definition could change
+   because a NAT device in the network path reboots and the resulting
+   public IP address or port mapping for the UA changes.  To detect
+   this, STUN requests are sent over the same flow that is being used
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 12]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   for the SIP traffic.  The proxy or registrar acts as a limited
+   Session Traversal Utilities for NAT (STUN) [RFC5389] server on the
+   SIP signaling port.
+
+      Note: The STUN mechanism is very robust and allows the detection
+      of a changed IP address and port.  Many other options were
+      considered, but the SIP Working Group selected the STUN-based
+      approach.  Approaches using SIP requests were abandoned because
+      many believed that good performance and full backwards
+      compatibility using this method were mutually exclusive.
+
+4.  User Agent Procedures
+
+4.1.  Instance ID Creation
+
+   Each UA MUST have an Instance Identifier Uniform Resource Name (URN)
+   [RFC2141] that uniquely identifies the device.  Usage of a URN
+   provides a persistent and unique name for the UA instance.  It also
+   provides an easy way to guarantee uniqueness within the AOR.  This
+   URN MUST be persistent across power cycles of the device.  The
+   instance ID MUST NOT change as the device moves from one network to
+   another.
+
+   A UA SHOULD create a Universally Unique Identifier (UUID) URN
+   [RFC4122] as its instance-id.  The UUID URN allows for non-
+   centralized computation of a URN based on time, unique names (such as
+   a MAC address), or a random number generator.
+
+      Note: A device like a "soft phone", when first installed, can
+      generate a UUID [RFC4122] and then save this in persistent storage
+      for all future use.  For a device such as a "hard phone", which
+      will only ever have a single SIP UA present, the UUID can include
+      the MAC address and be generated at any time because it is
+      guaranteed that no other UUID is being generated at the same time
+      on that physical device.  This means the value of the time
+      component of the UUID can be arbitrarily selected to be any time
+      less than the time when the device was manufactured.  A time of 0
+      (as shown in the example in Section 3.2) is perfectly legal as
+      long as the device knows no other UUIDs were generated at this
+      time on this device.
+
+   If a URN scheme other than UUID is used, the UA MUST only use URNs
+   for which an RFC (from the IETF stream) defines how the specific URN
+   needs to be constructed and used in the "+sip.instance" Contact
+   header field parameter for outbound behavior.
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 13]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   To convey its instance-id in both requests and responses, the UA
+   includes a "sip.instance" media feature tag as a UA characteristic
+   [RFC3840].  This media feature tag is encoded in the Contact header
+   field as the "+sip.instance" Contact header field parameter.  One
+   case where a UA could prefer to omit the "sip.instance" media feature
+   tag is when it is making an anonymous request or some other privacy
+   concern requires that the UA not reveal its identity.
+
+      Note: [RFC3840] defines equality rules for callee capabilities
+      parameters, and according to that specification, the
+      "sip.instance" media feature tag will be compared by case-
+      sensitive string comparison.  This means that the URN will be
+      encapsulated by angle brackets ("<" and ">") when it is placed
+      within the quoted string value of the "+sip.instance" Contact
+      header field parameter.  The case-sensitive matching rules apply
+      only to the generic usages defined in the callee capabilities
+      [RFC3840] and the caller preferences [RFC3841] specifications.
+      When the instance ID is used in this specification, it is
+      "extracted" from the value in the "sip.instance" media feature
+      tag.  Thus, equality comparisons are performed using the rules for
+      URN equality that are specific to the scheme in the URN.  If the
+      element performing the comparisons does not understand the URN
+      scheme, it performs the comparisons using the lexical equality
+      rules defined in [RFC2141].  Lexical equality could result in two
+      URNs being considered unequal when they are actually equal.  In
+      this specific usage of URNs, the only element that provides the
+      URN is the SIP UA instance identified by that URN.  As a result,
+      the UA instance has to provide lexically equivalent URNs in each
+      registration it generates.  This is likely to be normal behavior
+      in any case; clients are not likely to modify the value of the
+      instance ID so that it remains functionally equivalent to (yet
+      lexicographically different from) previous registrations.
+
+4.2.  Registrations
+
+4.2.1.  Initial Registrations
+
+   At configuration time, UAs obtain one or more SIP URIs representing
+   the default outbound-proxy-set.  This specification assumes the set
+   is determined via any of a number of configuration mechanisms, and
+   future specifications can define additional mechanisms such as using
+   DNS to discover this set.  How the UA is configured is outside the
+   scope of this specification.  However, a UA MUST support sets with at
+   least two outbound proxy URIs and SHOULD support sets with up to four
+   URIs.
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 14]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   For each outbound proxy URI in the set, the User Agent Client (UAC)
+   SHOULD send a REGISTER request using this URI as the default outbound
+   proxy.  (Alternatively, the UA could limit the number of flows formed
+   to conserve battery power, for example).  If the set has more than
+   one URI, the UAC MUST send a REGISTER request to at least two of the
+   default outbound proxies from the set.  UAs that support this
+   specification MUST include the outbound option tag in a Supported
+   header field in a REGISTER request.  Each of these REGISTER requests
+   will use a unique Call-ID.  Forming the route set for the request is
+   outside the scope of this document, but typically results in sending
+   the REGISTER such that the topmost Route header field contains a
+   loose route to the outbound proxy URI.
+
+   REGISTER requests, other than those described in Section 4.2.3, MUST
+   include an instance-id media feature tag as specified in Section 4.1.
+
+   A UAC conforming to this specification MUST include in the Contact
+   header field, a "reg-id" parameter that is distinct from other
+   "reg-id" parameters used in other registrations that use the same
+   "+sip.instance" Contact header field parameter and AOR.  Each one of
+   these registrations will form a new flow from the UA to the proxy.
+   The sequence of reg-id values does not have to be sequential but MUST
+   be exactly the same sequence of reg-id values each time the UA
+   instance power cycles or reboots, so that the reg-id values will
+   collide with the previously used reg-id values.  This is so the
+   registrar can replace the older registrations.
+
+      Note: The UAC can situationally decide whether to request outbound
+      behavior by including or omitting the "reg-id" Contact header
+      field parameter.  For example, imagine the outbound-proxy-set
+      contains two proxies in different domains, EP1 and EP2.  If an
+      outbound-style registration succeeded for a flow through EP1, the
+      UA might decide to include 'outbound' in its Require header field
+      when registering with EP2, in order to ensure consistency.
+      Similarly, if the registration through EP1 did not support
+      outbound, the UA might not register with EP2 at all.
+
+   The UAC MUST support the Path header [RFC3327] mechanism, and
+   indicate its support by including the 'path' option-tag in a
+   Supported header field value in its REGISTER requests.  Other than
+   optionally examining the Path vector in the response, this is all
+   that is required of the UAC to support Path.
+
+   The UAC examines successful registration responses for the presence
+   of an outbound option-tag in a Require header field value.  Presence
+   of this option-tag indicates that the registrar is compliant with
+   this specification, and that any edge proxies which needed to
+   participate are also compliant.  If the registrar did not support
+
+
+
+Jennings, et al.            Standards Track                    [Page 15]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   outbound, the UA has potentially registered an un-routable contact.
+   It is the responsibility of the UA to remove any inappropriate
+   Contacts.
+
+   If outbound registration succeeded, as indicated by the presence of
+   the outbound option-tag in the Require header field of a successful
+   registration response, the UA begins sending keep-alives as described
+   in Section 4.4.
+
+      Note: The UA needs to honor 503 (Service Unavailable) responses to
+      registrations as described in [RFC3261] and [RFC3263].  In
+      particular, implementors should note that when receiving a 503
+      (Service Unavailable) response with a Retry-After header field,
+      the UA is expected to wait the indicated amount of time and retry
+      the registration.  A Retry-After header field value of 0 is valid
+      and indicates the UA is expected to retry the REGISTER request
+      immediately.  Implementations need to ensure that when retrying
+      the REGISTER request, they revisit the DNS resolution results such
+      that the UA can select an alternate host from the one chosen the
+      previous time the URI was resolved.
+
+   If the registering UA receives a 439 (First Hop Lacks Outbound
+   Support) response to a REGISTER request, it MAY re-attempt
+   registration without using the outbound mechanism (subject to local
+   policy at the client).  If the client has one or more alternate
+   outbound proxies available, it MAY re-attempt registration through
+   such outbound proxies.  See Section 11.6 for more information on the
+   439 response code.
+
+4.2.2.  Subsequent REGISTER Requests
+
+   Registrations for refreshing a binding and for removing a binding use
+   the same instance-id and reg-id values as the corresponding initial
+   registration where the binding was added.  Registrations that merely
+   refresh an existing binding are sent over the same flow as the
+   original registration where the binding was added.
+
+   If a re-registration is rejected with a recoverable error response,
+   for example by a 503 (Service Unavailable) containing a Retry-After
+   header, the UAC SHOULD NOT tear down the corresponding flow if the
+   flow uses a connection-oriented transport such as TCP.  As long as
+   "pongs" are received in response to "pings", the flow SHOULD be kept
+   active until a non-recoverable error response is received.  This
+   prevents unnecessary closing and opening of connections.
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 16]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+4.2.3.  Third-Party Registrations
+
+   In an initial registration or re-registration, a UA MUST NOT include
+   a "reg-id" header field parameter in the Contact header field if the
+   registering UA is not the same instance as the UA referred to by the
+   target Contact header field.  (This practice is occasionally used to
+   install forwarding policy into registrars.)
+
+   A UAC also MUST NOT include an instance-id feature tag or "reg-id"
+   Contact header field parameter in a request to un-register all
+   Contacts (a single Contact header field value with the value of "*").
+
+4.3.  Sending Non-REGISTER Requests
+
+   When a UAC is about to send a request, it first performs normal
+   processing to select the next hop URI.  The UA can use a variety of
+   techniques to compute the route set and accordingly the next hop URI.
+   Discussion of these techniques is outside the scope of this document.
+   UAs that support this specification SHOULD include the outbound
+   option tag in a Supported header field in a request that is not a
+   REGISTER request.
+
+   The UAC performs normal DNS resolution on the next hop URI (as
+   described in [RFC3263]) to find a protocol, IP address, and port.
+   For protocols that don't use TLS, if the UAC has an existing flow to
+   this IP address, and port with the correct protocol, then the UAC
+   MUST use the existing connection.  For TLS protocols, there MUST also
+   be a match between the host production in the next hop and one of the
+   URIs contained in the subjectAltName in the peer certificate.  If the
+   UAC cannot use one of the existing flows, then it SHOULD form a new
+   flow by sending a datagram or opening a new connection to the next
+   hop, as appropriate for the transport protocol.
+
+   Typically, a UAC using the procedures of this document and sending a
+   dialog-forming request will want all subsequent requests in the
+   dialog to arrive over the same flow.  If the UAC is using a Globally
+   Routable UA URI (GRUU) [RFC5627] that was instantiated using a
+   Contact header field value that included an "ob" parameter, the UAC
+   sends the request over the flow used for registration, and subsequent
+   requests will arrive over that same flow.  If the UAC is not using
+   such a GRUU, then the UAC adds an "ob" parameter to its Contact
+   header field value.  This will cause all subsequent requests in the
+   dialog to arrive over the flow instantiated by the dialog-forming
+   request.  This case is typical when the request is sent prior to
+   registration, such as in the initial subscription dialog for the
+   configuration framework [CONFIG-FMWK].
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 17]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+      Note: If the UAC wants a UDP flow to work through NATs or
+      firewalls, it still needs to put the 'rport' parameter [RFC3581]
+      in its Via header field value, and send from the port it is
+      prepared to receive on.  More general information about NAT
+      traversal in SIP is described in [NAT-SCEN].
+
+4.4.  Keep-Alives and Detecting Flow Failure
+
+   Keep-alives are used for refreshing NAT/firewall bindings and
+   detecting flow failure.  Flows can fail for many reasons including
+   the rebooting of NATs and the crashing of edge proxies.
+
+   As described in Section 4.2, a UA that registers will begin sending
+   keep-alives after an appropriate registration response.  A UA that
+   does not register (for example, a PSTN gateway behind a firewall) can
+   also send keep-alives under certain circumstances.
+
+   Under specific circumstances, a UAC might be allowed to send STUN
+   keep-alives even if the procedures in Section 4.2 were not completed,
+   provided that there is an explicit indication that the target first-
+   hop SIP node supports STUN keep-alives.  For example, this applies to
+   a non-registering UA or to a case where the UA registration
+   succeeded, but the response did not include the outbound option-tag
+   in the Require header field.
+
+      Note: A UA can "always" send a double CRLF (a "ping") over
+      connection-oriented transports as this is already allowed by
+      Section 7.5 of [RFC3261].  However a UA that did not register
+      using outbound registration cannot expect a CRLF in response (a
+      "pong") unless the UA has an explicit indication that CRLF keep-
+      alives are supported as described in this section.  Likewise, a UA
+      that did not successfully register with outbound procedures needs
+      explicit indication that the target first-hop SIP node supports
+      STUN keep-alives before it can send any STUN messages.
+
+   A configuration option indicating keep-alive support for a specific
+   target is considered an explicit indication.  If these conditions are
+   satisfied, the UA sends its keep-alives according to the same
+   guidelines as those used when UAs register; these guidelines are
+   described below.
+
+   The UA needs to detect when a specific flow fails.  The UA actively
+   tries to detect failure by periodically sending keep-alive messages
+   using one of the techniques described in Sections 4.4.1 or 4.4.2.  If
+   a flow with a registration has failed, the UA follows the procedures
+   in Section 4.2 to form a new flow to replace the failed one.
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 18]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   When a successful registration response contains the Flow-Timer
+   header field, the value of this header field is the number of seconds
+   the server is prepared to wait without seeing keep-alives before it
+   could consider the corresponding flow dead.  Note that the server
+   would wait for an amount of time larger than the Flow-Timer in order
+   to have a grace period to account for transport delay.  The UA MUST
+   send keep-alives at least as often as this number of seconds.  If the
+   UA uses the server-recommended keep-alive frequency it SHOULD send
+   its keep-alives so that the interval between each keep-alive is
+   randomly distributed between 80% and 100% of the server-provided
+   time.  For example, if the server suggests 120 seconds, the UA would
+   send each keep-alive with a different frequency between 95 and 120
+   seconds.
+
+   If no Flow-Timer header field was present in a register response for
+   this flow, the UA can send keep-alives at its discretion.  The
+   sections below provide RECOMMENDED default values for these keep-
+   alives.
+
+   The client needs to perform normal [RFC3263] SIP DNS resolution on
+   the URI from the outbound-proxy-set to pick a transport.  Once a
+   transport is selected, the UA selects the keep-alive approach that is
+   recommended for that transport.
+
+   Section 4.4.1 describes a keep-alive mechanism for connection-
+   oriented transports such as TCP or SCTP.  Section 4.4.2 describes a
+   keep-alive mechanism for connection-less transports such as UDP.
+   Support for other transports such as DCCP [RFC4340] is for further
+   study.
+
+4.4.1.  Keep-Alive with CRLF
+
+   This approach MUST only be used with connection oriented transports
+   such as TCP or SCTP; it MUST NOT be used with connection-less
+   transports such as UDP.
+
+   A User Agent that forms flows checks if the configured URI to which
+   the UA is connecting resolves to a connection-oriented transport
+   (e.g., TCP and TLS over TCP).
+
+   For this mechanism, the client "ping" is a double-CRLF sequence, and
+   the server "pong" is a single CRLF, as defined in the ABNF below:
+
+   CRLF = CR LF
+   double-CRLF = CR LF CR LF
+   CR = %x0D
+   LF = %x0A
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 19]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The "ping" and "pong" need to be sent between SIP messages and cannot
+   be sent in the middle of a SIP message.  If sending over TLS, the
+   CRLFs are sent inside the TLS protected channel.  If sending over a
+   SigComp [RFC3320] compressed data stream, the CRLF keep-alives are
+   sent inside the compressed stream.  The double CRLF is considered a
+   single SigComp message.  The specific mechanism for representing
+   these characters is an implementation-specific matter to be handled
+   by the SigComp compressor at the sending end.
+
+   If a pong is not received within 10 seconds after sending a ping (or
+   immediately after processing any incoming message being received when
+   that 10 seconds expires), then the client MUST treat the flow as
+   failed.  Clients MUST support this CRLF keep-alive.
+
+      Note: This value of 10-second timeout was selected to be long
+      enough that it allows plenty of time for a server to send a
+      response even if the server is temporarily busy with an
+      administrative activity.  At the same time, it was selected to be
+      small enough that a UA registered to two redundant servers with
+      unremarkable hardware uptime could still easily provide very high
+      levels of overall reliability.  Although some Internet protocols
+      are designed for round-trip times over 10 seconds, SIP for real-
+      time communications is not really usable in these type of
+      environments as users often abandon calls before waiting much more
+      than a few seconds.
+
+   When a Flow-Timer header field is not provided in the most recent
+   success registration response, the proper selection of keep-alive
+   frequency is primarily a trade-off between battery usage and
+   availability.  The UA MUST select a random number between a fixed or
+   configurable upper bound and a lower bound, where the lower bound is
+   20% less then the upper bound.  The fixed upper bound or the default
+   configurable upper bound SHOULD be 120 seconds (95 seconds for the
+   lower bound) where battery power is not a concern and 840 seconds
+   (672 seconds for the lower bound) where battery power is a concern.
+   The random number will be different for each keep-alive "ping".
+
+      Note on selection of time values: the 120-second upper bound was
+      chosen based on the idea that for a good user experience, failures
+      normally will be detected in this amount of time and a new
+      connection will be set up.  The 14-minute upper bound for battery-
+      powered devices was selected based on NATs with TCP timeouts as
+      low as 15 minutes.  Operators that wish to change the relationship
+      between load on servers and the expected time that a user might
+      not receive inbound communications will probably adjust this time.
+      The 95-second lower bound was chosen so that the jitter introduced
+      will result in a relatively even load on the servers after 30
+      minutes.
+
+
+
+Jennings, et al.            Standards Track                    [Page 20]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+4.4.2.  Keep-Alive with STUN
+
+   This approach MUST only be used with connection-less transports, such
+   as UDP; it MUST NOT be used for connection-oriented transports such
+   as TCP and SCTP.
+
+   A User Agent that forms flows checks if the configured URI to which
+   the UA is connecting resolves to use the UDP transport.  The UA can
+   periodically perform keep-alive checks by sending STUN [RFC5389]
+   Binding Requests over the flow as described in Section 8.  Clients
+   MUST support STUN-based keep-alives.
+
+   When a Flow-Timer header field is not included in a successful
+   registration response, the time between each keep-alive request
+   SHOULD be a random number between 24 and 29 seconds.
+
+      Note on selection of time values: the upper bound of 29 seconds
+      was selected, as many NATs have UDP timeouts as low as 30 seconds.
+      The 24-second lower bound was selected so that after 10 minutes
+      the jitter introduced by different timers will make the keep-alive
+      requests unsynchronized to evenly spread the load on the servers.
+      Note that the short NAT timeouts with UDP have a negative impact
+      on battery life.
+
+   If a STUN Binding Error Response is received, or if no Binding
+   Response is received after 7 retransmissions (16 times the STUN "RTO"
+   timer -- where RTO is an estimate of round-trip time), the UA
+   considers the flow failed.  If the XOR-MAPPED-ADDRESS in the STUN
+   Binding Response changes, the UA MUST treat this event as a failure
+   on the flow.
+
+4.5.  Flow Recovery
+
+   When a flow used for registration (through a particular URI in the
+   outbound-proxy-set) fails, the UA needs to form a new flow to replace
+   the old flow and replace any registrations that were previously sent
+   over this flow.  Each new registration MUST have the same reg-id
+   value as the registration it replaces.  This is done in much the same
+   way as forming a brand new flow as described in Section 4.2; however,
+   if there is a failure in forming this flow, the UA needs to wait a
+   certain amount of time before retrying to form a flow to this
+   particular next hop.
+
+   The amount of time to wait depends if the previous attempt at
+   establishing a flow was successful.  For the purposes of this
+   section, a flow is considered successful if outbound registration
+   succeeded, and if keep-alives are in use on this flow, at least one
+   subsequent keep-alive response was received.
+
+
+
+Jennings, et al.            Standards Track                    [Page 21]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The number of seconds to wait is computed in the following way.  If
+   all of the flows to every URI in the outbound proxy set have failed,
+   the base-time is set to a lower value (with a default of 30 seconds);
+   otherwise, in the case where at least one of the flows has not
+   failed, the base-time is set to a higher value (with a default of 90
+   seconds).  The upper-bound wait time (W) is computed by taking two
+   raised to the power of the number of consecutive registration
+   failures for that URI, and multiplying this by the base-time, up to a
+   configurable maximum time (with a default of 1800 seconds).
+
+   W = min (max-time, (base-time * (2 ^ consecutive-failures)))
+
+   These times MAY be configurable in the UA.  The three times are:
+
+   o  max-time with a default of 1800 seconds
+
+   o  base-time (if all failed) with a default of 30 seconds
+
+   o  base-time (if all have not failed) with a default of 90 seconds
+
+   For example, if the base-time is 30 seconds, and there were three
+   failures, then the upper-bound wait time is min(1800, 30*(2^3)) or
+   240 seconds.  The actual amount of time the UA waits before retrying
+   registration (the retry delay time) is computed by selecting a
+   uniform random time between 50 and 100% of the upper-bound wait time.
+   The UA MUST wait for at least the value of the retry delay time
+   before trying another registration to form a new flow for that URI (a
+   503 response to an earlier failed registration attempt with a Retry-
+   After header field value may cause the UA to wait longer).
+
+   To be explicitly clear on the boundary conditions: when the UA boots,
+   it immediately tries to register.  If this fails and no registration
+   on other flows succeed, the first retry happens somewhere between 30
+   and 60 seconds after the failure of the first registration request.
+   If the number of consecutive-failures is large enough that the
+   maximum of 1800 seconds is reached, the UA will keep trying
+   indefinitely with a random time of 15 to 30 minutes between each
+   attempt.
+
+5.  Edge Proxy Procedures
+
+5.1.  Processing Register Requests
+
+   When an edge proxy receives a registration request with a "reg-id"
+   header field parameter in the Contact header field, it needs to
+   determine if it (the edge proxy) will have to be visited for any
+   subsequent requests sent to the User Agent identified in the Contact
+   header field, or not.  If the edge proxy is the first hop, as
+
+
+
+Jennings, et al.            Standards Track                    [Page 22]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   indicated by the Via header field, it MUST insert its URI in a Path
+   header field value as described in [RFC3327].  If it is not the first
+   hop, it might still decide to add itself to the Path header based on
+   local policy.  In addition, if the edge proxy is the first SIP node
+   after the UAC, the edge proxy either MUST store a "flow token"
+   (containing information about the flow from the previous hop) in its
+   Path URI or reject the request.  The flow token MUST be an identifier
+   that is unique to this network flow.  The flow token MAY be placed in
+   the userpart of the URI.  In addition, the first node MUST include an
+   "ob" URI parameter in its Path header field value.  If the edge proxy
+   is not the first SIP node after the UAC it MUST NOT place an "ob" URI
+   parameter in a Path header field value.  The edge proxy can determine
+   if it is the first hop by examining the Via header field.
+
+5.2.  Generating Flow Tokens
+
+   A trivial but impractical way to satisfy the flow token requirement
+   in Section 5.1 involves storing a mapping between an incrementing
+   counter and the connection information; however, this would require
+   the edge proxy to keep an infeasible amount of state.  It is unclear
+   when this state could be removed, and the approach would have
+   problems if the proxy crashed and lost the value of the counter.  A
+   stateless example is provided below.  A proxy can use any algorithm
+   it wants as long as the flow token is unique to a flow, the flow can
+   be recovered from the token, and the token cannot be modified by
+   attackers.
+
+      Example Algorithm: When the proxy boots, it selects a 20-octet
+      crypto random key called K that only the edge proxy knows.  A byte
+      array, called S, is formed that contains the following information
+      about the flow the request was received on: an enumeration
+      indicating the protocol, the local IP address and port, the remote
+      IP address and port.  The HMAC of S is computed using the key K
+      and the HMAC-SHA1-80 algorithm, as defined in [RFC2104].  The
+      concatenation of the HMAC and S are base64 encoded, as defined in
+      [RFC4648], and used as the flow identifier.  When using IPv4
+      addresses, this will result in a 32-octet identifier.
+
+5.3.  Forwarding Non-REGISTER Requests
+
+   When an edge proxy receives a request, it applies normal routing
+   procedures with the following additions.  If the edge proxy receives
+   a request where the edge proxy is the host in the topmost Route
+   header field value, and the Route header field value contains a flow
+   token, the proxy follows the procedures of this section.  Otherwise
+   the edge proxy skips the procedures in this section, removes itself
+   from the Route header field, and continues processing the request.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 23]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The proxy decodes the flow token and compares the flow in the flow
+   token with the source of the request to determine if this is an
+   "incoming" or "outgoing" request.
+
+   If the flow in the flow token identified by the topmost Route header
+   field value matches the source IP address and port of the request,
+   the request is an "outgoing" request; otherwise, it is an "incoming"
+   request.
+
+5.3.1.  Processing Incoming Requests
+
+   If the Route header value contains an "ob" URI parameter, the Route
+   header was probably copied from the Path header in a registration.
+   If the Route header value contains an "ob" URI parameter, and the
+   request is a new dialog-forming request, the proxy needs to adjust
+   the route set to ensure that subsequent requests in the dialog can be
+   delivered over a valid flow to the UA instance identified by the flow
+   token.
+
+      Note: A simple approach to satisfy this requirement is for the
+      proxy to add a Record-Route header field value that contains the
+      flow-token, by copying the URI in the Route header minus the "ob"
+      parameter.
+
+   Next, whether the Route header field contained an "ob" URI parameter
+   or not, the proxy removes the Route header field value and forwards
+   the request over the 'logical flow' identified by the flow token,
+   that is known to deliver data to the specific target UA instance.  If
+   the flow token has been tampered with, the proxy SHOULD send a 403
+   (Forbidden) response.  If the flow no longer exists, the proxy SHOULD
+   send a 430 (Flow Failed) response to the request.
+
+   Proxies that used the example algorithm described in Section 5.2 to
+   form a flow token follow the procedures below to determine the
+   correct flow.  To decode the flow token, take the flow identifier in
+   the user portion of the URI and base64 decode it, then verify the
+   HMAC is correct by recomputing the HMAC and checking that it matches.
+   If the HMAC is not correct, the request has been tampered with.
+
+5.3.2.  Processing Outgoing Requests
+
+   For mid-dialog requests to work with outbound UAs, the requests need
+   to be forwarded over some valid flow to the appropriate UA instance.
+   If the edge proxy receives an outgoing dialog-forming request, the
+   edge proxy can use the presence of the "ob" URI parameter in the
+   UAC's Contact URI (or topmost Route header field) to determine if the
+   edge proxy needs to assist in mid-dialog request routing.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 24]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+      Implementation note: Specific procedures at the edge proxy to
+      ensure that mid-dialog requests are routed over an existing flow
+      are not part of this specification.  However, an approach such as
+      having the edge proxy add a Record-Route header with a flow token
+      is one way to ensure that mid-dialog requests are routed over the
+      correct flow.
+
+5.4.  Edge Proxy Keep-Alive Handling
+
+   All edge proxies compliant with this specification MUST implement
+   support for STUN NAT keep-alives on their SIP UDP ports as described
+   in Section 8.
+
+   When a server receives a double CRLF sequence between SIP messages on
+   a connection-oriented transport such as TCP or SCTP, it MUST
+   immediately respond with a single CRLF over the same connection.
+
+   The last proxy to forward a successful registration response to a UA
+   MAY include a Flow-Timer header field if the response contains the
+   outbound option-tag in a Require header field value in the response.
+   The reason a proxy would send a Flow-Timer is if it wishes to detect
+   flow failures proactively and take appropriate action (e.g., log
+   alarms, provide alternative treatment if incoming requests for the UA
+   are received, etc.).  The server MUST wait for an amount of time
+   larger than the Flow-Timer in order to have a grace period to account
+   for transport delay.
+
+6.  Registrar Procedures
+
+   This specification updates the definition of a binding in [RFC3261],
+   Section 10 and [RFC3327], Section 5.3.
+
+   Registrars that implement this specification MUST support the Path
+   header mechanism [RFC3327].
+
+   When receiving a REGISTER request, the registrar MUST check from its
+   Via header field if the registrar is the first hop or not.  If the
+   registrar is not the first hop, it MUST examine the Path header of
+   the request.  If the Path header field is missing or it exists but
+   the first URI does not have an "ob" URI parameter, then outbound
+   processing MUST NOT be applied to the registration.  In this case,
+   the following processing applies: if the REGISTER request contains
+   the reg-id and the outbound option tag in a Supported header field,
+   then the registrar MUST respond to the REGISTER request with a 439
+   (First Hop Lacks Outbound Support) response; otherwise, the registrar
+   MUST ignore the "reg-id" parameter of the Contact header.  See
+   Section 11.6 for more information on the 439 response code.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 25]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   A Contact header field value with an instance-id media feature tag
+   but no "reg-id" header field parameter is valid (this combination
+   will result in the creation of a GRUU, as described in the GRUU
+   specification [RFC5627]), but one with a reg-id but no instance-id is
+   not valid.  If the registrar processes a Contact header field value
+   with a reg-id but no instance-id, it simply ignores the reg-id
+   parameter.
+
+   A registration containing a "reg-id" header field parameter and a
+   non-zero expiration is used to register a single UA instance over a
+   single flow, and can also de-register any Contact header fields with
+   zero expiration.  Therefore, if the Contact header field contains
+   more than one header field value with a non-zero expiration and any
+   of these header field values contain a "reg-id" Contact header field
+   parameter, the entire registration SHOULD be rejected with a 400 (Bad
+   Request) response.  The justification for recommending rejection
+   versus making it mandatory is that the receiver is allowed by
+   [RFC3261] to squelch (not respond to) excessively malformed or
+   malicious messages.
+
+   If the Contact header did not contain a "reg-id" Contact header field
+   parameter or if that parameter was ignored (as described above), the
+   registrar MUST NOT include the outbound option-tag in the Require
+   header field of its response.
+
+   The registrar MUST be prepared to receive, simultaneously for the
+   same AOR, some registrations that use instance-id and reg-id and some
+   registrations that do not.  The registrar MAY be configured with
+   local policy to reject any registrations that do not include the
+   instance-id and reg-id, or with Path header field values that do not
+   contain the "ob" URI parameter.  If the Contact header field does not
+   contain a "+sip.instance" Contact header field parameter, the
+   registrar processes the request using the Contact binding rules in
+   [RFC3261].
+
+   When a "+sip.instance" Contact header field parameter and a "reg-id"
+   Contact header field parameter are present in a Contact header field
+   of a REGISTER request (after the Contact header validation as
+   described above), the corresponding binding is between an AOR and the
+   combination of the instance-id (from the "+sip.instance" Contact
+   header parameter) and the value of "reg-id" Contact header field
+   parameter parameter.  The registrar MUST store in the binding the
+   Contact URI, all the Contact header field parameters, and any Path
+   header field values.  (Even though the Contact URI is not used for
+   binding comparisons, it is still needed by the authoritative proxy to
+   form the target set.)  Provided that the UAC had included an outbound
+   option-tag (defined in Section 11.4) in a Supported header field
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 26]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   value in the REGISTER request, the registrar MUST include the
+   outbound option-tag in a Require header field value in its response
+   to that REGISTER request.
+
+   If the UAC has a direct flow with the registrar, the registrar MUST
+   store enough information to uniquely identify the network flow over
+   which the request arrived.  For common operating systems with TCP,
+   this would typically be just the handle to the file descriptor where
+   the handle would become invalid if the TCP session was closed.  For
+   common operating systems with UDP this would typically be the file
+   descriptor for the local socket that received the request, the local
+   interface, and the IP address and port number of the remote side that
+   sent the request.  The registrar MAY store this information by adding
+   itself to the Path header field with an appropriate flow token.
+
+   If the registrar receives a re-registration for a specific
+   combination of AOR, and instance-id and reg-id values, the registrar
+   MUST update any information that uniquely identifies the network flow
+   over which the request arrived if that information has changed, and
+   SHOULD update the time the binding was last updated.
+
+   To be compliant with this specification, registrars that can receive
+   SIP requests directly from a UAC without intervening edge proxies
+   MUST implement the same keep-alive mechanisms as edge proxies
+   (Section 5.4).  Registrars with a direct flow with a UA MAY include a
+   Flow-Timer header in a 2xx class registration response that includes
+   the outbound option-tag in the Require header.
+
+7.  Authoritative Proxy Procedures: Forwarding Requests
+
+   When a proxy uses the location service to look up a registration
+   binding and then proxies a request to a particular contact, it
+   selects a contact to use normally, with a few additional rules:
+
+   o  The proxy MUST NOT populate the target set with more than one
+      contact with the same AOR and instance-id at a time.
+
+   o  If a request for a particular AOR and instance-id fails with a 430
+      (Flow Failed) response, the proxy SHOULD replace the failed branch
+      with another target (if one is available) with the same AOR and
+      instance-id, but a different reg-id.
+
+   o  If the proxy receives a final response from a branch other than a
+      408 (Request Timeout) or a 430 (Flow Failed) response, the proxy
+      MUST NOT forward the same request to another target representing
+      the same AOR and instance-id.  The targeted instance has already
+      provided its response.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 27]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   The proxy uses the next-hop target of the message and the value of
+   any stored Path header field vector in the registration binding to
+   decide how to forward and populate the Route header in the request.
+   If the proxy is co-located with the registrar and stored information
+   about the flow to the UA that created the binding, then the proxy
+   MUST send the request over the same 'logical flow' saved with the
+   binding, since that flow is known to deliver data to the specific
+   target UA instance's network flow that was saved with the binding.
+
+      Implementation note: Typically this means that for TCP, the
+      request is sent on the same TCP socket that received the REGISTER
+      request.  For UDP, the request is sent from the same local IP
+      address and port over which the registration was received, to the
+      same IP address and port from which the REGISTER was received.
+
+   If a proxy or registrar receives information from the network that
+   indicates that no future messages will be delivered on a specific
+   flow, then the proxy MUST invalidate all the bindings in the target
+   set that use that flow (regardless of AOR).  Examples of this are a
+   TCP socket closing or receiving a destination unreachable ICMP error
+   on a UDP flow.  Similarly, if a proxy closes a file descriptor, it
+   MUST invalidate all the bindings in the target set with flows that
+   use that file descriptor.
+
+8.  STUN Keep-Alive Processing
+
+   This section describes changes to the SIP transport layer that allow
+   SIP and STUN [RFC5389] Binding Requests to be mixed over the same
+   flow.  This constitutes a new STUN usage.  The STUN messages are used
+   to verify that connectivity is still available over a UDP flow, and
+   to provide periodic keep-alives.  These STUN keep-alives are always
+   sent to the next SIP hop.  STUN messages are not delivered end-to-
+   end.
+
+   The only STUN messages required by this usage are Binding Requests,
+   Binding Responses, and Binding Error Responses.  The UAC sends
+   Binding Requests over the same UDP flow that is used for sending SIP
+   messages.  These Binding Requests do not require any STUN attributes.
+   The corresponding Binding Responses do not require any STUN
+   attributes except the XOR-MAPPED-ADDRESS.  The UAS, proxy, or
+   registrar responds to a valid Binding Request with a Binding Response
+   that MUST include the XOR-MAPPED-ADDRESS attribute.
+
+   If a server compliant to this section receives SIP requests on a
+   given interface and UDP port, it MUST also provide a limited version
+   of a STUN server on the same interface and UDP port.
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 28]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+      Note: It is easy to distinguish STUN and SIP packets sent over
+      UDP, because the first octet of a STUN Binding method has a value
+      of 0 or 1, while the first octet of a SIP message is never a 0 or
+      1.
+
+   Because sending and receiving binary STUN data on the same ports used
+   for SIP is a significant and non-backwards compatible change to RFC
+   3261, this section requires a number of checks before sending STUN
+   messages to a SIP node.  If a SIP node sends STUN requests (for
+   example, due to incorrect configuration) despite these warnings, the
+   node could be blacklisted for UDP traffic.
+
+   A SIP node MUST NOT send STUN requests over a flow unless it has an
+   explicit indication that the target next-hop SIP server claims to
+   support this specification.  UACs MUST NOT use an ambiguous
+   configuration option such as "Work through NATs?" or "Do keep-
+   alives?" to imply next-hop STUN support.  A UAC MAY use the presence
+   of an "ob" URI parameter in the Path header in a registration
+   response as an indication that its first edge proxy supports the
+   keep-alives defined in this document.
+
+      Note: Typically, a SIP node first sends a SIP request and waits to
+      receive a 2xx class response over a flow to a new target
+      destination, before sending any STUN messages.  When scheduled for
+      the next NAT refresh, the SIP node sends a STUN request to the
+      target.
+
+   Once a flow is established, failure of a STUN request (including its
+   retransmissions) is considered a failure of the underlying flow.  For
+   SIP over UDP flows, if the XOR-MAPPED-ADDRESS returned over the flow
+   changes, this indicates that the underlying connectivity has changed,
+   and is considered a flow failure.
+
+   The SIP keep-alive STUN usage requires no backwards compatibility
+   with [RFC3489].
+
+8.1.  Use with SigComp
+
+   When STUN is used together with SigComp [RFC3320] compressed SIP
+   messages over the same flow, the STUN messages are simply sent
+   uncompressed, "outside" of SigComp.  This is supported by
+   multiplexing STUN messages with SigComp messages by checking the two
+   topmost bits of the message.  These bits are always one for SigComp,
+   or zero for STUN.
+
+      Note: All SigComp messages contain a prefix (the five most
+      significant bits of the first byte are set to one) that does not
+      occur in UTF-8 [RFC3629] encoded text messages, so for
+
+
+
+Jennings, et al.            Standards Track                    [Page 29]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+      applications that use this encoding (or ASCII encoding) it is
+      possible to multiplex uncompressed application messages and
+      SigComp messages on the same UDP port.  The most significant two
+      bits of every STUN Binding method are both zeroes.  This, combined
+      with the magic cookie, aids in differentiating STUN packets from
+      other protocols when STUN is multiplexed with other protocols on
+      the same port.
+
+9.  Example Message Flow
+
+   Below is an example message flow illustrating most of the concepts
+   discussed in this specification.  In many cases, Via, Content-Length,
+   and Max-Forwards headers are omitted for brevity and readability.
+
+   In these examples, "EP1" and "EP2" are outbound proxies, and "Proxy"
+   is the authoritativeProxy.
+
+   The section is subdivided into independent calls flows; however, they
+   are structured in sequential order of a hypothetical sequence of call
+   flows.
+
+9.1.  Subscription to Configuration Package
+
+   If the outbound proxy set is already configured on Bob's UA, then
+   this subsection can be skipped.  Otherwise, if the outbound proxy set
+   is learned through the configuration package, Bob's UA sends a
+   SUBSCRIBE request for the UA profile configuration package
+   [CONFIG-FMWK].  This request is a poll (Expires is zero).  After
+   receiving the NOTIFY request, Bob's UA fetches the external
+   configuration using HTTPS (not shown) and obtains a configuration
+   file that contains the outbound-proxy-set "sip:ep1.example.com;lr"
+   and "sip:ep2.example.com;lr".
+
+     [----example.com domain-------------------------]
+     Bob         EP1   EP2     Proxy             Config
+      |           |     |        |                  |
+    1)|SUBSCRIBE->|     |        |                  |
+    2)|           |---SUBSCRIBE Event: ua-profile ->|
+    3)|           |<--200 OK -----------------------|
+    4)|<--200 OK--|     |        |                  |
+    5)|           |<--NOTIFY------------------------|
+    6)|<--NOTIFY--|     |        |                  |
+    7)|---200 OK->|     |        |                  |
+    8)|           |---200 OK ---------------------->|
+      |           |     |        |                  |
+
+   In this example, the DNS server happens to be configured so that sip:
+   example.com resolves to EP1 and EP2.
+
+
+
+Jennings, et al.            Standards Track                    [Page 30]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Example Message #1:
+
+   SUBSCRIBE sip:00000000-0000-1000-8000-AABBCCDDEEFF@example.com
+     SIP/2.0
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bKnlsdkdj2
+   Max-Forwards: 70
+   From: <anonymous@example.com>;tag=23324
+   To: <sip:00000000-0000-1000-8000-AABBCCDDEEFF@example.com>
+   Call-ID: nSz1TWN54x7My0GvpEBj
+   CSeq: 1 SUBSCRIBE
+   Event: ua-profile ;profile-type=device
+    ;vendor="example.com";model="uPhone";version="1.1"
+   Expires: 0
+   Supported: path, outbound
+   Accept: message/external-body, application/x-uPhone-config
+   Contact: <sip:192.0.2.2;transport=tcp;ob>
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Content-Length: 0
+
+   In message #2, EP1 adds the following Record-Route header:
+
+   Record-Route:
+    <sip:GopIKSsn0oGLPXRdV9BAXpT3coNuiGKV@ep1.example.com;lr>
+
+   In message #5, the configuration server sends a NOTIFY with an
+   external URL for Bob to fetch his configuration.  The NOTIFY has a
+   Subscription-State header that ends the subscription.
+
+   Message #5
+
+   NOTIFY sip:192.0.2.2;transport=tcp;ob SIP/2.0
+   Via: SIP/2.0/TCP 192.0.2.5;branch=z9hG4bKn81dd2
+   Max-Forwards: 70
+   To: <anonymous@example.com>;tag=23324
+   From: <sip:00000000-0000-1000-8000-AABBCCDDEEFF@example.com>;tag=0983
+   Call-ID: nSz1TWN54x7My0GvpEBj
+   CSeq: 1 NOTIFY
+   Route: <sip:GopIKSsn0oGLPXRdV9BAXpT3coNuiGKV@ep1.example.com;lr>
+   Subscription-State: terminated;reason=timeout
+   Event: ua-profile
+   Content-Type: message/external-body; access-type="URL"
+    ;expiration="Thu, 01 Jan 2009 09:00:00 UTC"
+    ;URL="http://example.com/uPhone.cfg"
+    ;size=9999;hash=10AB568E91245681AC1B
+   Content-Length: 0
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 31]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   EP1 receives this NOTIFY request, strips off the Route header,
+   extracts the flow-token, calculates the correct flow, and forwards
+   the request (message #6) over that flow to Bob.
+
+   Bob's UA fetches the configuration file and learns the outbound proxy
+   set.
+
+9.2.  Registration
+
+   Now that Bob's UA is configured with the outbound-proxy-set whether
+   through configuration or using the configuration framework procedures
+   of the previous section, Bob's UA sends REGISTER requests through
+   each edge proxy in the set.  Once the registrations succeed, Bob's UA
+   begins sending CRLF keep-alives about every 2 minutes.
+
+     Bob         EP1   EP2     Proxy     Alice
+      |           |     |        |         |
+    9)|-REGISTER->|     |        |         |
+   10)|           |---REGISTER-->|         |
+   11)|           |<----200 OK---|         |
+   12)|<-200 OK---|     |        |         |
+   13)|----REGISTER---->|        |         |
+   14)|           |     |--REG-->|         |
+   15)|           |     |<-200---|         |
+   16)|<----200 OK------|        |         |
+      |           |     |        |         |
+      |  about 120 seconds later...        |
+      |           |     |        |         |
+   17)|--2CRLF--->|     |        |         |
+   18)|<--CRLF----|     |        |         |
+   19)|------2CRLF----->|        |         |
+   20)|<------CRLF------|        |         |
+      |           |     |        |         |
+
+   In message #9, Bob's UA sends its first registration through the
+   first edge proxy in the outbound-proxy-set by including a loose
+   route.  The UA includes an instance-id and reg-id in its Contact
+   header field value.  Note the option-tags in the Supported header.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 32]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Message #9
+
+   REGISTER sip:example.com SIP/2.0
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bKnashds7
+   Max-Forwards: 70
+   From: Bob <sip:bob@example.com>;tag=7F94778B653B
+   To: Bob <sip:bob@example.com>
+   Call-ID: 16CB75F21C70
+   CSeq: 1 REGISTER
+   Supported: path, outbound
+   Route: <sip:ep1.example.com;lr>
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=1
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Content-Length: 0
+
+   Message #10 is similar.  EP1 removes the Route header field value,
+   decrements Max-Forwards, and adds its Via header field value.  Since
+   EP1 is the first edge proxy, it adds a Path header with a flow token
+   and includes the "ob" parameter.
+
+   Path: <sip:VskztcQ/S8p4WPbOnHbuyh5iJvJIW3ib@ep1.example.com;lr;ob>
+
+   Since the response to the REGISTER (message #11) contains the
+   outbound option-tag in the Require header field, Bob's UA will know
+   that the registrar used outbound binding rules.  The response also
+   contains the currently active Contacts, and the Path for the current
+   registration.
+
+   Message #11
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP 192.0.2.15;branch=z9hG4bKnuiqisi
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bKnashds7
+   From: Bob <sip:bob@example.com>;tag=7F94778B653B
+   To: Bob <sip:bob@example.com>;tag=6AF99445E44A
+   Call-ID: 16CB75F21C70
+   CSeq: 1 REGISTER
+   Supported: path, outbound
+   Require: outbound
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=1;expires=3600
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Path: <sip:VskztcQ/S8p4WPbOnHbuyh5iJvJIW3ib@ep1.example.com;lr;ob>
+   Content-Length: 0
+
+   The second registration through EP2 (message #13) is similar except
+   that the Call-ID has changed, the reg-id is 2, and the Route header
+   goes through EP2.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 33]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Message #13
+
+   REGISTER sip:example.com SIP/2.0
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bKnqr9bym
+   Max-Forwards: 70
+   From: Bob <sip:bob@example.com>;tag=755285EABDE2
+   To: Bob <sip:bob@example.com>
+   Call-ID: E05133BD26DD
+   CSeq: 1 REGISTER
+   Supported: path, outbound
+   Route: <sip:ep2.example.com;lr>
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=2
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Content-Length: 0
+
+   Likewise in message #14, EP2 adds a Path header with flow token and
+   "ob" parameter.
+
+   Path: <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr;ob>
+
+   Message #16 tells Bob's UA that outbound registration was successful,
+   and shows both Contacts.  Note that only the Path corresponding to
+   the current registration is returned.
+
+   Message #16
+
+   SIP/2.0 200 OK
+   Via: SIP/2.0/TCP 192.0.2.2;branch=z9hG4bKnqr9bym
+   From: Bob <sip:bob@example.com>;tag=755285EABDE2
+   To: Bob <sip:bob@example.com>;tag=49A9AD0B3F6A
+   Call-ID: E05133BD26DD
+   Supported: path, outbound
+   Require: outbound
+   CSeq: 1 REGISTER
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=1;expires=3600
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=2;expires=3600
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+   Path: <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr;ob>
+   Content-Length: 0
+
+9.3.  Incoming Call and Proxy Crash
+
+   In this example, after registration, EP1 crashes and reboots.  Before
+   Bob's UA notices that its flow to EP1 is no longer responding, Alice
+   calls Bob.  Bob's authoritative proxy first tries the flow to EP1,
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 34]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   but EP1 no longer has a flow to Bob, so it responds with a 430 (Flow
+   Failed) response.  The proxy removes the stale registration and tries
+   the next binding for the same instance.
+
+     Bob         EP1   EP2     Proxy     Alice
+      |           |     |        |         |
+      |    CRASH  X     |        |         |
+      |        Reboot   |        |         |
+      |           |     |        |         |
+   21)|           |     |        |<-INVITE-|
+   22)|           |<---INVITE----|         |
+   23)|           |----430------>|         |
+   24)|           |     |<-INVITE|         |
+   25)|<---INVITE-------|        |         |
+   26)|----200 OK------>|        |         |
+   27)|           |     |200 OK->|         |
+   28)|           |     |        |-200 OK->|
+   29)|           |     |<----------ACK----|
+   30)|<---ACK----------|        |         |
+      |           |     |        |         |
+   31)|           |     |<----------BYE----|
+   32)|<---BYE----------|        |         |
+   33)|----200 OK------>|        |         |
+   34)|           |     |--------200 OK--->|
+      |           |     |        |         |
+
+
+   Message #21
+
+   INVITE sip:bob@example.com SIP/2.0
+   To: Bob <sip:bob@example.com>
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+
+   Bob's proxy rewrites the Request-URI to the Contact URI used in Bob's
+   registration, and places the path for one of the registrations
+   towards Bob's UA instance into a Route header field.  This Route goes
+   through EP1.
+
+   Message #22
+
+   INVITE sip:bob@192.0.2.2;transport=tcp SIP/2.0
+   To: Bob <sip:bob@example.com>
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+   Route: <sip:VskztcQ/S8p4WPbOnHbuyh5iJvJIW3ib@ep1.example.com;lr;ob>
+
+
+
+Jennings, et al.            Standards Track                    [Page 35]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Since EP1 just rebooted, it does not have the flow described in the
+   flow token.  It returns a 430 (Flow Failed) response.
+
+   Message #23
+
+   SIP/2.0 430 Flow Failed
+   To: Bob <sip:bob@example.com>
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+
+   The proxy deletes the binding for this path and tries to forward the
+   INVITE again, this time with the path through EP2.
+
+   Message #24
+
+   INVITE sip:bob@192.0.2.2;transport=tcp SIP/2.0
+   To: Bob <sip:bob@example.com>
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+   Route: <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr;ob>
+
+   In message #25, EP2 needs to add a Record-Route header field value,
+   so that any subsequent in-dialog messages from Alice's UA arrive at
+   Bob's UA.  EP2 can determine it needs to Record-Route since the
+   request is a dialog-forming request and the Route header contained a
+   flow token and an "ob" parameter.  This Record-Route information is
+   passed back to Alice's UA in the responses (messages #26, 27, and
+   28).
+
+   Message #25
+
+   INVITE sip:bob@192.0.2.2;transport=tcp SIP/2.0
+   To: Bob <sip:bob@example.com>
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+   Record-Route:
+     <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr>
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 36]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Message #26
+
+   SIP/2.0 200 OK
+   To: Bob <sip:bob@example.com>;tag=skduk2
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 INVITE
+   Record-Route:
+     <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr>
+
+   At this point, both UAs have the correct route-set for the dialog.
+   Any subsequent requests in this dialog will route correctly.  For
+   example, the ACK request in message #29 is sent from Alice's UA
+   directly to EP2.  The BYE request in message #31 uses the same route-
+   set.
+
+   Message #29
+
+   ACK sip:bob@192.0.2.2;transport=tcp SIP/2.0
+   To: Bob <sip:bob@example.com>;tag=skduk2
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 1 ACK
+   Route: <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr>
+
+   Message #31
+
+   BYE sip:bob@192.0.2.2;transport=tcp SIP/2.0
+   To: Bob <sip:bob@example.com>;tag=skduk2
+   From: Alice <sip:alice@a.example>;tag=02935
+   Call-ID: klmvCxVWGp6MxJp2T2mb
+   CSeq: 2 BYE
+   Route: <sip:wazHDLdIMtUg6r0I/oRZ15zx3zHE1w1Z@ep2.example.com;lr>
+
+9.4.  Re-Registration
+
+   Somewhat later, Bob's UA sends keep-alives to both its edge proxies,
+   but it discovers that the flow with EP1 failed.  Bob's UA re-
+   registers through EP1 using the same reg-id and Call-ID it previously
+   used.
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 37]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+     Bob         EP1   EP2     Proxy     Alice
+      |           |     |        |         |
+   35)|------2CRLF----->|        |         |
+   36)|<------CRLF------|        |         |
+   37)|--2CRLF->X |     |        |         |
+      |           |     |        |         |
+   38)|-REGISTER->|     |        |         |
+   39)|           |---REGISTER-->|         |
+   40)|           |<----200 OK---|         |
+   41)|<-200 OK---|     |        |         |
+      |           |     |        |         |
+
+   Message #38
+
+   REGISTER sip:example.com SIP/2.0
+   From: Bob <sip:bob@example.com>;tag=7F94778B653B
+   To: Bob <sip:bob@example.com>
+   Call-ID: 16CB75F21C70
+   CSeq: 2 REGISTER
+   Supported: path, outbound
+   Route: <sip:ep1.example.com;lr>
+   Contact: <sip:bob@192.0.2.2;transport=tcp>;reg-id=1
+    ;+sip.instance="<urn:uuid:00000000-0000-1000-8000-AABBCCDDEEFF>"
+
+   In message #39, EP1 inserts a Path header with a new flow token:
+
+   Path: <sip:3yJEbr1GYZK9cPYk5Snocez6DzO7w+AX@ep1.example.com;lr;ob>
+
+9.5.  Outgoing Call
+
+   Finally, Bob makes an outgoing call to Alice.  Bob's UA includes an
+   "ob" parameter in its Contact URI in message #42.  EP1 adds a Record-
+   Route with a flow-token in message #43.  The route-set is returned to
+   Bob in the response (messages #45, 46, and 47), and either Bob or
+   Alice can send in-dialog requests.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 38]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+     Bob         EP1   EP2     Proxy     Alice
+      |           |     |        |         |
+   42)|--INVITE-->|     |        |         |
+   43)|           |---INVITE---->|         |
+   44)|           |     |        |-INVITE->|
+   45)|           |     |        |<--200---|
+   46)|           |<----200 OK---|         |
+   47)|<-200 OK---|     |        |         |
+   48)|--ACK----->|     |        |         |
+   49)|           |-----ACK--------------->|
+      |           |     |        |         |
+   50)|-- BYE---->|     |        |         |
+   51)|           |-----------BYE--------->|
+   52)|           |<----------200 OK-------|
+   53)|<--200 OK--|     |        |         |
+      |           |     |        |         |
+
+   Message #42
+
+   INVITE sip:alice@a.example SIP/2.0
+   From: Bob <sip:bob@example.com>;tag=ldw22z
+   To: Alice <sip:alice@a.example>
+   Call-ID: 95KGsk2V/Eis9LcpBYy3
+   CSeq: 1 INVITE
+   Route: <sip:ep1.example.com;lr>
+   Contact: <sip:bob@192.0.2.2;transport=tcp;ob>
+
+   In message #43, EP1 adds the following Record-Route header.
+
+   Record-Route:
+     <sip:3yJEbr1GYZK9cPYk5Snocez6DzO7w+AX@ep1.example.com;lr>
+
+   When EP1 receives the BYE (message #50) from Bob's UA, it can tell
+   that the request is an "outgoing" request (since the source of the
+   request matches the flow in the flow token) and simply deletes its
+   Route header field value and forwards the request on to Alice's UA.
+
+   Message #50
+
+   BYE sip:alice@a.example SIP/2.0
+   From: Bob <sip:bob@example.com>;tag=ldw22z
+   To: Alice <sip:alice@a.example>;tag=plqus8
+   Call-ID: 95KGsk2V/Eis9LcpBYy3
+   CSeq: 2 BYE
+   Route: <sip:3yJEbr1GYZK9cPYk5Snocez6DzO7w+AX@ep1.example.com;lr>
+   Contact: <sip:bob@192.0.2.2;transport=tcp;ob>
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 39]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+10.  Grammar
+
+   This specification defines a new header field "Flow-Timer", and new
+   Contact header field parameters, "reg-id" and "+sip.instance".  The
+   grammar includes the definitions from [RFC3261].  Flow-Timer is an
+   extension-header from the message-header in the [RFC3261] ABNF.
+
+   The ABNF [RFC5234] is:
+
+    Flow-Timer     = "Flow-Timer" HCOLON 1*DIGIT
+
+    contact-params =/ c-p-reg / c-p-instance
+
+    c-p-reg        = "reg-id" EQUAL 1*DIGIT ; 1 to (2^31 - 1)
+
+    c-p-instance   =  "+sip.instance" EQUAL
+                      DQUOTE "<" instance-val ">" DQUOTE
+
+    instance-val   = 1*uric ; defined in RFC 3261
+
+   The value of the reg-id MUST NOT be 0 and MUST be less than 2^31.
+
+11.  IANA Considerations
+
+11.1.  Flow-Timer Header Field
+
+   This specification defines a new SIP header field "Flow-Timer" whose
+   syntax is defined in Section 10.
+
+     Header Name        compact    Reference
+     -----------------  -------    ---------
+     Flow-Timer                    [RFC5626]
+
+11.2.  "reg-id" Contact Header Field Parameter
+
+   This specification defines a new Contact header field parameter
+   called reg-id in the "Header Field Parameters and Parameter Values"
+   sub-registry as per the registry created by [RFC3968].  The syntax is
+   defined in Section 10.  The required information is:
+
+                                                  Predefined
+   Header Field            Parameter Name         Values      Reference
+   ----------------------  ---------------------  ----------  ---------
+   Contact                 reg-id                 No          [RFC5626]
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 40]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+11.3.  SIP/SIPS URI Parameters
+
+   This specification augments the "SIP/SIPS URI Parameters" sub-
+   registry as per the registry created by [RFC3969].  The required
+   information is:
+
+   Parameter Name     Predefined Values     Reference
+   --------------     -----------------     ---------
+   ob                 No                    [RFC5626]
+
+11.4.  SIP Option Tag
+
+   This specification registers a new SIP option tag, as per the
+   guidelines in Section 27.1 of [RFC3261].
+
+   Name:  outbound
+
+   Description:  This option-tag is used to identify UAs and registrars
+      that support extensions for Client-Initiated Connections.  A UA
+      places this option in a Supported header to communicate its
+      support for this extension.  A registrar places this option-tag in
+      a Require header to indicate to the registering User Agent that
+      the registrar used registrations using the binding rules defined
+      in this extension.
+
+11.5.  430 (Flow Failed) Response Code
+
+   This document registers a new SIP response code (430 Flow Failed), as
+   per the guidelines in Section 27.4 of [RFC3261].  This response code
+   is used by an edge proxy to indicate to the Authoritative Proxy that
+   a specific flow to a UA instance has failed.  Other flows to the same
+   instance could still succeed.  The Authoritative Proxy SHOULD attempt
+   to forward to another target (flow) with the same instance-id and
+   AOR.  Endpoints should never receive a 430 response.  If an endpoint
+   receives a 430 response, it should treat it as a 400 (Bad Request)
+   per normal procedures, as in Section 8.1.3.2 of [RFC3261].  This
+   response code is defined by the following information, which has been
+   added to the method and response-code sub-registry under the SIP
+   Parameters registry.
+
+     Response Code                               Reference
+     ------------------------------------------  ---------
+     Request Failure 4xx
+       430 Flow Failed                           [RFC5626]
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 41]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+11.6.  439 (First Hop Lacks Outbound Support) Response Code
+
+   This document registers a new SIP response code (439 First Hop Lacks
+   Outbound Support), as per the guidelines in Section 27.4 of
+   [RFC3261].  This response code is used by a registrar to indicate
+   that it supports the 'outbound' feature described in this
+   specification, but that the first outbound proxy that the user is
+   attempting to register through does not.  Note that this response
+   code is only appropriate in the case that the registering User Agent
+   advertises support for outbound processing by including the outbound
+   option tag in a Supported header field.  Proxies MUST NOT send a 439
+   response to any requests that do not contain a "reg-id" parameter and
+   an outbound option tag in a Supported header field.  This response
+   code is defined by the following information, which has been added to
+   the method and response-code sub-registry under the SIP Parameters
+   registry.
+
+     Response Code                               Reference
+     ------------------------------------------  ---------
+     Request Failure 4xx
+       439 First Hop Lacks Outbound Support      [RFC&rfc.number;]
+
+11.7.  Media Feature Tag
+
+   This section registers a new media feature tag, per the procedures
+   defined in [RFC2506].  The tag is placed into the sip tree, which is
+   defined in [RFC3840].
+
+   Media feature tag name:  sip.instance
+
+   ASN.1 Identifier:  23
+
+   Summary of the media feature indicated by this tag:  This feature tag
+      contains a string containing a URN that indicates a unique
+      identifier associated with the UA instance registering the
+      Contact.
+
+   Values appropriate for use with this feature tag:  String (equality
+      relationship).
+
+   The feature tag is intended primarily for use in the following
+      applications, protocols, services, or negotiation mechanisms:
+      This feature tag is most useful in a communications application,
+      for describing the capabilities of a device, such as a phone or
+      PDA.
+
+   Examples of typical use:  Routing a call to a specific device.
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 42]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   Related standards or documents:  RFC 5626
+
+   Security Considerations:  This media feature tag can be used in ways
+      which affect application behaviors.  For example, the SIP caller
+      preferences extension [RFC3841] allows for call routing decisions
+      to be based on the values of these parameters.  Therefore, if an
+      attacker can modify the values of this tag, they might be able to
+      affect the behavior of applications.  As a result, applications
+      that utilize this media feature tag SHOULD provide a means for
+      ensuring its integrity.  Similarly, this feature tag should only
+      be trusted as valid when it comes from the user or User Agent
+      described by the tag.  As a result, protocols for conveying this
+      feature tag SHOULD provide a mechanism for guaranteeing
+      authenticity.
+
+12.  Security Considerations
+
+   One of the key security concerns in this work is making sure that an
+   attacker cannot hijack the sessions of a valid user and cause all
+   calls destined to that user to be sent to the attacker.  Note that
+   the intent is not to prevent existing active attacks on SIP UDP and
+   TCP traffic, but to ensure that no new attacks are added by
+   introducing the outbound mechanism.
+
+   The simple case is when there are no edge proxies.  In this case, the
+   only time an entry can be added to the routing for a given AOR is
+   when the registration succeeds.  SIP already protects against
+   attackers being able to successfully register, and this scheme relies
+   on that security.  Some implementers have considered the idea of just
+   saving the instance-id without relating it to the AOR with which it
+   registered.  This idea will not work because an attacker's UA can
+   impersonate a valid user's instance-id and hijack that user's calls.
+
+   The more complex case involves one or more edge proxies.  When a UA
+   sends a REGISTER request through an edge proxy on to the registrar,
+   the edge proxy inserts a Path header field value.  If the
+   registration is successfully authenticated, the registrar stores the
+   value of the Path header field.  Later, when the registrar forwards a
+   request destined for the UA, it copies the stored value of the Path
+   header field into the Route header field of the request and forwards
+   the request to the edge proxy.
+
+   The only time an edge proxy will route over a particular flow is when
+   it has received a Route header that has the flow identifier
+   information that it has created.  An incoming request would have
+   gotten this information from the registrar.  The registrar will only
+   save this information for a given AOR if the registration for the AOR
+   has been successful; and the registration will only be successful if
+
+
+
+Jennings, et al.            Standards Track                    [Page 43]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   the UA can correctly authenticate.  Even if an attacker has spoofed
+   some bad information in the Path header sent to the registrar, the
+   attacker will not be able to get the registrar to accept this
+   information for an AOR that does not belong to the attacker.  The
+   registrar will not hand out this bad information to others, and
+   others will not be misled into contacting the attacker.
+
+   The Security Considerations discussed in [RFC3261] and [RFC3327] are
+   also relevant to this document.  For the security considerations of
+   generating flow tokens, please also see Section 5.2.  A discussion of
+   preventing the avalanche restart problem is in Section 4.5.
+
+   This document does not change the mandatory-to-implement security
+   mechanisms in SIP.  User Agents are already required to implement
+   Digest authentication while support of TLS is recommended; proxy
+   servers are already required to implement Digest and TLS.
+
+13.  Operational Notes on Transports
+
+   This entire section is non-normative.
+
+   [RFC3261] requires proxies, registrars, and User Agents to implement
+   both TCP and UDP but deployments can chose which transport protocols
+   they want to use.  Deployments need to be careful in choosing what
+   transports to use.  Many SIP features and extensions, such as large
+   presence notification bodies, result in SIP requests that can be too
+   large to be reasonably transported over UDP.  [RFC3261] states that
+   when a request is too large for UDP, the device sending the request
+   attempts to switch over to TCP.  It is important to note that when
+   using outbound, this will only work if the UA has formed both UDP and
+   TCP outbound flows.  This specification allows the UA to do so, but
+   in most cases it will probably make more sense for the UA to form a
+   TCP outbound connection only, rather than forming both UDP and TCP
+   flows.  One of the key reasons that many deployments choose not to
+   use TCP has to do with the difficulty of building proxies that can
+   maintain a very large number of active TCP connections.  Many
+   deployments today use SIP in such a way that the messages are small
+   enough that they work over UDP but they can not take advantage of all
+   the functionality SIP offers.  Deployments that use only UDP outbound
+   connections are going to fail with sufficiently large SIP messages.
+
+14.  Requirements
+
+   This specification was developed to meet the following requirements:
+
+   1.  Must be able to detect that a UA supports these mechanisms.
+
+   2.  Support UAs behind NATs.
+
+
+
+Jennings, et al.            Standards Track                    [Page 44]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   3.  Support TLS to a UA without a stable DNS name or IP address.
+
+   4.  Detect failure of a connection and be able to correct for this.
+
+   5.  Support many UAs simultaneously rebooting.
+
+   6.  Support a NAT rebooting or resetting.
+
+   7.  Minimize initial startup load on a proxy.
+
+   8.  Support architectures with edge proxies.
+
+15.  Acknowledgments
+
+   Francois Audet acted as document shepherd for this document, tracking
+   hundreds of comments and incorporating many grammatical fixes as well
+   as prodding the editors to "get on with it".  Jonathan Rosenberg,
+   Erkki Koivusalo, and Byron Campen provided many comments and useful
+   text.  Dave Oran came up with the idea of using the most recent
+   registration first in the proxy.  Alan Hawrylyshen co-authored the
+   document that formed the initial text of this specification.
+   Additionally, many of the concepts here originated at a connection
+   reuse meeting at IETF 60 that included the authors, Jon Peterson,
+   Jonathan Rosenberg, Alan Hawrylyshen, and Paul Kyzivat.  The TCP
+   design team consisting of Chris Boulton, Scott Lawrence, Rajnish
+   Jain, Vijay K. Gurbani, and Ganesh Jayadevan provided input and text.
+   Nils Ohlmeier provided many fixes and initial implementation
+   experience.  In addition, thanks to the following folks for useful
+   comments: Francois Audet, Flemming Andreasen, Mike Hammer, Dan Wing,
+   Srivatsa Srinivasan, Dale Worely, Juha Heinanen, Eric Rescorla,
+   Lyndsay Campbell, Christer Holmberg, Kevin Johns, Jeroen van Bemmel,
+   Derek MacDonald, Dean Willis, and Robert Sparks.
+
+16.  References
+
+16.1.  Normative References
+
+   [RFC2119]      Bradner, S., "Key words for use in RFCs to Indicate
+                  Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2141]      Moats, R., "URN Syntax", RFC 2141, May 1997.
+
+   [RFC2506]      Holtman, K., Mutz, A., and T. Hardie, "Media Feature
+                  Tag Registration Procedure", BCP 31, RFC 2506,
+                  March 1999.
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 45]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   [RFC3261]      Rosenberg, J., Schulzrinne, H., Camarillo, G.,
+                  Johnston, A., Peterson, J., Sparks, R., Handley, M.,
+                  and E. Schooler, "SIP: Session Initiation Protocol",
+                  RFC 3261, June 2002.
+
+   [RFC3263]      Rosenberg, J. and H. Schulzrinne, "Session Initiation
+                  Protocol (SIP): Locating SIP Servers", RFC 3263,
+                  June 2002.
+
+   [RFC3327]      Willis, D. and B. Hoeneisen, "Session Initiation
+                  Protocol (SIP) Extension Header Field for Registering
+                  Non-Adjacent Contacts", RFC 3327, December 2002.
+
+   [RFC3581]      Rosenberg, J. and H. Schulzrinne, "An Extension to the
+                  Session Initiation Protocol (SIP) for Symmetric
+                  Response Routing", RFC 3581, August 2003.
+
+   [RFC3629]      Yergeau, F., "UTF-8, a transformation format of ISO
+                  10646", STD 63, RFC 3629, November 2003.
+
+   [RFC3840]      Rosenberg, J., Schulzrinne, H., and P. Kyzivat,
+                  "Indicating User Agent Capabilities in the Session
+                  Initiation Protocol (SIP)", RFC 3840, August 2004.
+
+   [RFC3841]      Rosenberg, J., Schulzrinne, H., and P. Kyzivat,
+                  "Caller Preferences for the Session Initiation
+                  Protocol (SIP)", RFC 3841, August 2004.
+
+   [RFC3968]      Camarillo, G., "The Internet Assigned Number Authority
+                  (IANA) Header Field Parameter Registry for the Session
+                  Initiation Protocol (SIP)", BCP 98, RFC 3968,
+                  December 2004.
+
+   [RFC3969]      Camarillo, G., "The Internet Assigned Number Authority
+                  (IANA) Uniform Resource Identifier (URI) Parameter
+                  Registry for the Session Initiation Protocol (SIP)",
+                  BCP 99, RFC 3969, December 2004.
+
+   [RFC4122]      Leach, P., Mealling, M., and R. Salz, "A Universally
+                  Unique IDentifier (UUID) URN Namespace", RFC 4122,
+                  July 2005.
+
+   [RFC5234]      Crocker, D. and P. Overell, "Augmented BNF for Syntax
+                  Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5389]      Rosenberg, J., Mahy, R., Matthews, P., and D. Wing,
+                  "Session Traversal Utilities for NAT (STUN)",
+                  RFC 5389, October 2008.
+
+
+
+Jennings, et al.            Standards Track                    [Page 46]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+16.2.  Informative References
+
+   [CONFIG-FMWK]  Petrie, D. and S. Channabasappa, Ed., "A Framework for
+                  Session Initiation Protocol User Agent Profile
+                  Delivery", Work in Progress, February 2008.
+
+   [NAT-SCEN]     Boulton, C., Rosenberg, J., Camarillo, G., and F.
+                  Audet, "Best Current Practices for NAT Traversal for
+                  Client-Server SIP", Work in Progress, September 2008.
+
+   [RFC0768]      Postel, J., "User Datagram Protocol", STD 6, RFC 768,
+                  August 1980.
+
+   [RFC0793]      Postel, J., "Transmission Control Protocol", STD 7,
+                  RFC 793, September 1981.
+
+   [RFC1035]      Mockapetris, P., "Domain names - implementation and
+                  specification", STD 13, RFC 1035, November 1987.
+
+   [RFC2104]      Krawczyk, H., Bellare, M., and R. Canetti, "HMAC:
+                  Keyed-Hashing for Message Authentication", RFC 2104,
+                  February 1997.
+
+   [RFC2131]      Droms, R., "Dynamic Host Configuration Protocol",
+                  RFC 2131, March 1997.
+
+   [RFC2782]      Gulbrandsen, A., Vixie, P., and L. Esibov, "A DNS RR
+                  for specifying the location of services (DNS SRV)",
+                  RFC 2782, February 2000.
+
+   [RFC3320]      Price, R., Bormann, C., Christoffersson, J., Hannu,
+                  H., Liu, Z., and J. Rosenberg, "Signaling Compression
+                  (SigComp)", RFC 3320, January 2003.
+
+   [RFC3489]      Rosenberg, J., Weinberger, J., Huitema, C., and R.
+                  Mahy, "STUN - Simple Traversal of User Datagram
+                  Protocol (UDP) Through Network Address Translators
+                  (NATs)", RFC 3489, March 2003.
+
+   [RFC3986]      Berners-Lee, T., Fielding, R., and L. Masinter,
+                  "Uniform Resource Identifier (URI): Generic Syntax",
+                  STD 66, RFC 3986, January 2005.
+
+   [RFC4340]      Kohler, E., Handley, M., and S. Floyd, "Datagram
+                  Congestion Control Protocol (DCCP)", RFC 4340,
+                  March 2006.
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 47]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+   [RFC4648]      Josefsson, S., "The Base16, Base32, and Base64 Data
+                  Encodings", RFC 4648, October 2006.
+
+   [RFC4960]      Stewart, R., "Stream Control Transmission Protocol",
+                  RFC 4960, September 2007.
+
+   [RFC5246]      Dierks, T. and E. Rescorla, "The Transport Layer
+                  Security (TLS) Protocol Version 1.2", RFC 5246,
+                  August 2008.
+
+   [RFC5627]      Rosenberg, J., "Obtaining and Using Globally Routable
+                  User Agent URIs (GRUUs) in the Session Initiation
+                  Protocol (SIP)", RFC 5627, October 2009.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 48]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+Appendix A.  Default Flow Registration Backoff Times
+
+   The base-time used for the flow re-registration backoff times
+   described in Section 4.5 are configurable.  If the base-time-all-fail
+   value is set to the default of 30 seconds and the base-time-not-
+   failed value is set to the default of 90 seconds, the following table
+   shows the resulting amount of time the UA will wait to retry
+   registration.
+
+     +-------------------+--------------------+---------------------+
+     | # of reg failures | all flows unusable | > 1 non-failed flow |
+     +-------------------+--------------------+---------------------+
+     | 0                 | 0 s                | 0 s                 |
+     | 1                 | 30-60 s            | 90-180 s            |
+     | 2                 | 1-2 min            | 3-6 min             |
+     | 3                 | 2-4 min            | 6-12 min            |
+     | 4                 | 4-8 min            | 12-24 min           |
+     | 5                 | 8-16 min           | 15-30 min           |
+     | 6 or more         | 15-30 min          | 15-30 min           |
+     +-------------------+--------------------+---------------------+
+
+Appendix B.  ABNF
+
+   This appendix contains the ABNF defined earlier in this document.
+
+
+      CRLF = CR LF
+      double-CRLF = CR LF CR LF
+      CR = %x0D
+      LF = %x0A
+
+      Flow-Timer     = "Flow-Timer" HCOLON 1*DIGIT
+
+      contact-params =/ c-p-reg / c-p-instance
+
+      c-p-reg        = "reg-id" EQUAL 1*DIGIT ; 1 to (2^31 - 1)
+
+      c-p-instance   =  "+sip.instance" EQUAL
+                        DQUOTE "<" instance-val ">" DQUOTE
+
+      instance-val   = 1*uric ; defined in RFC 3261
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 49]
+
+RFC 5626          Client-Initiated Connections in SIP       October 2009
+
+
+Authors' Addresses
+
+   Cullen Jennings (editor)
+   Cisco Systems
+   170 West Tasman Drive
+   Mailstop SJC-21/2
+   San Jose, CA  95134
+   USA
+
+   Phone: +1 408 902-3341
+   EMail: fluffy@cisco.com
+
+
+   Rohan Mahy (editor)
+   Unaffiliated
+
+   EMail: rohan@ekabal.com
+
+
+   Francois Audet (editor)
+   Skype Labs
+
+   EMail: francois.audet@skypelabs.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Jennings, et al.            Standards Track                    [Page 50]
+

--- a/rfcs/rfc6026.txt
+++ b/rfcs/rfc6026.txt
@@ -1,0 +1,1123 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         R. Sparks
+Request for Comments: 6026                                       Tekelec
+Updates: 3261                                           T. Zourzouvillys
+Category: Standards Track                                          Skype
+ISSN: 2070-1721                                           September 2010
+
+
+             Correct Transaction Handling for 2xx Responses
+          to Session Initiation Protocol (SIP) INVITE Requests
+
+Abstract
+
+   This document normatively updates RFC 3261, the Session Initiation
+   Protocol (SIP), to address an error in the specified handling of
+   success (2xx class) responses to INVITE requests.  Elements following
+   RFC 3261 exactly will misidentify retransmissions of the request as a
+   new, unassociated request.  The correction involves modifying the
+   INVITE transaction state machines.  The correction also changes the
+   way responses that cannot be matched to an existing transaction are
+   handled to address a security risk.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6026.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 1]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. Conventions and Definitions .....................................3
+   3. Reason for Change ...............................................3
+   4. Summary of Change ...............................................4
+   5. Consequences if Not Implemented .................................4
+   6. The Change ......................................................4
+   7. Change Details ..................................................5
+      7.1. Server Transaction Impacts .................................5
+      7.2. Client Transaction Impacts .................................9
+      7.3. Proxy Considerations ......................................10
+   8. Exact Changes to RFC 3261 ......................................11
+      8.1. Page 85 ...................................................11
+      8.2. Page 107 ..................................................11
+      8.3. Page 114 ..................................................11
+      8.4. Pages 126 through 128 .....................................12
+      8.5. Pages 134 to 135 ..........................................15
+      8.6. Page 136 ..................................................15
+      8.7. Page 137 ..................................................17
+      8.8. Page 141 ..................................................17
+      8.9. Page 144 ..................................................18
+      8.10. Page 146 .................................................18
+      8.11. Page 265 .................................................18
+   9. IANA Considerations ............................................18
+   10. Security Considerations .......................................19
+   11. Acknowledgments ...............................................20
+   12. Normative References ..........................................20
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 2]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+1.  Introduction
+
+   This document describes an essential correction to the Session
+   Initiation Protocol (SIP), defined in [RFC3261].  The change
+   addresses an error in the handling of 2xx class responses to INVITE
+   requests that leads to retransmissions of the INVITE being treated as
+   new requests and forbids forwarding stray INVITE responses.
+
+2.  Conventions and Definitions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Reason for Change
+
+   One use of the INVITE method in SIP is to establish new sessions.
+   These "initial" INVITEs may fork at intermediaries, and more than one
+   receiving endpoint may choose to accept the request.  SIP is designed
+   such that the requester receives all of these success responses.
+
+   Two sets of requirements in [RFC3261] work together to allow multiple
+   2xx responses to be processed correctly by the requester.  First, all
+   elements are required to immediately destroy any INVITE client
+   transaction state upon forwarding a matching 2xx class response.
+   This requirement applies to both UAs (user agents) and proxies
+   (proxies forward the response upstream, the transaction layer at user
+   agents forwards the response to its "UA core").  Second, all proxies
+   are required to statelessly forward upstream any 2xx class responses
+   that do not match an existing transaction, also called stray
+   responses.  The transaction layer at user agents is required to
+   forward these responses to its UA core.  Logic in the UA core deals
+   with acknowledging each of these responses.
+
+   This technique for specifying the behavior was chosen over adjusting
+   INVITE client transaction state machines as a simpler way to specify
+   the correct behavior.
+
+   Over time, implementation experience demonstrated the existing text
+   is in error.  Once any element with a server transaction (say, a
+   proxy in the path of the INVITE) deletes that transaction state, any
+   retransmission of the INVITE will be treated as a new request,
+   potentially forwarded to different locations than the original.  Many
+   implementations in the field have made proprietary adjustments to
+   their transaction logic to avoid this error.
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 3]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+   The requirement to statelessly forward stray responses has also been
+   identified as a security risk.  Through it, elements compliant to
+   [RFC3261] are compelled to do work (forward packets) that is not
+   protected by the admission policies applied to requests.  This can be
+   leveraged to, for instance, use a SIP proxy as an anonymizing
+   forwarder of packets in a distributed denial-of-service attack.
+   General Internet endpoints can also collude to tunnel non-SIP content
+   through such proxies by wrapping them in an SIP response envelope.
+
+   Additionally, [RFC3261] requires that if an unrecoverable transport
+   error is encountered while sending a response in a client
+   transaction, that the transaction moves immediately into the
+   "Terminated" state.  This will result in any retransmitted INVITE
+   requests received after such an error was encountered to be processed
+   as a new request instead of being absorbed as a retransmission.
+
+4.  Summary of Change
+
+   This correction document updates [RFC3261], adding a state and
+   changing the transitions in the INVITE client state machine such that
+   the INVITE client transaction remains in place to receive multiple
+   2xx responses.  It adds a state to the INVITE server state machine to
+   absorb retransmissions of the INVITE after a 2xx response has been
+   sent.  It modifies state transitions in the INVITE server state
+   machine to absorb retransmissions of the INVITE request after
+   encountering an unrecoverable transport error when sending a
+   response.  It also forbids forwarding stray responses to INVITE
+   requests (not just 2xx responses), which RFC 3261 requires.
+
+5.  Consequences if Not Implemented
+
+   Implementations strictly conformant to [RFC3261] will process
+   retransmitted initial INVITE requests as new requests.  Proxies may
+   forward them to different locations than the original.  Proxies may
+   also be used as anonymizing forwarders of bulk traffic.
+   Implementations will process any retransmitted INVITE request as a
+   new request after an attempt to send a response results in an
+   unrecoverable error.
+
+6.  The Change
+
+   An element sending or receiving a 2xx to an INVITE transaction MUST
+   NOT destroy any matching INVITE transaction state.  This state is
+   necessary to ensure correct processing of retransmissions of the
+   request and the retransmission of the 2xx and ACK that follow.
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 4]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+   An element encountering an unrecoverable transport error when trying
+   to send a response to an INVITE request MUST NOT immediately destroy
+   the associated INVITE server transaction state.  This state is
+   necessary to ensure correct processing of retransmissions of the
+   request.
+
+   When receiving any SIP response, a transaction-stateful proxy MUST
+   compare the transaction identifier in that response against its
+   existing transaction state machines.  The proxy MUST NOT forward the
+   response if there is no matching transaction state machine.
+
+   When receiving an ACK that matches an existing INVITE server
+   transaction and that does not contain a branch parameter containing
+   the magic cookie defined in RFC 3261, the matching transaction MUST
+   be checked to see if it is in the "Accepted" state.  If it is, then
+   the ACK must be passed directly to the transaction user instead of
+   being absorbed by the transaction state machine.  This is necessary
+   as requests from RFC 2543 clients will not include a unique branch
+   parameter, and the mechanisms for calculating the transaction ID from
+   such a request will be the same for both INVITE and ACKs.
+
+7.  Change Details
+
+   These changes impact requirements in several sections of RFC 3261.
+   The exact effect on that text is detailed in Section 8.  This section
+   describes the details of the change, particularly the impact on the
+   INVITE state machines, more succinctly to facilitate review and
+   simplify implementation.
+
+7.1.  Server Transaction Impacts
+
+   To allow a SIP element to recognize retransmissions of an INVITE as
+   retransmissions instead of new requests, a new state, "Accepted", is
+   added to the INVITE server transaction state machine.  A new timer,
+   Timer L, is also added to ultimately allow the state machine to
+   terminate.  A server transaction in the "Proceeding" state will
+   transition to the "Accepted" state when it issues a 2xx response and
+   will remain in that state just long enough to absorb any
+   retransmissions of the INVITE.
+
+   If the SIP element's TU (Transaction User) issues a 2xx response for
+   this transaction while the state machine is in the "Proceeding"
+   state, the state machine MUST transition to the "Accepted" state and
+   set Timer L to 64*T1, where T1 is the round-trip time estimate
+   defined in Section 17.1.1.1 of [RFC3261].
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 5]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+   While in the "Accepted" state, any retransmissions of the INVITE
+   received will match this transaction state machine and will be
+   absorbed by the machine without changing its state.  These
+   retransmissions are not passed onto the TU.  RFC 3261 requires the TU
+   to periodically retransmit the 2xx response until it receives an ACK.
+   The server transaction MUST NOT generate 2xx retransmissions on its
+   own.  Any retransmission of the 2xx response passed from the TU to
+   the transaction while in the "Accepted" state MUST be passed to the
+   transport layer for transmission.  Any ACKs received from the network
+   while in the "Accepted" state MUST be passed directly to the TU and
+   not absorbed.
+
+   When Timer L fires and the state machine is in the "Accepted" state,
+   the machine MUST transition to the "Terminated" state.  Once the
+   transaction is in the "Terminated" state, it MUST be destroyed
+   immediately.  Timer L reflects the amount of time the server
+   transaction could receive 2xx responses for retransmission from the
+   TU while it is waiting to receive an ACK.
+
+   A server transaction MUST NOT discard transaction state based only on
+   encountering a non-recoverable transport error when sending a
+   response.  Instead, the associated INVITE server transaction state
+   machine MUST remain in its current state.  (Timers will eventually
+   cause it to transition to the "Terminated" state).  This allows
+   retransmissions of the INVITE to be absorbed instead of being
+   processed as a new request.
+
+   Figures 1 and 2 show the parts of the INVITE server state machine
+   that have changed.  The entire new INVITE server state machine is
+   shown in Figure 5.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 6]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+    BEFORE                                 AFTER
+
+  +-----------+                       +-----------+
+  |           |                       |           |
+  | Proceeding|                       | Proceeding|
+  |           |                       |           |
+  |           |                       |           |
+  |           |                       |           |
+  |           |                       |           |
+  +-----------+                       +-----------+
+           |2xx from TU                      |2xx from TU
+           |send response                    |send response
+           +-------------->+                 +------->+
+                           |                          |
+                           |                          |
+                           |                          |
+                           |                          |  Transport
+                           |                 INVITE   |  Error
+                           |                 -        |  Inform TU
+                           |                 +-----+  |  +--+
+                           |                 |     |  V  |  v
+                           |                 |  +------------+
+                           |                 |  |            |<--+
+                           |                 +->|  Accepted  |   | ACK
+                           |                    |            |---+ to TU
+                           |                    +------------+
+                           |                     |   ^     |
+                           |                  +--+   |     |
+                           |                  |      +-----+
+                           |                  |  2xx from TU
+                           |                  |  send response
+                           |                  |
+                           |                  | Timer L fires
+                           |                  | -
+                           |                  |
+                           |                  V
+  +-----------+            |                +------------+
+  |           |            |                |            |
+  | Terminated|<-----------+                | Terminated |
+  |           |                             |            |
+  +-----------+                             +------------+
+
+     Figure 1: Changes to the INVITE server transaction state machine
+                             when sending 2xx
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 7]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+     BEFORE                                  AFTER
+
+  +-----------+                          +------------+
+  |           |                          |            |
+  | Proceeding|                          | Proceeding | Transport Err.
+  |           |                          |            | Inform TU
+  |           |   Transport Err.         |            |----------+
+  |           |   Inform TU              |            |          |
+  |           |--------------->+         |            |<---------+
+  +-----------+                |         +------------+
+                               |
+                               |
+                               |
+                               |
+                               |                       Transport Err.
+  +-----------+                |         +-----------+ Inform TU
+  |           |                |         |           |---------+
+  | Completed |                |         | Completed |         |
+  |           |                |         |           |<--------+
+  +-----------+                |         +-----------+
+           |                   |
+           |                   |
+           +------------------>+
+                 Transport Err.|
+                 Inform TU     |
+                               |
+                               |
+                               |
+                               |
+                               |
+                               |
+                               |
+                               |
+                               |
+  +-----------+                |
+  |           |                |
+  | Terminated|<---------------+
+  |           |
+  +-----------+
+
+   Figure 2: Changes to the INVITE server transaction state machine on
+                       encountering transport error
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 8]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+7.2.  Client Transaction Impacts
+
+   In order to correctly distinguish retransmissions of 2xx responses
+   from stray 2xx responses, the INVITE client state machine is modified
+   to not transition immediately to "Terminated" on receipt of a 2xx
+   response.  Instead, the machine will transition to a new "Accepted"
+   state, and remain there just long enough, determined by a new timer
+   M, to receive and pass to the TU any retransmissions of the 2xx
+   response or any additional 2xx responses from other branches of a
+   downstream fork of the matching request.  If a 2xx response is
+   received while the client INVITE state machine is in the "Calling" or
+   "Proceeding" states, it MUST transition to the "Accepted" state, pass
+   the 2xx response to the TU, and set Timer M to 64*T1.  A 2xx response
+   received while in the "Accepted" state MUST be passed to the TU and
+   the machine remains in the "Accepted" state.  The client transaction
+   MUST NOT generate an ACK to any 2xx response on its own.  The TU
+   responsible for the transaction will generate the ACK.
+
+   When Timer M fires and the state machine is in the "Accepted" state,
+   the machine MUST transition to the "Terminated" state.  Once the
+   transaction is in the "Terminated" state, it MUST be destroyed
+   immediately.
+
+   Any response received that does not match an existing client
+   transaction state machine is simply dropped.  (Implementations are,
+   of course, free to log or do other implementation-specific things
+   with such responses, but the implementer should be sure to consider
+   the impact of large numbers of malicious stray responses.)
+
+   Note that it is not necessary to preserve client transaction state
+   upon the detection of unrecoverable transport errors.  Existing
+   requirements ensure the TU has been notified, and the new
+   requirements in this document ensure that any received retransmitted
+   response will be dropped since there will no longer be any matching
+   transaction state.
+
+   Figure 3 shows the part of the INVITE client state machine that has
+   changed.  The entire new INVITE client state machine is shown in
+   Figure 5.
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                    [Page 9]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+   +-----------+                        +-----------+
+   |           |                        |           |
+   |  Calling  |                        |  Calling  |
+   |           |----------->+           |           |-----------+
+   +-----------+ 2xx        |           +-----------+ 2xx       |
+                 2xx to TU  |                         2xx to TU |
+                            |                                   |
+                            |                                   |
+                            |                                   |
+                            |                                   |
+   +-----------+            |           +-----------+           |
+   |           |            |           |           |           |
+   |Proceeding |----------->|           |Proceeding |---------->|
+   |           | 2xx        |           |           | 2xx       |
+   +-----------+ 2xx to TU  |           +-----------+ 2xx to TU |
+                            |                                   |
+                            |                                   |
+                            |                                   |
+                            |                                   V
+                            |                            +-----------+
+                            |                            |           |
+                            |                            | Accepted  |
+                            |                        +---|           |
+                            |              2xx       |   +-----------+
+                            |              2xx to TU |     ^    |
+                            |                        |     |    |
+                            |                        +-----+    |
+                            |                                   |
+                            |                 +-----------------+
+                            |                 | Timer M fires
+                            |                 | -
+                            |                 V
+   +-----------+            |           +-----------+
+   |           |            |           |           |
+   | Terminated|<-----------+           | Terminated|
+   |           |                        |           |
+   +-----------+                        +-----------+
+
+     Figure 3: Changes to the INVITE client transaction state machine
+
+7.3.  Proxy Considerations
+
+   This document changes the behavior of transaction-stateful proxies to
+   not forward stray INVITE responses.  When receiving any SIP response,
+   a transaction-stateful proxy MUST compare the transaction identifier
+   in that response against its existing transaction state machines.
+   The proxy MUST NOT forward the response if there is no matching
+   transaction state machine.
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 10]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+8.  Exact Changes to RFC 3261
+
+   This section describes exactly the same changes as above, but shows
+   exactly which text in RFC 3261 is affected.  This document
+   intentionally does not contain a Figure 4 or Figure 6 so that the
+   labels for Figures 5 and 7 are identical to the labels of the figures
+   they are replacing in RFC 3261.
+
+8.1.  Page 85
+
+   Section 13.3.1.4, paragraph 4, is replaced entirely by:
+
+      Once the response has been constructed, it is passed to the INVITE
+      server transaction.  In order to ensure reliable end-to-end
+      transport of the response, it is necessary to periodically pass
+      the response directly to the transport until the ACK arrives.  The
+      2xx response is passed to the transport with an interval that
+      starts at T1 seconds and doubles for each retransmission until it
+      reaches T2 seconds (T1 and T2 are defined in Section 17).
+      Response retransmissions cease when an ACK request for the
+      response is received.  This is independent of whatever transport
+      protocols are used to send the response.
+
+8.2.  Page 107
+
+   Section 16.7, paragraphs 1 and 2, are replaced entirely by:
+
+      When a response is received by an element, it first tries to
+      locate a client transaction (Section 17.1.3) matching the
+      response.  If a transaction is found, the response is handed to
+      the client transaction.  If none is found, the element MUST NOT
+      forward the response.
+
+8.3.  Page 114
+
+   Section 16.7, part 9, first paragraph.  Replace this sentence:
+
+      If the server transaction is no longer available to handle the
+      transmission, the element MUST forward the response statelessly by
+      sending it to the server transport.
+
+   with
+
+      If the server transaction is no longer available to handle the
+      transmission, the response is simply discarded.
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 11]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+8.4.  Pages 126 through 128
+
+   Section 17.1.1.2.  Replace paragraph 7 (starting "When in either")
+   through the end of the section with:
+
+      When in either the "Calling" or "Proceeding" states, reception of
+      a response with status code from 300-699 MUST cause the client
+      transaction to transition to "Completed".  The client transaction
+      MUST pass the received response up to the TU, and the client
+      transaction MUST generate an ACK request, even if the transport is
+      reliable (guidelines for constructing the ACK from the response
+      are given in Section 17.1.1.3), and then pass the ACK to the
+      transport layer for transmission.  The ACK MUST be sent to the
+      same address, port, and transport to which the original request
+      was sent.
+
+      The client transaction MUST start Timer D when it enters the
+      "Completed" state for any reason, with a value of at least 32
+      seconds for unreliable transports, and a value of zero seconds for
+      reliable transports.  Timer D reflects the amount of time that the
+      server transaction can remain in the "Completed" state when
+      unreliable transports are used.  This is equal to Timer H in the
+      INVITE server transaction, whose default is 64*T1, and is also
+      equal to the time a UAS core will wait for an ACK once it sends a
+      2xx response.  However, the client transaction does not know the
+      value of T1 in use by the server transaction or any downstream UAS
+      cores, so an absolute minimum of 32 s is used instead of basing
+      Timer D on T1.
+
+      Any retransmissions of a response with status code 300-699 that
+      are received while in the "Completed" state MUST cause the ACK to
+      be re-passed to the transport layer for retransmission, but the
+      newly received response MUST NOT be passed up to the TU.
+
+      A retransmission of the response is defined as any response that
+      would match the same client transaction based on the rules of
+      Section 17.1.3.
+
+      If Timer D fires while the client transaction is in the
+      "Completed" state, the client transaction MUST move to the
+      "Terminated" state.
+
+      When a 2xx response is received while in either the "Calling" or
+      "Proceeding" states, the client transaction MUST transition to the
+      "Accepted" state, and Timer M MUST be started with a value of
+      64*T1.  The 2xx response MUST be passed up to the TU.  The client
+      transaction MUST NOT generate an ACK to the 2xx response -- its
+      handling is delegated to the TU.  A UAC core will send an ACK to
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 12]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+      the 2xx response using a new transaction.  A proxy core will
+      always forward the 2xx response upstream.
+
+      The purpose of the "Accepted" state is to allow the client
+      transaction to continue to exist to receive, and pass to the TU,
+      any retransmissions of the 2xx response and any additional 2xx
+      responses from other branches of the INVITE if it forked
+      downstream.  Timer M reflects the amount of time that the
+      transaction user will wait for such messages.
+
+      Any 2xx responses that match this client transaction and that are
+      received while in the "Accepted" state MUST be passed up to the
+      TU.  The client transaction MUST NOT generate an ACK to the 2xx
+      response.  The client transaction takes no further action.
+
+      If Timer M fires while the client transaction is in the "Accepted"
+      state, the client transaction MUST move to the "Terminated" state.
+
+      The client transaction MUST be destroyed the instant it enters the
+      "Terminated" state.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 13]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+      Replace Figure 5 with:
+
+                                    |INVITE from TU
+                  Timer A fires     |INVITE sent      Timer B fires
+                  Reset A,          V                 or Transport Err.
+                  INVITE sent +-----------+           inform TU
+                    +---------|           |--------------------------+
+                    |         |  Calling  |                          |
+                    +-------->|           |-----------+              |
+   300-699                    +-----------+ 2xx       |              |
+   ACK sent                      |  |       2xx to TU |              |
+   resp. to TU                   |  |1xx              |              |
+   +-----------------------------+  |1xx to TU        |              |
+   |                                |                 |              |
+   |                1xx             V                 |              |
+   |                1xx to TU +-----------+           |              |
+   |                +---------|           |           |              |
+   |                |         |Proceeding |           |              |
+   |                +-------->|           |           |              |
+   |                          +-----------+ 2xx       |              |
+   |         300-699             |    |     2xx to TU |              |
+   |         ACK sent,  +--------+    +---------------+              |
+   |         resp. to TU|                             |              |
+   |                    |                             |              |
+   |                    V                             V              |
+   |              +-----------+                   +----------+       |
+   +------------->|           |Transport Err.     |          |       |
+                  | Completed |Inform TU          | Accepted |       |
+               +--|           |-------+           |          |-+     |
+       300-699 |  +-----------+       |           +----------+ |     |
+       ACK sent|    ^  |              |               |  ^     |     |
+               |    |  |              |               |  |     |     |
+               +----+  |              |               |  +-----+     |
+                       |Timer D fires |  Timer M fires|    2xx       |
+                       |-             |             - |    2xx to TU |
+                       +--------+     |   +-----------+              |
+      NOTE:                     V     V   V                          |
+   Transitions                 +------------+                        |
+   are labeled                 |            |                        |
+   with the event              | Terminated |<-----------------------+
+   over the action             |            |
+   to take.                    +------------+
+
+                    Figure 5: INVITE client transaction
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 14]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+8.5.  Pages 134 to 135
+
+   Section 17.2.1, paragraph 4, is replaced with:
+
+      If, while in the "Proceeding" state, the TU passes a 2xx response
+      to the server transaction, the server transaction MUST pass this
+      response to the transport layer for transmission.  It is not
+      retransmitted by the server transaction; retransmissions of 2xx
+      responses are handled by the TU.  The server transaction MUST then
+      transition to the "Accepted" state.
+
+8.6.  Page 136
+
+   Replace Figure 7 with:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 15]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+                                      |INVITE
+                                      |pass INV to TU
+                   INVITE             V send 100 if TU won't in 200 ms
+                   send response+------------+
+                       +--------|            |--------+ 101-199 from TU
+                       |        |            |        | send response
+                       +------->|            |<-------+
+                                | Proceeding |
+                                |            |--------+ Transport Err.
+                                |            |        | Inform TU
+                                |            |<-------+
+                                +------------+
+                   300-699 from TU |    |2xx from TU
+                   send response   |    |send response
+                    +--------------+    +------------+
+                    |                                |
+   INVITE           V          Timer G fires         |
+   send response +-----------+ send response         |
+        +--------|           |--------+              |
+        |        |           |        |              |
+        +------->| Completed |<-------+      INVITE  |  Transport Err.
+                 |           |               -       |  Inform TU
+        +--------|           |----+          +-----+ |  +---+
+        |        +-----------+    | ACK      |     | v  |   v
+        |          ^   |          | -        |  +------------+
+        |          |   |          |          |  |            |---+ ACK
+        +----------+   |          |          +->|  Accepted  |   | to TU
+        Transport Err. |          |             |            |<--+
+        Inform TU      |          V             +------------+
+                       |      +-----------+        |  ^     |
+                       |      |           |        |  |     |
+                       |      | Confirmed |        |  +-----+
+                       |      |           |        |  2xx from TU
+         Timer H fires |      +-----------+        |  send response
+         -             |          |                |
+                       |          | Timer I fires  |
+                       |          | -              | Timer L fires
+                       |          V                | -
+                       |        +------------+     |
+                       |        |            |<----+
+                       +------->| Terminated |
+                                |            |
+                                +------------+
+
+                    Figure 7: INVITE server transaction
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 16]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+8.7.  Page 137
+
+   In Section 17.2.1, replace the last paragraph (starting "Once the
+   transaction") with:
+
+      The purpose of the "Accepted" state is to absorb retransmissions
+      of an accepted INVITE request.  Any such retransmissions are
+      absorbed entirely within the server transaction.  They are not
+      passed up to the TU since any downstream UAS cores that accepted
+      the request have taken responsibility for reliability and will
+      already retransmit their 2xx responses if necessary.
+
+      While in the "Accepted" state, if the TU passes a 2xx response,
+      the server transaction MUST pass the response to the transport
+      layer for transmission.
+
+      When the INVITE server transaction enters the "Accepted" state,
+      Timer L MUST be set to fire in 64*T1 for all transports.  This
+      value matches both Timer B in the next upstream client state
+      machine (the amount of time the previous hop will wait for a
+      response when no provisionals have been sent) and the amount of
+      time this (or any downstream) UAS core might be retransmitting the
+      2xx while waiting for an ACK.  If an ACK is received while the
+      INVITE server transaction is in the "Accepted" state, then the ACK
+      must be passed up to the TU.  If Timer L fires while the INVITE
+      server transaction is in the "Accepted" state, the transaction
+      MUST transition to the "Terminated" state.
+
+      Once the transaction is in the "Terminated" state, it MUST be
+      destroyed immediately.
+
+8.8.  Page 141
+
+   In Section 17.2.4, replace the second paragraph with:
+
+      First, the procedures in [4] are followed, which attempt to
+      deliver the response to a backup.  If those should all fail, based
+      on the definition of failure in [4], the server transaction SHOULD
+      inform the TU that a failure has occurred, and MUST remain in the
+      current state.
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 17]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+8.9.  Page 144
+
+      In Section 18.1.2, replace the second paragraph with:
+
+      The client transport uses the matching procedures of Section
+      17.1.3 to attempt to match the response to an existing
+      transaction.  If there is a match, the response MUST be passed to
+      that transaction.  Otherwise, any element other than a stateless
+      proxy MUST silently discard the response.
+
+8.10.  Page 146
+
+      In Section 18.2.1, replace the last paragraph with:
+
+      Next, the server transport attempts to match the request to a
+      server transaction.  It does so using the matching rules described
+      in Section 17.2.3.  If a matching server transaction is found, the
+      request is passed to that transaction for processing.  If no match
+      is found, the request is passed to the core, which may decide to
+      construct a new server transaction for that request.
+
+8.11.  Page 265
+
+      Add to Table 4:
+
+      Timer L  64*T1            Section 17.2.1       Wait time for
+                                                     accepted INVITE
+                                                     request retransmits
+
+      Timer M  64*T1            Section 17.1.1       Wait time for
+                                                     retransmission of
+                                                     2xx to INVITE or
+                                                     additional 2xx from
+                                                     other branches of
+                                                     a forked INVITE
+
+9.  IANA Considerations
+
+   IANA has updated the SIP Parameters: Method and Response Codes
+   registry as follows:
+
+   OLD:
+
+   Methods Reference
+   ------- ---------
+   INVITE  [RFC3261]
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 18]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+   NEW:
+
+   Methods Reference
+   ------- ---------
+   INVITE  [RFC3261][RFC6026]
+
+10.  Security Considerations
+
+   This document makes two changes to the Session Initiation Protocol to
+   address the error discussed in Section 3.  It changes the behavior of
+   both the client and server INVITE transaction state machines, and it
+   changes the way "stray" responses (those that don't match any
+   existing transaction) are handled at transaction-stateful elements.
+
+   The changes to the state machines cause elements to hold onto each
+   accepted INVITE transaction state 32 seconds longer than what was
+   specified in RFC 3261.  This will have a direct impact on the amount
+   of work an attacker that is leveraging state exhaustion will have to
+   exert against the system.  However, this additional state is
+   necessary to achieve correct operation.  There is some discussion of
+   avoiding state exhaustion and other denial-of-service attacks in RFC
+   3261, Section 26.3.2.4.
+
+   RFC 3261 required SIP proxies to forward any stray 2xx class
+   responses to an INVITE request upstream statelessly.  As a result,
+   conformant proxies can be forced to forward packets (that look
+   sufficiently like SIP responses) to destinations of the sender's
+   choosing.  Section 3 discusses some of the malicious behavior this
+   enables.  This document reverses the stateless forwarding
+   requirement, making it a violation of the specification to forward
+   stray responses.
+
+   RFC 3261 defines a "stateless proxy", which forwards requests and
+   responses without creating or maintaining any transaction state.  The
+   requirements introduced in this document do not change the behavior
+   of these elements in any way.  Stateless proxies are inherently
+   vulnerable to the abuses discussed in Section 3.  One way operators
+   might mitigate this vulnerability is to carefully control which peer
+   elements can present traffic to a given stateless proxy.
+
+   The changes introduced by this document are backward-compatible.
+   Transaction behavior will be no less correct, and possibly more
+   correct, when only one peer in a transaction implements these
+   changes.  Except for the considerations mentioned earlier in this
+   section, introducing elements implementing these changes into
+   deployments with RFC 3261 implementations adds no additional security
+   concerns.
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 19]
+
+RFC 6026         Correct Handling for SIP 2xx Responses   September 2010
+
+
+11.  Acknowledgments
+
+   Pekka Pessi reported the improper handling of INVITE retransmissions.
+   Brett Tate performed a careful review uncovering the need for the
+   "Accepted" state and Timer M in the client transaction state machine.
+   Jan Kolomaznik noticed that a server transaction should let a TU know
+   about transport errors when it attempts to send a 2xx class response.
+   Michael Procter corrected several nits.
+
+12.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
+              A., Peterson, J., Sparks, R., Handley, M., and E.
+              Schooler, "SIP: Session Initiation Protocol", RFC 3261,
+              June 2002.
+
+Authors' Addresses
+
+   Robert Sparks
+   Tekelec
+   17210 Campbell Road
+   Suite 250
+   Dallas, Texas  75252
+   USA
+
+   EMail: RjS@nostrum.com
+
+
+   Theo Zourzouvillys
+   Skype
+   3rd Floor
+   8000 Marina Blvd
+   Brisbane, California  84005
+   US
+
+   EMail: theo@crazygreek.co.uk
+
+
+
+
+
+
+
+
+
+
+
+
+Sparks & Zourzouvillys       Standards Track                   [Page 20]
+


### PR DESCRIPTION
## Summary
- Vendor 5 new RFCs referenced in codebase: 6026 (INVITE txn revision), 3581 (rport), 5626 (keepalive), 4733 (DTMF), 3389 (comfort noise)
- Update `rfcs/download.sh` with new RFC numbers
- Expand `rfc-index.md` with section indexes for NAT traversal, keepalive, DTMF, and comfort noise
- Add ITU-T recommendation lookup instructions to `SKILL.md` with direct PDF download URLs for G.711, G.712, G.114

## Test plan
- [x] All 174 tests pass
- [x] Verified ITU-T PDF download workflow end-to-end (G.711, G.114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)