### PR TITLE
Add RTP version + payload type validation to receive path

### DIFF
--- a/src/frizzle_phone/rtp/receive.py
+++ b/src/frizzle_phone/rtp/receive.py
@@ -14,7 +14,7 @@ from frizzle_phone.bridge import (
     ChunkedResampler,
 )
 from frizzle_phone.bridge_stats import BridgeStats
-from frizzle_phone.rtp import pcmu
+from frizzle_phone.rtp import pcmu, stream
 from frizzle_phone.rtp.pcmu import ulaw_to_pcm
 
 logger = logging.getLogger(__name__)
@@ -49,6 +49,13 @@ class RtpReceiveProtocol(asyncio.DatagramProtocol):
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         if len(data) < 12:
+            return
+        # RFC 3550 §5.1: reject non-V2 packets
+        if (data[0] >> 6) != 2:
+            return
+        # Reject non-PCMU payloads (comfort noise, telephone-event, etc.)
+        pt = data[1] & 0x7F
+        if pt != stream.PAYLOAD_TYPE_PCMU:
             return
         # Parse variable-length RTP header
         cc = data[0] & 0x0F

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,12 @@ class FakeTransport(asyncio.DatagramTransport):
             self.sent.append((bytes(data), addr))
 
 
-def build_rtp_packet(payload: bytes, *, cc: int = 0, extension: bool = False) -> bytes:
+def build_rtp_packet(
+    payload: bytes, *, cc: int = 0, extension: bool = False, pt: int = 0
+) -> bytes:
     """Build a minimal RTP packet for testing."""
     first_byte = 0x80 | (0x10 if extension else 0) | cc  # V=2, P=0
-    header = struct.pack("!BBHII", first_byte, 0, 0, 0, 0)
+    header = struct.pack("!BBHII", first_byte, pt, 0, 0, 0)
     csrc = b"\x00\x00\x00\x00" * cc
     ext_bytes = b""
     if extension:

--- a/tests/test_rtp_receive.py
+++ b/tests/test_rtp_receive.py
@@ -42,6 +42,29 @@ def test_rtp_receive_handles_extension():
     assert not q.empty()
 
 
+def test_rtp_receive_rejects_non_v2():
+    """Packets with RTP version != 2 are silently dropped."""
+    q: queue.Queue[bytes] = queue.Queue()
+    proto = RtpReceiveProtocol(q)
+    # V=1 packet (0x40 = version 1, no padding/extension/CSRC)
+    bad_packet = bytes([0x40, 0x00]) + b"\x00" * 10 + b"\xff" * 160
+    for _ in range(10):
+        proto.datagram_received(bad_packet, ("127.0.0.1", 9000))
+    assert q.empty()
+
+
+def test_rtp_receive_rejects_wrong_payload_type():
+    """Non-PCMU payload types (comfort noise, telephone-event) are dropped."""
+    q: queue.Queue[bytes] = queue.Queue()
+    proto = RtpReceiveProtocol(q)
+    payload = b"\xff" * 160
+    for pt in (13, 101):  # CN, telephone-event
+        for _ in range(10):
+            packet = build_rtp_packet(payload, pt=pt)
+            proto.datagram_received(packet, ("127.0.0.1", 9000))
+    assert q.empty()
+
+
 def test_rtp_receive_drops_oldest_on_overflow():
     """When p2d queue is full, oldest frame is dropped and new frame enqueued."""
     q: queue.Queue[bytes] = queue.Queue(maxsize=2)


### PR DESCRIPTION
## Summary
- Reject non-V2 RTP packets before decoding (RFC 3550 §5.1)
- Filter out non-PCMU payload types (comfort noise PT 13, telephone-event PT 101) that were being decoded as μ-law, producing garbage audio
- Add tests for both rejection paths

## Test plan
- [x] `test_rtp_receive_rejects_non_v2` — V1 packets silently dropped
- [x] `test_rtp_receive_rejects_wrong_payload_type` — PT 13/101 packets dropped
- [x] Existing tests still pass (PCMU PT 0 accepted)
- [x] All CI checks pass (lint, format, types, vulture, 176 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)