### PR TITLE
Fix d2p starvation warning to distinguish silence from pipeline loss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ The `actions/labeler` workflow also auto-labels based on file paths and branch n
 | Symptom in logs | Likely cause |
 |---|---|
 | `d2p_dropped > 0` | RTP send loop falling behind |
-| `rtp_silence_sent` high | Discord not delivering audio frames |
+| `rtp_silence_sent` high, `d2p_frames_mixed` low | Normal — no one speaking on Discord |
+| `rtp_silence_sent` high, `d2p_frames_mixed` also high | Pipeline loss — frames consumed but not sent |
 | `rtp_max_sleep_overshoot > 5ms` | Event loop congestion |
 | `p2d_queue_overflow > 0` | Discord `read()` not keeping up |
 | `p2d_silence_reads` high, `p2d_frames_in` normal | Phone audio arriving in bursts (jitter) |

--- a/src/frizzle_phone/bridge_stats.py
+++ b/src/frizzle_phone/bridge_stats.py
@@ -101,13 +101,20 @@ class BridgeStats:
                 snap["p2d_silence"] / snap["p2d_reads"] * 100,
             )
 
-        if snap["rtp_sent"] > 0 and snap["rtp_silence"] / snap["rtp_sent"] > 0.20:
-            logger.warning(
-                "bridge d2p starvation: %d/%d RTP sends were silence (%.0f%%)",
-                snap["rtp_silence"],
-                snap["rtp_sent"],
-                snap["rtp_silence"] / snap["rtp_sent"] * 100,
-            )
+        if snap["rtp_sent"] > 0:
+            expected_silence = max(0, snap["rtp_sent"] - snap["d2p_mixed"])
+            unexplained = max(0, snap["rtp_silence"] - expected_silence)
+            if unexplained / snap["rtp_sent"] > 0.10:
+                audio_sent = snap["rtp_sent"] - snap["rtp_silence"]
+                logger.warning(
+                    "bridge d2p pipeline loss: fed %d mixed slots but only %d "
+                    "audio payloads sent (%d/%d unexplained silence, %.0f%%)",
+                    snap["d2p_mixed"],
+                    audio_sent,
+                    unexplained,
+                    snap["rtp_sent"],
+                    unexplained / snap["rtp_sent"] * 100,
+                )
 
         if snap["p2d_gap_warns"] > 0:
             logger.warning(

--- a/tests/test_bridge_stats.py
+++ b/tests/test_bridge_stats.py
@@ -68,14 +68,27 @@ def test_log_summary_warns_on_high_silence_reads(caplog):
     assert any("p2d underflow" in r.message for r in warnings)
 
 
-def test_log_summary_warns_on_high_silence_sends(caplog):
+def test_log_summary_warns_on_pipeline_loss(caplog):
     stats = BridgeStats()
     stats.rtp_frames_sent = 100
-    stats.rtp_silence_sent = 25  # 25% > 20%
+    stats.d2p_frames_mixed = 80  # fed 80 mixed slots
+    stats.rtp_silence_sent = 50  # expected_silence=20, unexplained=30, 30% > 10%
     with caplog.at_level(logging.WARNING, logger="frizzle_phone.bridge_stats"):
         stats.log_and_reset()
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("d2p starvation" in r.message for r in warnings)
+    assert any("d2p pipeline loss" in r.message for r in warnings)
+
+
+def test_log_summary_no_starvation_warn_when_nobody_speaking(caplog):
+    """All silence is expected when nobody is talking on Discord."""
+    stats = BridgeStats()
+    stats.rtp_frames_sent = 250
+    stats.rtp_silence_sent = 250
+    stats.d2p_frames_mixed = 0  # expected_silence=250, unexplained=0
+    with caplog.at_level(logging.WARNING, logger="frizzle_phone.bridge_stats"):
+        stats.log_and_reset()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("pipeline loss" in r.message for r in warnings)
 
 
 def test_log_summary_no_warn_when_below_thresholds(caplog):


### PR DESCRIPTION
## Summary

- Replace naive silence-ratio d2p starvation warning with "unexplained silence" metric that accounts for expected silence when nobody is speaking on Discord
- Compute `expected_silence = rtp_sent - d2p_mixed` and only warn when unexplained silence exceeds 10% of `rtp_sent`, eliminating false positives during normal conversation pauses
- Update diagnostic table in CLAUDE.md to distinguish normal silence (low `d2p_frames_mixed`) from genuine pipeline loss (high `d2p_frames_mixed`)

## Test plan

- [x] `test_log_summary_warns_on_pipeline_loss` — verifies warning fires on genuine pipeline loss (80 mixed, 50 silence → 30 unexplained = 30%)
- [x] `test_log_summary_no_starvation_warn_when_nobody_speaking` — verifies no warning when all silence is expected (250/250 silence, 0 mixed)
- [x] `test_log_summary_no_warn_when_below_thresholds` — existing test still passes
- [x] All 259 tests pass, lint/format/types/vulture clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)