### PR TITLE
Fix SSRC race: propagate mappings to decoder thread on start

### DIFF
--- a/src/frizzle_phone/discord_voice_rx/client.py
+++ b/src/frizzle_phone/discord_voice_rx/client.py
@@ -65,6 +65,9 @@ class VoiceRecvClient(discord.VoiceClient):
         self._recv_stats = VoiceRecvStats()
         self._decoder_thread = DecoderThread(stats=self._recv_stats)
         self._decoder_thread.start()
+        # Propagate SSRC→user mappings received before listening started
+        for ssrc, user_id in self._ssrc_to_id.items():
+            self._decoder_thread.set_ssrc_user(ssrc, user_id)
         self._connection.add_socket_listener(self._socket_callback_fn)
 
     def stop_listening(self) -> None:


### PR DESCRIPTION
## Summary

- **Bug**: `d2p mixed=0` — zero Discord audio frames reaching the phone after deploying the in-house `discord_voice_rx` module
- **Root cause**: Gateway SPEAKING events arrive before `start_listening()` creates the `DecoderThread`, so the decoder starts with an empty SSRC→user map and silently drops all voice packets
- **Fix**: Propagate existing `_ssrc_to_id` mappings to the decoder thread immediately after creation

## Test plan
- [x] All 238 tests pass
- [ ] CI passes
- [ ] Deploy to production, make a call, verify `d2p mixed > 0` in bridge stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)