### PR TITLE
Guard _start_discord_bridge against call termination during await

### DIFF
--- a/src/frizzle_phone/sip/server.py
+++ b/src/frizzle_phone/sip/server.py
@@ -786,6 +786,9 @@ class SipServer(asyncio.DatagramProtocol):
         handle = await self._bridge_manager.start(
             pb.voice_client, call.rtp_port, call.remote_rtp_addr
         )
+        if call.terminated:
+            handle.stop()
+            return
         call.discord_bridge = DiscordBridgeContext(
             voice_client=pb.voice_client,
             guild_id=pb.guild_id,

--- a/tests/test_sip_server.py
+++ b/tests/test_sip_server.py
@@ -205,6 +205,31 @@ def _make_call(call_id: str = "test@10.0.0.1") -> Call:
     )
 
 
+@pytest.mark.asyncio
+async def test_start_discord_bridge_stops_handle_if_terminated(db):
+    """If call is terminated during bridge_manager.start(), handle is stopped."""
+    server, _transport = _make_server(db)
+    call = _make_call()
+    vc = MagicMock()
+    call.pending_bridge = PendingBridge(voice_client=vc, guild_id=1, channel_id=2)
+    server._calls[call.call_id] = call
+
+    mock_handle = MagicMock(spec=BridgeHandle)
+
+    async def _simulate_bye(*_args, **_kwargs):
+        call.terminated = True
+        call.pending_bridge = None
+        return mock_handle
+
+    server._bridge_manager = MagicMock()
+    server._bridge_manager.start = AsyncMock(side_effect=_simulate_bye)
+
+    await server._start_discord_bridge(call)
+
+    mock_handle.stop.assert_called_once()
+    assert call.discord_bridge is None
+
+
 def test_get_bridged_calls_active_bridges(db):
     """get_bridged_calls returns (guild_id, channel_id) for active bridges."""
     server, _transport = _make_server(db)


### PR DESCRIPTION
## Summary

- Add `call.terminated` guard after `await self._bridge_manager.start()` in `_start_discord_bridge` — if BYE arrives during the await, the returned `BridgeHandle` is stopped immediately instead of being assigned to the dead call
- Prevents orphaned RTP send loop, UDP transport, and decoder thread that would never be cleaned up

## Test plan

- [x] New test `test_start_discord_bridge_stops_handle_if_terminated` simulates BYE arriving during bridge setup by setting `call.terminated = True` inside the `bridge_manager.start()` side effect
- [x] Asserts `handle.stop()` is called and `call.discord_bridge` remains `None`
- [x] All 239 tests pass, lint/format/types/vulture clean

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)