### PR TITLE
Add GitHub Release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # frizzle-phone
 
 [![codecov](https://codecov.io/gh/frizzle-chan/frizzle-phone/graph/badge.svg?token=RQSA7M18EY)](https://codecov.io/gh/frizzle-chan/frizzle-phone)
-![GitHub Release](https://img.shields.io/github/v/release/frizzle-chan/frizzle-phone)
+[![GitHub Release](https://img.shields.io/github/v/release/frizzle-chan/frizzle-phone)](https://github.com/frizzle-chan/frizzle-phone/releases/latest)
 
 frizzle-phone allows you to use your favorite SIP VoIP phone to call into your favorite Discord voice channels.
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Release version badge to the README, linked to the latest releases page

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify badge links to releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)