### PR TITLE
Add Prometheus metrics on /metrics endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,8 @@ The `actions/labeler` workflow also auto-labels based on file paths and branch n
 | Symptom in logs | Likely cause |
 |---|---|
 | `d2p_dropped > 0` | RTP send loop falling behind |
-| `rtp_silence_sent` high | Discord not delivering audio frames |
+| `rtp_silence_sent` high, `d2p_frames_mixed` low | Normal — no one speaking on Discord |
+| `rtp_silence_sent` high, `d2p_frames_mixed` also high | Pipeline loss — frames consumed but not sent |
 | `rtp_max_sleep_overshoot > 5ms` | Event loop congestion |
 | `p2d_queue_overflow > 0` | Discord `read()` not keeping up |
 | `p2d_silence_reads` high, `p2d_frames_in` normal | Phone audio arriving in bursts (jitter) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Lefthook runs ruff, ty, vulture, and pytest on pre-commit. Direct commits to `ma
 
 - `DESIGN.md` documents the architecture, call flow, and audio pipeline — keep it up to date when changing components, call flow, or audio bridge logic
 - When adding new technical concepts to `DESIGN.md`, add a footnote reference (`[^key]`) on the first occurrence and a footnote definition at the bottom (keep definitions sorted alphabetically by key)
+- `docs/METRICS.md` is the Prometheus metrics reference and interpretation guide — keep it up to date when adding, removing, or changing metrics in `metrics.py`, `bridge_stats.py`, or `discord_voice_rx/stats.py`
 
 ## Testing Philosophy
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -161,6 +161,12 @@ Both directions use `soxr.LQ` (sinc-based, ~96dB stopband[^stopband] rejection) 
 
 **Why `ChunkedResampler`:** Sinc-based soxr modes (`LQ`+) buffer internally and emit samples in variable-size bursts rather than a steady 1:ratio output. `ChunkedResampler` accumulates resampler output and yields exactly the expected frame size (160 samples at 8kHz for d2p, 960 samples at 48kHz for p2d) so the rest of the pipeline sees a consistent chunk per feed.
 
+## Observability
+
+[`metrics.py`](src/frizzle_phone/metrics.py): Prometheus[^prometheus] metrics exposed on `GET /metrics` (port 8080). Uses a custom `CollectorRegistry` for test isolation. All metrics use `frizzle_bridge_`, `frizzle_voice_rx_`, or `frizzle_` prefixes.
+
+**Update cadence:** Counters and gauges are fed from the existing 5-second snapshot-and-reset cycle in `BridgeStats` and `VoiceRecvStats`. The hot path (per-frame) stays zero-overhead — Prometheus objects are only touched during periodic `log_and_reset()` calls. The `frizzle_active_calls` gauge is refreshed at scrape time via a callback. See [`docs/METRICS.md`](docs/METRICS.md) for the full metric reference and interpretation guide.
+
 [^agc]: AGC, [Automatic gain control](https://en.wikipedia.org/wiki/Automatic_gain_control): normalizes audio levels per speaker
 [^aiohttp]: [aiohttp](https://docs.aiohttp.org/en/stable/): async HTTP server/client framework for Python
 [^aiosqlite]: [aiosqlite](https://pypi.org/project/aiosqlite/): async wrapper for Python's sqlite3
@@ -179,6 +185,7 @@ Both directions use `soxr.LQ` (sinc-based, ~96dB stopband[^stopband] rejection) 
 [^nacl]: [NaCl](https://nacl.cr.yp.to/): networking and cryptography library for voice packet encryption
 [^noisegate]: [Noise gate](https://en.wikipedia.org/wiki/Noise_gate): silences signal below a threshold
 [^opus]: [Opus](https://en.wikipedia.org/wiki/Opus_(audio_format)): low-latency audio codec used by Discord
+[^prometheus]: [Prometheus](https://prometheus.io/): open-source monitoring and alerting toolkit
 [^rfc3261]: [RFC 3261](https://datatracker.ietf.org/doc/html/rfc3261): core SIP specification
 [^rms]: RMS, [Root mean square](https://en.wikipedia.org/wiki/Root_mean_square): measure of signal amplitude
 [^rtp]: RTP, [Real-time Transport Protocol](https://en.wikipedia.org/wiki/Real-time_Transport_Protocol): carries audio/video over UDP

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -2,6 +2,8 @@
 
 frizzle-phone exposes Prometheus metrics on `GET /metrics` (port 8080). Scrape interval: 15–30s recommended (metrics update every 5s internally).
 
+**Grafana dashboard:** [`docs/grafana-dashboard.json`](grafana-dashboard.json) — import via Dashboards → Import and select your Prometheus datasource.
+
 ## Metric Inventory
 
 ### Bridge Counters (`frizzle_bridge_*`)

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,159 @@
+# Prometheus Metrics Reference
+
+frizzle-phone exposes Prometheus metrics on `GET /metrics` (port 8080). Scrape interval: 15–30s recommended (metrics update every 5s internally).
+
+## Metric Inventory
+
+### Bridge Counters (`frizzle_bridge_*`)
+
+Updated every 5s from `BridgeStats.log_and_reset()`. Values are monotonically increasing totals.
+
+| Metric | Description |
+|---|---|
+| `frizzle_bridge_d2p_frames_mixed_total` | Discord→phone frames mixed into RTP slots |
+| `frizzle_bridge_d2p_frames_dropped_total` | Discord→phone frames dropped (slot queue freshness eviction) |
+| `frizzle_bridge_p2d_frames_in_total` | Phone→Discord RTP frames received |
+| `frizzle_bridge_p2d_queue_overflow_total` | Phone→Discord queue overflows (queue full, oldest dropped) |
+| `frizzle_bridge_p2d_reads_total` | Phone→Discord `read()` calls from Discord voice sink |
+| `frizzle_bridge_p2d_silence_reads_total` | Phone→Discord reads that returned silence (queue empty) |
+| `frizzle_bridge_p2d_gap_warnings_total` | Phone→Discord recv gaps >40ms (jitter/network issues) |
+| `frizzle_bridge_rtp_frames_sent_total` | RTP frames sent to phone (audio + silence) |
+| `frizzle_bridge_rtp_silence_sent_total` | RTP silence frames sent to phone |
+
+### Bridge Gauges
+
+Set to the value observed in the most recent 5s snapshot window.
+
+| Metric | Description |
+|---|---|
+| `frizzle_bridge_d2p_queue_depth` | Discord→phone slot queue depth at snapshot time |
+| `frizzle_bridge_p2d_max_recv_gap_seconds` | Largest gap between consecutive phone RTP packets (seconds) |
+| `frizzle_bridge_rtp_max_sleep_overshoot_seconds` | Largest RTP send loop timing overshoot (seconds) |
+
+### Voice Receive Counters (`frizzle_voice_rx_*`)
+
+Updated every 5s from `VoiceRecvStats.log_and_reset()`.
+
+| Metric | Description |
+|---|---|
+| `frizzle_voice_rx_packets_in_total` | Discord voice UDP packets received |
+| `frizzle_voice_rx_decrypt_failures_total` | Packets that failed decryption (NaCl/DAVE) |
+| `frizzle_voice_rx_opus_decodes_total` | Successful Opus frame decodes |
+| `frizzle_voice_rx_opus_errors_total` | Opus decode errors |
+| `frizzle_voice_rx_ticks_empty_total` | `pop_tick()` calls that returned no frames |
+| `frizzle_voice_rx_ticks_served_total` | `pop_tick()` calls that returned frames |
+
+### Voice Receive Gauges
+
+| Metric | Description |
+|---|---|
+| `frizzle_voice_rx_max_callback_microseconds` | Peak socket callback duration (μs) in last 5s window |
+| `frizzle_voice_rx_max_decode_microseconds` | Peak Opus decode duration (μs) in last 5s window |
+
+### SIP Server
+
+| Metric | Description |
+|---|---|
+| `frizzle_active_calls` | Current number of active SIP calls (refreshed at scrape time) |
+
+## Interpreting Metrics
+
+### Healthy Call
+
+During a normal bidirectional call with one Discord speaker:
+
+- `rate(frizzle_bridge_rtp_frames_sent_total[1m])` ≈ 50/s (one 20ms frame per tick)
+- `rate(frizzle_bridge_d2p_frames_mixed_total[1m])` > 0 (Discord audio flowing)
+- `frizzle_bridge_d2p_frames_dropped_total` stable (no drops)
+- `frizzle_bridge_rtp_max_sleep_overshoot_seconds` < 0.005 (5ms)
+- `rate(frizzle_voice_rx_packets_in_total[1m])` ≈ 50/s per speaker
+- `frizzle_voice_rx_decrypt_failures_total` stable (no failures)
+- `frizzle_active_calls` ≥ 1
+
+### Silence vs Pipeline Loss
+
+When nobody is speaking on Discord, silence is expected and healthy:
+- `rtp_silence_sent` high + `d2p_frames_mixed` = 0 → **normal silence**, no speakers active
+- `rtp_silence_sent` high + `d2p_frames_mixed` also high → **pipeline loss**, frames consumed but not making it to RTP
+
+PromQL to detect pipeline loss:
+```promql
+(
+  rate(frizzle_bridge_rtp_silence_sent_total[5m])
+  - clamp_min(rate(frizzle_bridge_rtp_frames_sent_total[5m]) - rate(frizzle_bridge_d2p_frames_mixed_total[5m]), 0)
+) / rate(frizzle_bridge_rtp_frames_sent_total[5m]) > 0.10
+```
+
+### Phone Audio Not Arriving
+
+- `rate(frizzle_bridge_p2d_frames_in_total[1m])` ≈ 0 → phone not sending RTP
+- `rate(frizzle_bridge_p2d_silence_reads_total[1m]) / rate(frizzle_bridge_p2d_reads_total[1m])` > 0.20 → phone audio underflow
+
+### Jitter / Network Issues
+
+- `frizzle_bridge_p2d_max_recv_gap_seconds` > 0.040 → phone-side jitter or packet loss
+- `rate(frizzle_bridge_p2d_gap_warnings_total[5m])` > 0 → sustained recv gaps
+- `frizzle_bridge_rtp_max_sleep_overshoot_seconds` > 0.005 → event loop congestion
+
+### Discord Voice Issues
+
+- `rate(frizzle_voice_rx_decrypt_failures_total[5m])` > 0 → encryption key rotation issue or corrupt packets
+- `rate(frizzle_voice_rx_opus_errors_total[5m])` > 0 → malformed Opus frames from Discord
+- `frizzle_voice_rx_max_callback_microseconds` > 1000 → socket callback taking too long (>1ms)
+
+### Queue Health
+
+- `frizzle_bridge_d2p_queue_depth` > 25 → slot queue building up (approaching 50-slot cap)
+- `rate(frizzle_bridge_p2d_queue_overflow_total[5m])` > 0 → phone→Discord queue full, dropping audio
+- `rate(frizzle_bridge_d2p_frames_dropped_total[5m])` > 0 → freshness eviction in d2p slot queue
+
+## Example Grafana Queries
+
+**Call volume:**
+```promql
+frizzle_active_calls
+```
+
+**RTP send rate (should be ~50/s during calls):**
+```promql
+rate(frizzle_bridge_rtp_frames_sent_total[1m])
+```
+
+**Silence ratio (lower is better during active speech):**
+```promql
+rate(frizzle_bridge_rtp_silence_sent_total[1m]) / rate(frizzle_bridge_rtp_frames_sent_total[1m])
+```
+
+**Decrypt failure rate:**
+```promql
+rate(frizzle_voice_rx_decrypt_failures_total[5m])
+```
+
+**Peak timing overshoot:**
+```promql
+frizzle_bridge_rtp_max_sleep_overshoot_seconds
+```
+
+## Alert Examples
+
+**No active calls when expected:**
+```yaml
+- alert: FrizzleNoActiveCalls
+  expr: frizzle_active_calls == 0
+  for: 10m
+```
+
+**High pipeline loss:**
+```yaml
+- alert: FrizzlePipelineLoss
+  expr: >
+    rate(frizzle_bridge_d2p_frames_dropped_total[5m]) > 1
+  for: 2m
+```
+
+**Decrypt failures:**
+```yaml
+- alert: FrizzleDecryptFailures
+  expr: rate(frizzle_voice_rx_decrypt_failures_total[5m]) > 0
+  for: 1m
+```

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,0 +1,1128 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "#808080", "value": null },
+              { "color": "green", "value": 1 },
+              { "color": "yellow", "value": 5 }
+            ]
+          },
+          "mappings": [
+            { "options": { "0": { "text": "None" } }, "type": "value" }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_active_calls",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Active Calls",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 40 },
+              { "color": "green", "value": 48 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_rtp_frames_sent_total[$__rate_interval])",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "title": "RTP Send Rate",
+      "description": "Should be ~50/s during active calls",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.95 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_rtp_silence_sent_total[$__rate_interval]) / rate(frizzle_bridge_rtp_frames_sent_total[$__rate_interval])",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "title": "D2P Silence Ratio",
+      "description": "High during silence is normal; high with mixed frames = pipeline loss",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.2 },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_silence_reads_total[$__rate_interval]) / rate(frizzle_bridge_p2d_reads_total[$__rate_interval])",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "title": "Phone Audio Underflow",
+      "description": "Fraction of Discord read() calls returning silence instead of phone audio",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_bridge_rtp_max_sleep_overshoot_seconds",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "RTP Timing Overshoot",
+      "description": "Peak RTP send loop sleep overshoot; >5ms indicates event loop congestion",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 25 },
+              { "color": "red", "value": 40 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 7,
+      "options": {
+        "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_bridge_d2p_queue_depth",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "D2P Queue Depth",
+      "description": "Discord-to-phone slot queue depth; cap is 50",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 8,
+      "title": "Discord \u2192 Phone (D2P)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 9,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_d2p_frames_mixed_total[$__rate_interval])",
+          "legendFormat": "mixed",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_rtp_frames_sent_total[$__rate_interval])",
+          "legendFormat": "RTP sent",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_rtp_silence_sent_total[$__rate_interval])",
+          "legendFormat": "silence sent",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_d2p_frames_dropped_total[$__rate_interval])",
+          "legendFormat": "dropped",
+          "refId": "D"
+        }
+      ],
+      "title": "D2P Frame Rates",
+      "description": "Discord-to-phone frame rates (frames/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 25 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
+      "id": 10,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_bridge_d2p_queue_depth",
+          "legendFormat": "queue depth",
+          "refId": "A"
+        }
+      ],
+      "title": "D2P Queue Depth",
+      "description": "Slot queue depth over time (cap=50)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 6 },
+      "id": 11,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_d2p_frames_dropped_total[$__rate_interval])",
+          "legendFormat": "drops/s",
+          "refId": "A"
+        }
+      ],
+      "title": "D2P Drop Rate",
+      "description": "Freshness eviction drop rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 12,
+      "title": "Phone \u2192 Discord (P2D)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 13,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_frames_in_total[$__rate_interval])",
+          "legendFormat": "frames in",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_reads_total[$__rate_interval])",
+          "legendFormat": "reads",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_silence_reads_total[$__rate_interval])",
+          "legendFormat": "silence reads",
+          "refId": "C"
+        }
+      ],
+      "title": "P2D Frame Rates",
+      "description": "Phone-to-Discord frame rates (frames/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.04 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 15 },
+      "id": 14,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_bridge_p2d_max_recv_gap_seconds",
+          "legendFormat": "max recv gap",
+          "refId": "A"
+        }
+      ],
+      "title": "P2D Recv Gap",
+      "description": "Max gap between consecutive phone RTP packets; >40ms indicates jitter",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 15 },
+      "id": 15,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_queue_overflow_total[$__rate_interval])",
+          "legendFormat": "overflows",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_bridge_p2d_gap_warnings_total[$__rate_interval])",
+          "legendFormat": "gap warnings",
+          "refId": "B"
+        }
+      ],
+      "title": "P2D Queue Health",
+      "description": "Queue overflows and recv gap warnings (>40ms)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 16,
+      "title": "Discord Voice Receive",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
+      "id": 17,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_packets_in_total[$__rate_interval])",
+          "legendFormat": "packets in",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_opus_decodes_total[$__rate_interval])",
+          "legendFormat": "opus decodes",
+          "refId": "B"
+        }
+      ],
+      "title": "Packet Throughput",
+      "description": "Discord voice UDP packets received and Opus frames decoded",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
+      "id": 18,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_decrypt_failures_total[$__rate_interval])",
+          "legendFormat": "decrypt failures",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_opus_errors_total[$__rate_interval])",
+          "legendFormat": "opus errors",
+          "refId": "B"
+        }
+      ],
+      "title": "Error Rates",
+      "description": "Decryption failures and Opus decode errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "normal", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "id": 19,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_ticks_served_total[$__rate_interval])",
+          "legendFormat": "served",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "rate(frizzle_voice_rx_ticks_empty_total[$__rate_interval])",
+          "legendFormat": "empty",
+          "refId": "B"
+        }
+      ],
+      "title": "Tick Yield",
+      "description": "pop_tick() calls that returned frames vs empty (stacked)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 20,
+      "title": "Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.005 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 33 },
+      "id": 21,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_bridge_rtp_max_sleep_overshoot_seconds",
+          "legendFormat": "overshoot",
+          "refId": "A"
+        }
+      ],
+      "title": "RTP Send Loop Overshoot",
+      "description": "Peak RTP send loop timing overshoot; threshold at 5ms",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "unit": "\u00b5s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 33 },
+      "id": 22,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_voice_rx_max_callback_microseconds",
+          "legendFormat": "callback",
+          "refId": "A"
+        }
+      ],
+      "title": "Voice RX Callback Duration",
+      "description": "Peak socket callback duration; threshold at 1000\u00b5s (1ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": { "mode": "none", "group": "A" },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": { "type": "linear" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "\u00b5s",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 33 },
+      "id": 23,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "frizzle_voice_rx_max_decode_microseconds",
+          "legendFormat": "decode",
+          "refId": "A"
+        }
+      ],
+      "title": "Voice RX Decode Duration",
+      "description": "Peak Opus decode duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "id": 24,
+      "title": "Lifetime Totals",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 42 },
+          "id": 25,
+          "options": {
+            "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "wideLayout": true,
+            "orientation": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "frizzle_bridge_rtp_frames_sent_total",
+              "legendFormat": "",
+              "refId": "A",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "title": "Total RTP Frames Sent",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 42 },
+          "id": 26,
+          "options": {
+            "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "wideLayout": true,
+            "orientation": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "frizzle_bridge_d2p_frames_mixed_total",
+              "legendFormat": "",
+              "refId": "A",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "title": "Total D2P Mixed",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 42 },
+          "id": 27,
+          "options": {
+            "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "wideLayout": true,
+            "orientation": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "frizzle_voice_rx_packets_in_total",
+              "legendFormat": "",
+              "refId": "A",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "title": "Total Voice RX Packets",
+          "type": "stat"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] },
+              "unit": "short",
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 42 },
+          "id": 28,
+          "options": {
+            "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "wideLayout": true,
+            "orientation": "auto"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+              "expr": "frizzle_bridge_p2d_frames_in_total",
+              "legendFormat": "",
+              "refId": "A",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "title": "Total P2D Frames In",
+          "type": "stat"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["frizzle-phone"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "frizzle-phone",
+  "uid": "",
+  "version": 0
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "davey>=0.1.4",
     "discord-py[voice]>=2.7.0",
+    "prometheus-client>=0.21",
     "python-dotenv>=1.2.1",
     "soxr>=0.5.0",
 ]

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -53,6 +53,28 @@ else
   fail "GET / missing value=\"300\""
 fi
 
+# GET /metrics — Prometheus endpoint
+metrics_body=$(curl -sf "${BASE_URL}/metrics")
+metrics_status=$?
+
+if [[ $metrics_status -eq 0 ]]; then
+  pass "GET /metrics → 200"
+else
+  fail "GET /metrics → non-200 or unreachable"
+fi
+
+if echo "$metrics_body" | grep -q 'frizzle_active_calls'; then
+  pass "GET /metrics contains frizzle_active_calls"
+else
+  fail "GET /metrics missing frizzle_active_calls"
+fi
+
+if echo "$metrics_body" | grep -q 'frizzle_bridge_rtp_frames_sent_total'; then
+  pass "GET /metrics contains frizzle_bridge_rtp_frames_sent_total"
+else
+  fail "GET /metrics missing frizzle_bridge_rtp_frames_sent_total"
+fi
+
 # ── SIP checks ───────────────────────────────────────────────────────
 echo ""
 echo "=== SIP checks ==="

--- a/src/frizzle_phone/bridge.py
+++ b/src/frizzle_phone/bridge.py
@@ -20,6 +20,7 @@ import soxr
 
 from frizzle_phone.agc import AgcBank
 from frizzle_phone.bridge_stats import BridgeStats
+from frizzle_phone.discord_voice_rx.stats import VoiceRecvStats
 from frizzle_phone.rtp import pcmu
 from frizzle_phone.rtp.pcmu import pcm16_arr_to_ulaw
 from frizzle_phone.rtp.stream import PTIME_MS, SAMPLES_PER_PACKET, build_rtp_packet
@@ -139,6 +140,7 @@ async def rtp_send_loop(
     *,
     stop_event: asyncio.Event,
     stats: BridgeStats | None = None,
+    voice_recv_stats: VoiceRecvStats | None = None,
 ) -> None:
     """Pull frames via pop_tick, mix, resample, send RTP at 20ms intervals."""
     ssrc = random.randint(0, 0xFFFFFFFF)
@@ -228,3 +230,5 @@ async def rtp_send_loop(
         if stats:
             loop.call_soon(stats.maybe_log_and_reset)
             agc_bank.expire_stale()
+        if voice_recv_stats:
+            loop.call_soon(voice_recv_stats.maybe_log_and_reset)

--- a/src/frizzle_phone/bridge_manager.py
+++ b/src/frizzle_phone/bridge_manager.py
@@ -75,6 +75,7 @@ class BridgeManager:
 
         # RTP send loop
         stop_event = asyncio.Event()
+        voice_recv_stats = getattr(voice_client, "recv_stats", None)
         send_task = loop.create_task(
             rtp_send_loop(
                 voice_client.pop_tick,
@@ -82,6 +83,7 @@ class BridgeManager:
                 remote_rtp_addr,
                 stop_event=stop_event,
                 stats=stats,
+                voice_recv_stats=voice_recv_stats,
             ),
             name=f"rtp-send-{rtp_port}",
         )

--- a/src/frizzle_phone/bridge_stats.py
+++ b/src/frizzle_phone/bridge_stats.py
@@ -9,6 +9,8 @@ incur call overhead on every frame.
 import logging
 import time
 
+from frizzle_phone import metrics
+
 logger = logging.getLogger(__name__)
 
 _SUMMARY_INTERVAL_S = 5.0
@@ -69,6 +71,29 @@ class BridgeStats:
         }
 
         self.reset()
+
+        # Feed snapshot into Prometheus counters/gauges
+        if snap["d2p_mixed"]:
+            metrics.BRIDGE_D2P_MIXED.inc(snap["d2p_mixed"])
+        if snap["d2p_dropped"]:
+            metrics.BRIDGE_D2P_DROPPED.inc(snap["d2p_dropped"])
+        if snap["p2d_in"]:
+            metrics.BRIDGE_P2D_IN.inc(snap["p2d_in"])
+        if snap["p2d_overflow"]:
+            metrics.BRIDGE_P2D_OVERFLOW.inc(snap["p2d_overflow"])
+        if snap["p2d_reads"]:
+            metrics.BRIDGE_P2D_READS.inc(snap["p2d_reads"])
+        if snap["p2d_silence"]:
+            metrics.BRIDGE_P2D_SILENCE.inc(snap["p2d_silence"])
+        if snap["p2d_gap_warns"]:
+            metrics.BRIDGE_P2D_GAP_WARNS.inc(snap["p2d_gap_warns"])
+        if snap["rtp_sent"]:
+            metrics.BRIDGE_RTP_SENT.inc(snap["rtp_sent"])
+        if snap["rtp_silence"]:
+            metrics.BRIDGE_RTP_SILENCE.inc(snap["rtp_silence"])
+        metrics.BRIDGE_D2P_QDEPTH.set(snap["d2p_qdepth"])
+        metrics.BRIDGE_P2D_MAX_GAP.set(snap["p2d_max_gap"])
+        metrics.BRIDGE_RTP_OVERSHOOT.set(snap["rtp_overshoot"])
 
         logger.info(
             "bridge stats | d2p mixed=%d dropped=%d "

--- a/src/frizzle_phone/bridge_stats.py
+++ b/src/frizzle_phone/bridge_stats.py
@@ -101,13 +101,20 @@ class BridgeStats:
                 snap["p2d_silence"] / snap["p2d_reads"] * 100,
             )
 
-        if snap["rtp_sent"] > 0 and snap["rtp_silence"] / snap["rtp_sent"] > 0.20:
-            logger.warning(
-                "bridge d2p starvation: %d/%d RTP sends were silence (%.0f%%)",
-                snap["rtp_silence"],
-                snap["rtp_sent"],
-                snap["rtp_silence"] / snap["rtp_sent"] * 100,
-            )
+        if snap["rtp_sent"] > 0:
+            expected_silence = max(0, snap["rtp_sent"] - snap["d2p_mixed"])
+            unexplained = max(0, snap["rtp_silence"] - expected_silence)
+            if unexplained / snap["rtp_sent"] > 0.10:
+                audio_sent = snap["rtp_sent"] - snap["rtp_silence"]
+                logger.warning(
+                    "bridge d2p pipeline loss: fed %d mixed slots but only %d "
+                    "audio payloads sent (%d/%d unexplained silence, %.0f%%)",
+                    snap["d2p_mixed"],
+                    audio_sent,
+                    unexplained,
+                    snap["rtp_sent"],
+                    unexplained / snap["rtp_sent"] * 100,
+                )
 
         if snap["p2d_gap_warns"] > 0:
             logger.warning(

--- a/src/frizzle_phone/discord_voice_rx/stats.py
+++ b/src/frizzle_phone/discord_voice_rx/stats.py
@@ -3,6 +3,8 @@
 import logging
 import time
 
+from frizzle_phone import metrics
+
 logger = logging.getLogger(__name__)
 
 _SUMMARY_INTERVAL_S = 5.0
@@ -43,6 +45,22 @@ class VoiceRecvStats:
         }
 
         self.reset()
+
+        # Feed snapshot into Prometheus counters/gauges
+        if snap["packets_in"]:
+            metrics.VOICE_RX_PACKETS_IN.inc(snap["packets_in"])
+        if snap["decrypt_fail"]:
+            metrics.VOICE_RX_DECRYPT_FAIL.inc(snap["decrypt_fail"])
+        if snap["opus_decodes"]:
+            metrics.VOICE_RX_OPUS_DECODES.inc(snap["opus_decodes"])
+        if snap["opus_errors"]:
+            metrics.VOICE_RX_OPUS_ERRORS.inc(snap["opus_errors"])
+        if snap["ticks_empty"]:
+            metrics.VOICE_RX_TICKS_EMPTY.inc(snap["ticks_empty"])
+        if snap["ticks_served"]:
+            metrics.VOICE_RX_TICKS_SERVED.inc(snap["ticks_served"])
+        metrics.VOICE_RX_MAX_CALLBACK_US.set(snap["max_callback_us"])
+        metrics.VOICE_RX_MAX_DECODE_US.set(snap["max_decode_us"])
 
         logger.info(
             "voice_recv stats | pkts_in=%d decrypt_fail=%d opus=%d/%d "

--- a/src/frizzle_phone/metrics.py
+++ b/src/frizzle_phone/metrics.py
@@ -1,0 +1,157 @@
+"""Prometheus metrics for frizzle-phone.
+
+Uses a custom CollectorRegistry (not the default global) so tests stay
+isolated and the /metrics endpoint only exposes our own metrics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from prometheus_client import CollectorRegistry, Counter, Gauge
+
+REGISTRY = CollectorRegistry()
+
+# Callbacks invoked at scrape time to refresh gauges that are expensive
+# or error-prone to keep in sync via mutation-point tracking.
+_scrape_callbacks: list[Callable[[], None]] = []
+
+
+def register_scrape_callback(fn: Callable[[], None]) -> None:
+    _scrape_callbacks.append(fn)
+
+
+def run_scrape_callbacks() -> None:
+    for fn in _scrape_callbacks:
+        fn()
+
+
+# ---------------------------------------------------------------------------
+# Bridge counters (incremented by each 5s snapshot delta)
+# ---------------------------------------------------------------------------
+
+BRIDGE_D2P_MIXED = Counter(
+    "frizzle_bridge_d2p_frames_mixed_total",
+    "Discord-to-phone frames mixed",
+    registry=REGISTRY,
+)
+BRIDGE_D2P_DROPPED = Counter(
+    "frizzle_bridge_d2p_frames_dropped_total",
+    "Discord-to-phone frames dropped (freshness)",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_IN = Counter(
+    "frizzle_bridge_p2d_frames_in_total",
+    "Phone-to-Discord RTP frames received",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_OVERFLOW = Counter(
+    "frizzle_bridge_p2d_queue_overflow_total",
+    "Phone-to-Discord queue overflows",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_READS = Counter(
+    "frizzle_bridge_p2d_reads_total",
+    "Phone-to-Discord read() calls",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_SILENCE = Counter(
+    "frizzle_bridge_p2d_silence_reads_total",
+    "Phone-to-Discord silence reads",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_GAP_WARNS = Counter(
+    "frizzle_bridge_p2d_gap_warnings_total",
+    "Phone-to-Discord recv gap warnings (>40ms)",
+    registry=REGISTRY,
+)
+BRIDGE_RTP_SENT = Counter(
+    "frizzle_bridge_rtp_frames_sent_total",
+    "RTP frames sent to phone",
+    registry=REGISTRY,
+)
+BRIDGE_RTP_SILENCE = Counter(
+    "frizzle_bridge_rtp_silence_sent_total",
+    "RTP silence frames sent to phone",
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# Bridge gauges (set to peak/current value each summary period)
+# ---------------------------------------------------------------------------
+
+BRIDGE_D2P_QDEPTH = Gauge(
+    "frizzle_bridge_d2p_queue_depth",
+    "Discord-to-phone slot queue depth at snapshot",
+    registry=REGISTRY,
+)
+BRIDGE_P2D_MAX_GAP = Gauge(
+    "frizzle_bridge_p2d_max_recv_gap_seconds",
+    "Max phone-to-Discord recv gap (seconds)",
+    registry=REGISTRY,
+)
+BRIDGE_RTP_OVERSHOOT = Gauge(
+    "frizzle_bridge_rtp_max_sleep_overshoot_seconds",
+    "Max RTP send loop sleep overshoot (seconds)",
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# Voice receive counters
+# ---------------------------------------------------------------------------
+
+VOICE_RX_PACKETS_IN = Counter(
+    "frizzle_voice_rx_packets_in_total",
+    "Voice receive packets in",
+    registry=REGISTRY,
+)
+VOICE_RX_DECRYPT_FAIL = Counter(
+    "frizzle_voice_rx_decrypt_failures_total",
+    "Voice receive decrypt failures",
+    registry=REGISTRY,
+)
+VOICE_RX_OPUS_DECODES = Counter(
+    "frizzle_voice_rx_opus_decodes_total",
+    "Voice receive Opus decodes",
+    registry=REGISTRY,
+)
+VOICE_RX_OPUS_ERRORS = Counter(
+    "frizzle_voice_rx_opus_errors_total",
+    "Voice receive Opus errors",
+    registry=REGISTRY,
+)
+VOICE_RX_TICKS_EMPTY = Counter(
+    "frizzle_voice_rx_ticks_empty_total",
+    "Voice receive empty ticks",
+    registry=REGISTRY,
+)
+VOICE_RX_TICKS_SERVED = Counter(
+    "frizzle_voice_rx_ticks_served_total",
+    "Voice receive served ticks",
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# Voice receive gauges
+# ---------------------------------------------------------------------------
+
+VOICE_RX_MAX_CALLBACK_US = Gauge(
+    "frizzle_voice_rx_max_callback_microseconds",
+    "Voice receive max callback duration (microseconds)",
+    registry=REGISTRY,
+)
+VOICE_RX_MAX_DECODE_US = Gauge(
+    "frizzle_voice_rx_max_decode_microseconds",
+    "Voice receive max decode duration (microseconds)",
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# SIP server gauge
+# ---------------------------------------------------------------------------
+
+ACTIVE_CALLS = Gauge(
+    "frizzle_active_calls",
+    "Number of active SIP calls",
+    registry=REGISTRY,
+)

--- a/src/frizzle_phone/sip/server.py
+++ b/src/frizzle_phone/sip/server.py
@@ -24,6 +24,7 @@ import aiosqlite
 from discord.ext import commands
 
 from frizzle_phone.bridge_manager import BridgeHandle, BridgeManager
+from frizzle_phone.metrics import ACTIVE_CALLS, register_scrape_callback
 from frizzle_phone.rtp.stream import RtpStream
 from frizzle_phone.sip.message import (
     SipMessage,
@@ -204,6 +205,7 @@ class SipServer(asyncio.DatagramProtocol):
         self._bridge_manager = bridge_manager or BridgeManager()
         self._voice_connector = voice_connector or DiscordVoiceConnector(bot)
         self._db_update_errors: int = 0
+        register_scrape_callback(lambda: ACTIVE_CALLS.set(len(self._calls)))
         self._handlers: dict[str, _HandlerType] = {
             "REGISTER": self._handle_register,
             "INVITE": self._handle_invite,
@@ -583,6 +585,7 @@ class SipServer(asyncio.DatagramProtocol):
                     "Failed to connect to voice channel %s", result.channel_id
                 )
                 self._calls.pop(call_id, None)
+
                 self._send(
                     build_response(msg, 503, "Service Unavailable", to_tag=to_tag),
                     resp_addr,
@@ -663,6 +666,7 @@ class SipServer(asyncio.DatagramProtocol):
             response = build_response(msg, 481, "Call/Transaction Does Not Exist")
             self._send(response, resp_addr)
             return
+
         self._terminate_call(call)
         if call.db_call_id:
             self._fire_and_forget(
@@ -702,6 +706,7 @@ class SipServer(asyncio.DatagramProtocol):
         # RFC 3261 §9.2: CANCEL matched a transaction still in PROCEEDING.
         # First, respond 200 OK to the CANCEL itself.
         self._calls.pop(call_id, None)
+
         ok = build_response(msg, 200, "OK", to_tag=call.to_tag)
         self._send(ok, resp_addr)
 
@@ -968,6 +973,7 @@ class SipServer(asyncio.DatagramProtocol):
         """Stop all active calls and transactions during shutdown."""
         calls = list(self._calls.values())
         self._calls.clear()
+
         for call in calls:
             self._terminate_call(call)
         # Terminate any orphaned transactions not linked to a call

--- a/src/frizzle_phone/web.py
+++ b/src/frizzle_phone/web.py
@@ -9,6 +9,9 @@ import aiosqlite
 import jinja2
 from aiohttp import web
 from discord.ext import commands
+from prometheus_client import generate_latest
+
+from frizzle_phone.metrics import REGISTRY, run_scrape_callbacks
 
 _db_key = web.AppKey("db", aiosqlite.Connection)
 _bot_key = web.AppKey("bot", commands.Bot)
@@ -97,6 +100,12 @@ async def _post_handler(
     raise web.HTTPSeeOther(location="/")
 
 
+async def _metrics_handler(request: web.Request) -> web.Response:
+    run_scrape_callbacks()
+    body = generate_latest(REGISTRY)
+    return web.Response(body=body, content_type="text/plain", charset="utf-8")
+
+
 def create_app(
     db: aiosqlite.Connection,
     bot: commands.Bot,
@@ -113,6 +122,7 @@ def create_app(
     app[_audio_names_key] = audio_names
     app.router.add_get("/", _get_handler)
     app.router.add_post("/extensions", _post_handler)
+    app.router.add_get("/metrics", _metrics_handler)
     return app
 
 

--- a/tests/test_bridge_stats.py
+++ b/tests/test_bridge_stats.py
@@ -68,14 +68,27 @@ def test_log_summary_warns_on_high_silence_reads(caplog):
     assert any("p2d underflow" in r.message for r in warnings)
 
 
-def test_log_summary_warns_on_high_silence_sends(caplog):
+def test_log_summary_warns_on_pipeline_loss(caplog):
     stats = BridgeStats()
     stats.rtp_frames_sent = 100
-    stats.rtp_silence_sent = 25  # 25% > 20%
+    stats.d2p_frames_mixed = 80  # fed 80 mixed slots
+    stats.rtp_silence_sent = 50  # expected_silence=20, unexplained=30, 30% > 10%
     with caplog.at_level(logging.WARNING, logger="frizzle_phone.bridge_stats"):
         stats.log_and_reset()
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("d2p starvation" in r.message for r in warnings)
+    assert any("d2p pipeline loss" in r.message for r in warnings)
+
+
+def test_log_summary_no_starvation_warn_when_nobody_speaking(caplog):
+    """All silence is expected when nobody is talking on Discord."""
+    stats = BridgeStats()
+    stats.rtp_frames_sent = 250
+    stats.rtp_silence_sent = 250
+    stats.d2p_frames_mixed = 0  # expected_silence=250, unexplained=0
+    with caplog.at_level(logging.WARNING, logger="frizzle_phone.bridge_stats"):
+        stats.log_and_reset()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("pipeline loss" in r.message for r in warnings)
 
 
 def test_log_summary_no_warn_when_below_thresholds(caplog):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,109 @@
+"""Tests for Prometheus metrics integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from frizzle_phone.bridge_stats import BridgeStats
+from frizzle_phone.discord_voice_rx.stats import VoiceRecvStats
+from frizzle_phone.metrics import (
+    BRIDGE_D2P_MIXED,
+    BRIDGE_D2P_QDEPTH,
+    BRIDGE_RTP_OVERSHOOT,
+    BRIDGE_RTP_SENT,
+    VOICE_RX_MAX_CALLBACK_US,
+    VOICE_RX_OPUS_DECODES,
+    VOICE_RX_PACKETS_IN,
+)
+from frizzle_phone.web import create_app
+
+
+def _make_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.guilds = []
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_200(db):
+    app = create_app(db, _make_bot(), [])
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/metrics")
+        assert resp.status == 200
+        text = await resp.text()
+        assert "frizzle_bridge_d2p_frames_mixed_total" in text
+        assert "frizzle_voice_rx_packets_in_total" in text
+        assert "frizzle_active_calls" in text
+
+
+def test_bridge_stats_increments_counters():
+    before_mixed = BRIDGE_D2P_MIXED._value.get()
+    before_rtp = BRIDGE_RTP_SENT._value.get()
+
+    stats = BridgeStats()
+    stats.d2p_frames_mixed = 42
+    stats.rtp_frames_sent = 100
+    stats.log_and_reset()
+
+    assert BRIDGE_D2P_MIXED._value.get() - before_mixed == 42
+    assert BRIDGE_RTP_SENT._value.get() - before_rtp == 100
+
+
+def test_voice_recv_stats_increments_counters():
+    before_packets = VOICE_RX_PACKETS_IN._value.get()
+    before_opus = VOICE_RX_OPUS_DECODES._value.get()
+
+    stats = VoiceRecvStats()
+    stats.packets_in = 50
+    stats.opus_decodes = 30
+    stats.log_and_reset()
+
+    assert VOICE_RX_PACKETS_IN._value.get() - before_packets == 50
+    assert VOICE_RX_OPUS_DECODES._value.get() - before_opus == 30
+
+
+def test_gauges_are_set_not_accumulated():
+    stats = BridgeStats()
+    stats.d2p_queue_depth = 10
+    stats.rtp_max_sleep_overshoot = 0.005
+    stats.log_and_reset()
+    assert BRIDGE_D2P_QDEPTH._value.get() == 10
+    assert BRIDGE_RTP_OVERSHOOT._value.get() == 0.005
+
+    # Second call with lower values should replace, not add
+    stats.d2p_queue_depth = 3
+    stats.rtp_max_sleep_overshoot = 0.001
+    stats.log_and_reset()
+    assert BRIDGE_D2P_QDEPTH._value.get() == 3
+    assert BRIDGE_RTP_OVERSHOOT._value.get() == 0.001
+
+
+def test_voice_rx_gauges_are_set_not_accumulated():
+    stats = VoiceRecvStats()
+    stats.max_callback_us = 500
+    stats.log_and_reset()
+    assert VOICE_RX_MAX_CALLBACK_US._value.get() == 500
+
+    stats.max_callback_us = 200
+    stats.log_and_reset()
+    assert VOICE_RX_MAX_CALLBACK_US._value.get() == 200
+
+
+def test_zero_counters_not_incremented():
+    """Counter.inc(0) raises ValueError — verify we guard against it."""
+    before_mixed = BRIDGE_D2P_MIXED._value.get()
+    stats = BridgeStats()
+    # All counters are 0 after init
+    stats.log_and_reset()
+    assert BRIDGE_D2P_MIXED._value.get() == before_mixed
+
+
+@pytest.mark.asyncio
+async def test_metrics_content_type(db):
+    app = create_app(db, _make_bot(), [])
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/metrics")
+        assert "text/plain" in resp.headers.get("Content-Type", "")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,16 +9,15 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from frizzle_phone.bridge_stats import BridgeStats
 from frizzle_phone.discord_voice_rx.stats import VoiceRecvStats
-from frizzle_phone.metrics import (
-    BRIDGE_D2P_MIXED,
-    BRIDGE_D2P_QDEPTH,
-    BRIDGE_RTP_OVERSHOOT,
-    BRIDGE_RTP_SENT,
-    VOICE_RX_MAX_CALLBACK_US,
-    VOICE_RX_OPUS_DECODES,
-    VOICE_RX_PACKETS_IN,
-)
+from frizzle_phone.metrics import REGISTRY
 from frizzle_phone.web import create_app
+
+
+def _val(name: str) -> float:
+    """Read a metric value from the custom registry."""
+    v = REGISTRY.get_sample_value(name)
+    assert v is not None, f"metric {name!r} not found in registry"
+    return v
 
 
 def _make_bot() -> MagicMock:
@@ -40,29 +39,29 @@ async def test_metrics_endpoint_returns_200(db):
 
 
 def test_bridge_stats_increments_counters():
-    before_mixed = BRIDGE_D2P_MIXED._value.get()
-    before_rtp = BRIDGE_RTP_SENT._value.get()
+    before_mixed = _val("frizzle_bridge_d2p_frames_mixed_total")
+    before_rtp = _val("frizzle_bridge_rtp_frames_sent_total")
 
     stats = BridgeStats()
     stats.d2p_frames_mixed = 42
     stats.rtp_frames_sent = 100
     stats.log_and_reset()
 
-    assert BRIDGE_D2P_MIXED._value.get() - before_mixed == 42
-    assert BRIDGE_RTP_SENT._value.get() - before_rtp == 100
+    assert _val("frizzle_bridge_d2p_frames_mixed_total") - before_mixed == 42
+    assert _val("frizzle_bridge_rtp_frames_sent_total") - before_rtp == 100
 
 
 def test_voice_recv_stats_increments_counters():
-    before_packets = VOICE_RX_PACKETS_IN._value.get()
-    before_opus = VOICE_RX_OPUS_DECODES._value.get()
+    before_packets = _val("frizzle_voice_rx_packets_in_total")
+    before_opus = _val("frizzle_voice_rx_opus_decodes_total")
 
     stats = VoiceRecvStats()
     stats.packets_in = 50
     stats.opus_decodes = 30
     stats.log_and_reset()
 
-    assert VOICE_RX_PACKETS_IN._value.get() - before_packets == 50
-    assert VOICE_RX_OPUS_DECODES._value.get() - before_opus == 30
+    assert _val("frizzle_voice_rx_packets_in_total") - before_packets == 50
+    assert _val("frizzle_voice_rx_opus_decodes_total") - before_opus == 30
 
 
 def test_gauges_are_set_not_accumulated():
@@ -70,35 +69,35 @@ def test_gauges_are_set_not_accumulated():
     stats.d2p_queue_depth = 10
     stats.rtp_max_sleep_overshoot = 0.005
     stats.log_and_reset()
-    assert BRIDGE_D2P_QDEPTH._value.get() == 10
-    assert BRIDGE_RTP_OVERSHOOT._value.get() == 0.005
+    assert _val("frizzle_bridge_d2p_queue_depth") == 10
+    assert _val("frizzle_bridge_rtp_max_sleep_overshoot_seconds") == 0.005
 
     # Second call with lower values should replace, not add
     stats.d2p_queue_depth = 3
     stats.rtp_max_sleep_overshoot = 0.001
     stats.log_and_reset()
-    assert BRIDGE_D2P_QDEPTH._value.get() == 3
-    assert BRIDGE_RTP_OVERSHOOT._value.get() == 0.001
+    assert _val("frizzle_bridge_d2p_queue_depth") == 3
+    assert _val("frizzle_bridge_rtp_max_sleep_overshoot_seconds") == 0.001
 
 
 def test_voice_rx_gauges_are_set_not_accumulated():
     stats = VoiceRecvStats()
     stats.max_callback_us = 500
     stats.log_and_reset()
-    assert VOICE_RX_MAX_CALLBACK_US._value.get() == 500
+    assert _val("frizzle_voice_rx_max_callback_microseconds") == 500
 
     stats.max_callback_us = 200
     stats.log_and_reset()
-    assert VOICE_RX_MAX_CALLBACK_US._value.get() == 200
+    assert _val("frizzle_voice_rx_max_callback_microseconds") == 200
 
 
 def test_zero_counters_not_incremented():
-    """Counter.inc(0) raises ValueError — verify we guard against it."""
-    before_mixed = BRIDGE_D2P_MIXED._value.get()
+    """Zero-valued counters should not change Prometheus values."""
+    before_mixed = _val("frizzle_bridge_d2p_frames_mixed_total")
     stats = BridgeStats()
     # All counters are 0 after init
     stats.log_and_reset()
-    assert BRIDGE_D2P_MIXED._value.get() == before_mixed
+    assert _val("frizzle_bridge_d2p_frames_mixed_total") == before_mixed
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -381,6 +381,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "davey" },
     { name = "discord-py", extra = ["voice"] },
+    { name = "prometheus-client" },
     { name = "python-dotenv" },
     { name = "soxr" },
 ]
@@ -404,6 +405,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "davey", specifier = ">=0.1.4" },
     { name = "discord-py", extras = ["voice"], specifier = ">=2.7.0" },
+    { name = "prometheus-client", specifier = ">=0.21" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "soxr", specifier = ">=0.5.0" },
 ]
@@ -731,6 +733,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `prometheus-client` dependency and expose Prometheus metrics on `GET /metrics` (port 8080)
- Feed existing 5-second `BridgeStats` and `VoiceRecvStats` snapshots into Prometheus Counters/Gauges — zero overhead on the per-frame hot path
- Active calls gauge uses a scrape-time callback (reads `len(self._calls)` when `/metrics` is hit) instead of mutation-point tracking
- Add `docs/METRICS.md` with full metric inventory, interpretation guide, example Grafana queries, and alert examples

## Test plan

- [x] `just` passes — lint, format, types, vulture, 266 tests
- [x] 7 new tests in `test_metrics.py`: endpoint 200, counter increments, gauge set-not-accumulate, zero-value guards, content-type
- [ ] Manual: `./dev` then `curl localhost:8080/metrics` returns Prometheus text with all `frizzle_` metrics
- [ ] During active call: verify counters increment on successive `/metrics` scrapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)